### PR TITLE
Use Aurora block hash for indexing NEAR blocks

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -12,6 +12,7 @@ pub mod types;
 pub struct EngineContext {
     storage: Storage,
     engine_account_id: AccountId,
+    chain_id: [u8; 32],
     data_id_mapping: lru::LruCache<CryptoHash, Option<Vec<u8>>>,
 }
 
@@ -19,11 +20,14 @@ impl EngineContext {
     pub fn new<P: AsRef<Path>>(
         storage_path: P,
         engine_account_id: AccountId,
+        chain_id: u64,
     ) -> Result<Self, error::Error> {
         let storage = Storage::open(storage_path)?;
+        let chain_id = aurora_engine_types::types::u256_to_arr(&(chain_id.into()));
         Ok(Self {
             storage,
             engine_account_id,
+            chain_id,
             data_id_mapping: lru::LruCache::new(1000),
         })
     }
@@ -39,6 +43,7 @@ pub fn consume_near_block(
         block,
         &mut context.data_id_mapping,
         &context.engine_account_id,
+        context.chain_id,
         outcomes,
     )
 }

--- a/engine/src/tests.rs
+++ b/engine/src/tests.rs
@@ -21,11 +21,13 @@ fn test_batched_transactions() {
     };
     let mut data_id_mapping = lru::LruCache::new(1000);
     let mut outcomes_map = HashMap::new();
+    let chain_id = aurora_engine_types::types::u256_to_arr(&(1313161554.into()));
     crate::sync::consume_near_block(
         &mut test_context.storage,
         &block,
         &mut data_id_mapping,
         &test_context.engine_account_id,
+        chain_id,
         Some(&mut outcomes_map),
     )
     .unwrap();


### PR DESCRIPTION
It is important that the engine has the Aurora block hash for the blocks, not the NEAR block hash. Otherwise it will not be able to look up blocks by hash in a way that is consistent with the rest of the Aurora ecosystem.