### PR TITLE
Fix(engine): Skip transactions that failed on NEAR before even parsing that transaction

### DIFF
--- a/engine/src/res/block_71771951.json
+++ b/engine/src/res/block_71771951.json
@@ -1,0 +1,2734 @@
+{
+  "block": {
+    "author": "bisontrails.poolv1.near",
+    "header": {
+      "height": 71771951,
+      "prev_height": 71771950,
+      "epoch_id": "GrnU3fWS4wJoTb4tBG72PzLLBnknjw2hVEgCFZ5mAWLT",
+      "next_epoch_id": "FUn898gv215mcreUoTYveVy4hYr5anGGCpcG77zbTdwv",
+      "hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+      "prev_hash": "5njXB5DwrUbiPtt39FP4JbQZCF58J4bLijhr6L6vPVY",
+      "prev_state_root": "2doZbGxR1j8biugnEJTtB7nyK5NicAWRyGvpSE9Vgmia",
+      "chunk_receipts_root": "G9rPyQRcqPYXQ5zBsoE82ekstKCCZGNfSBuYrjhWzKts",
+      "chunk_headers_root": "uxMaSDdjfw4W3Cg8N6fZkLndnkK3cEkMd7t2KkYY3E8",
+      "chunk_tx_root": "FWuUzWX1621rpoV4knLYTTeDjSbYV2R49kW8RG3wqeLf",
+      "outcome_root": "9o4Xbfw6ZcMQpVe5tRbbhAi7kj3KsXTh2mP5jCF5N3ks",
+      "chunks_included": 4,
+      "challenges_root": "11111111111111111111111111111111",
+      "timestamp": 1660217624788505115,
+      "timestamp_nanosec": "1660217624788505115",
+      "random_value": "Gi1PCvSyE6sq7bRppRuYFhNJur1xtgdCFGcJyxWyyvNn",
+      "validator_proposals": [],
+      "chunk_mask": [
+        true,
+        true,
+        true,
+        true
+      ],
+      "gas_price": "100000000",
+      "block_ordinal": 61766819,
+      "total_supply": "1092905100651025020989437699645925",
+      "challenges_result": [],
+      "last_final_block": "AVFnjc9aUkJx3nN19k13sMFPH5t1EjuiCo4JM46gdv67",
+      "last_ds_final_block": "5njXB5DwrUbiPtt39FP4JbQZCF58J4bLijhr6L6vPVY",
+      "next_bp_hash": "FkXPxa1mDFW2tUvq8YL1gsxPk1q5qKgxWX7A42JWUE3r",
+      "block_merkle_root": "8sRzaLqtc3G5f2gyBmraeNfFQCGswqqdDr6gfFNmtzuT",
+      "epoch_sync_data_hash": null,
+      "approvals": [
+        "ed25519:67cbi4mK6WjD97Kz6Mg6fWViGJE1b2f4BANpMw6SG8f4Np58GUV2koAdVuoZSdm6azwGuunYZk3kNoYeXzPN5iQZ",
+        "ed25519:5n4nkzban96SWCd4XMmuJ1u3TB531hTC7TqnSG3LMVWQ2MpXTjCBTambohxdx4Ld2YKn2LyWC6HNF13Ut67iCE2n",
+        "ed25519:5pQfjyoBjJmxEsSYnuk5wc7ic6Ge4BrgreKW13SDD2Cm5i4VJHJhbVa9FsDUVTd1px38zzFS343pRAWBy29jypyY",
+        null,
+        "ed25519:2DeDJ1TrkwYTBYURh2dA5fi3b1ZMqgrLkcANmwwKHNcusNNEyEzdxUKsEWvc2Xeh5LcBFNuQ1TALqGtARcFPwTY3",
+        "ed25519:53xLztZabGeVYFTqr6ga5RADQrKDBHL5KehRge9MEfBKucUkBdJzwbeu5c2C1iYLkfKcEcA6gKdkGTKnK4dEideR",
+        null,
+        "ed25519:2DBxFCyTuNsF6fWZ3uLAh8eeU1e8hxHanyvEjLRAtsyEw66YKE9PmqyVa8JmFTr63XWB5pD3uoiXr1Pa8JNfEs44",
+        "ed25519:3t3J7N6RS4G5W89tRi3fqgSWNQgrtQWX5j7eAN2bty5jtQHv531GPBgQi8N7S5utqNMisN5fohUJJWc8CR7NsCPX",
+        "ed25519:4MvZNrHF2L5MrGSXPV92V7yKLbEaNGzLaCJyWnWSkrZQJbdGLdWMphkGvB7y1r8tX14DRevJW4ACPE4V1FkqiVrq",
+        "ed25519:2pvy8f3EAkWxtVKp5eUWh4RL9pvRbSaRVJx3kqDuGPAsK6XT4ViWBrHcZ1qZBdf2qLmmMZEuBwJ2TsEHeUL324ha",
+        "ed25519:nPuvJ3QgszuiBcXnptzjaN6xxJRxxmnE2PVk15ZkkZGvk2PBkBoLge1jVc4tHK9KDtpcCiTN6AMiLweDXQdAf1p",
+        "ed25519:3pbT4cyZp3uoSNvZYxhZxooCoMjoQ6Bze5ae61QhDS4mftKRCA1qwWTqjHYa6aTY9QXVXneFiGeoQ514XufNeeqT",
+        "ed25519:9mUFczAf33fijtsTHNMXLB4txEc6CJ48bSARi7MDCLx2mE94nNpzFFB5tHJ7gp6Vxrj6dFwfFyCMkixuiYYEyt8",
+        null,
+        "ed25519:4LesmpGbTnsiRoVDaWarLve159iaMojGipdXPibmtDWhC5JgXnGMeP4Yjt3F7DzCe6kR4MZk4oMW9K4AnpiMWL8P",
+        "ed25519:2JfJebCAktrSsgoU47yc6MTFFGgphZ1irv3yUnz3V4DPPL2L5HhrecDxbscoHrvGkaGJ986bdVML7pcaNgZeoYXc",
+        "ed25519:3V4VwAud8rMzFFE9igDtJbUn4yrG1HCARhAVKBZK8gBFtxDGuyxvLQNUsDui3sZBHsasKMtfLsctL7HM8UsbMpWW",
+        "ed25519:2RrGhjBNSp5JQgwMeCk3D6utro35dm1s7MeXZ2cenKPXc62dDFBPKQDQ8p8P9cxouVG4dMSt6KsNN1FEseEyhbEq",
+        "ed25519:49UfjfMzydQFo1hvxAoifsvCMWVofSeGfxS2bHadaUeE6AfprixePs64GuEGcJHdM7d8cbWNKk8qoAUCuRcumbw8",
+        "ed25519:5qaySWmPwtJxG6WZGZkWLrwPHYMf3i4p8Xe4n8LEowkDjmDMwWFe1T5wxrmbxWsh1z4vVQ9rsBvuRsFBKJVE7STX",
+        "ed25519:26Rec3BdNjnMYKhZimNaaVUvL9eDMHJFtkAiUxUEpqpE1uKv1wmrLvZeQ23md5wa98CQuEKr2N5hhcBJ95qgYMTG",
+        "ed25519:4zaNrU7jyFgNMJ9Frsg4Fx8rfemkJxxVnLBzzeTXqJLr3BHFJbnm2JYmu812g4jxM5NT16e5em4r9PYvJGiC6WaV",
+        "ed25519:4uNcTq2B1C8iNuhGwSzhcqXBBSVVf7pPsPdQpii9Xwjpvy3yYdFYJFASJYwzVGgdycSqifUKczzuhqnKkANw4iaJ",
+        "ed25519:41J7GSH26Z4vJf4h9wSCof5LG9JdzpNsYscZJ6z29ge4FwCoQqsvSonTa4HqbkTBoq8dwuBUzeFRSEYeZQv6WWKk",
+        null,
+        "ed25519:4ejrUu2VYNAkdpgfwxEZZc9WeAK8jCa6KaSs4sJj8mPAxPffc5GnCoz7wZxZParm3g7nFjPV7kBp3wJ8QYTPKHPP",
+        "ed25519:2JRTiQY6zwTYGTxAZFSjKZ2VU74XWRNB3iFtDnAtoGjRLT5mBiYxKJxnN2GE2VT9Hj9YMLLwshz9wat1Qqt4xcNu",
+        "ed25519:5Ta29MvtmeW6cie87KxJrR4TSLnptWZaK8NehqRJMg2WNVjHu46XLrPZpMBQZgqbJHJkKEAj2Ur22twhtLaFoXyr",
+        "ed25519:4cYZ1QuSyqET1JC7gGXC4kUMks59evystZPygwHsW1sP7pHj8mzxqgtQcSLkK14d2mzP14AFWyQWyZ9fL446Ji1e",
+        "ed25519:4xNrpomiAyB5fyfcUUnpKDTRsCJQ5Hz7bVLuDMZubvs4PtTciaRfydFp8NWwZaJtZGXJTY4hkmdETkNCgAgjksRR",
+        null,
+        null,
+        "ed25519:5aLaimVoGv1cAGAGChDuJujMoZ1CfySk9K41jxrfGMDdi1ntRh25FW3rhSHyo78QKCaECnAZCitodAWi8eaiqNH6",
+        "ed25519:2JfJebCAktrSsgoU47yc6MTFFGgphZ1irv3yUnz3V4DPPL2L5HhrecDxbscoHrvGkaGJ986bdVML7pcaNgZeoYXc",
+        "ed25519:5Q2C9Jxk56GX6pLTu8K8LaGpH9oZg73eFAdAmqxSrVj5ZaNBSdJqSyHTwbjYPQUFQfLiEGWaBnrvs54QDHPFNMQT",
+        "ed25519:299yxtavPC3dh88jFfUPLnZKwRqbjNbCXKsd2d5mnq7AcUAftVeZpLNMb4xkWxzWkd1YmnvgaBQwLYVaPbsB2XBC",
+        null,
+        "ed25519:2VFwM8MZ6akd2iLEuYhvrfz7yyAoiFDvtq7b8eqDoijzoKV3wojZMU1pYDAQRaMCNhXDduhKUGLmSB6U5UPdSEVp",
+        "ed25519:3qPLA2JJGU4EXXmDZvc3M21CKQXdfkjT3bamf1uQvVecQeuYr7RdjPMYFH7UPLSfwEXcyom3FQrz3DtVTvxbBNpT",
+        null,
+        "ed25519:5cphVQTyfX2BqNHw3CnHKFj8zTesWZZxYt2Hka8DupzqykcgJhYv39vrCUuAD4tzPZaYA8kxsxz6gsFRBY7ySxe2",
+        "ed25519:61yCMLyxjRSV4rhMbWdvMgvCJPbMMS5EW9fBrKrtj5tBmbvPbV6wFtR1i3S13NzKsB96SHunmtNW8WQCHvaiGQmK",
+        null,
+        null,
+        "ed25519:4TMpf3su3HbRCGwomKqwZkuBfZesSXJnCbE3ZLBtpSARfrcbqfpP5v81EejzJkBMnL2Yb5dHKKno6bCVS2gzcFNf",
+        null,
+        "ed25519:3kGVgxS3yLgFQ473bJmLX27k82DxToe1sPUiVGTf8MZbQtMTPkHba9fUzng7gV8LaxQvWi5i2d1Dhnr1JEAERe9M",
+        "ed25519:2Znjf9YGkggJvuwnS36eRkMgy7AcuysNKBuVLBY3q4gSKkhBsyyLsChABLxHxXoPJ34c32AjUdtNn5uMBvDXAHtv",
+        "ed25519:3urz5YkWmhn3SokUsJwegcKPenEv4Tp4rTfdHN9Yb51wcu6FUfxUURMoeJMkaAFoUHtSJx9fWoT97BM6FFWkQA4t",
+        "ed25519:4sy2GhzhcfKbuT99SawN1VHYNQjcCgsGqYYgmwTy9bgAbrcwJwYesCiJznvTntozNdfB2WvNbmDqcH2BcAxFnz5U",
+        "ed25519:34nEKYdnPfjLGJgYCbrzy5DhZoP5itY2d5ALD5a3RZwnSRjCje5hsy2SDKtxm1idQNna25XFQMpvA23Pw9nnpcX1",
+        null,
+        null,
+        "ed25519:42fciZNEQaPcRSkRRNpQVigwJ6vENdJHpfVJS7287gK9jd5yQTsHhDzjCM24j9hrnxwuMzHBvjZBe3jjUN84EcSR",
+        "ed25519:5CSUVyp8XKFz9hsNxXqrQP7FrGbyYFj1fnwEfb4TyR7TqbGY43EKx3z1o6G6fC8AqP5GbG94UVZzzjLj3ZhtVddz",
+        "ed25519:3URU6ZfpkWusHXsKmVGxJVxZdXGDqTWvdhQgh6Dg2HgZiJnfgeHN3pBJ8aiGf9wL9UZBq8fTYcPQufDPpZd45Ee9",
+        "ed25519:at7pPPojXfrbz2mAnayeeJ1VFNx2mTaHhDZcZQoe74Liz3dh6EomQkzuV3NFw4w8ydpaSrZS3PJmYxVAAZHWvhz",
+        "ed25519:3z44f4NNVovbnX2hGU8oCYK85HRmvAFzmrFLLpkCfxmMF3rSpnCxJtWwSjwfgwRAwrFZx3H4xiZT48sx1fYehac1",
+        "ed25519:3HaYFzqEJ2SoRMXzbXMNTPrY5VBrS67wZ9v8qBfPfiKxAs1pPYPat9KYPQCNYFFnWj5nFJZHR7WtZujtqYjGvff",
+        "ed25519:22Vz8iN64hBa5L68GB4fVpRxu2A6vECcQjcYefdyFDAmLN983YknHn8StqwkzYjbgL14CHQ5YRag1meo2oaGJ37g",
+        "ed25519:G1HSDx5R2PDv1DQNYJn6YoCjyb6w9CgWXK7gXtXRwsp1iNjQPxcYgtRJR24D47x9MtfX5pyv9WxpYadXhLJBJd2",
+        "ed25519:53DwgzBB2eyMUGxrB33r8J2icdsfBKn6ZA3eaG4jc7iXN1FoberyDmMJWsBnLk56Kwaszs2PzJhNo6FXWYa9KhKj",
+        "ed25519:YnaxfCwqmsLJZ3XnEUGxygAaVvJXSXjB8znhnoqCpthsbKxNxVCoaeFRdmucoMPcReXJEURNmBREdfuea3KDymv",
+        "ed25519:5oP4HCMWQC5VZT2w3LNyE74QyXS4pDZjHrshHvyfsyTJoG22T25wwBdBC5hLmdNyTa4uUGcH5Au12NZS1zRdAB49",
+        null,
+        "ed25519:5o8cJEEcn1Xkun6RX9g6xrEZ37QydNcahb19r5gWDWowfrCsoLVfkASYRwTLii1C3iTg6qNUjHCwQV9grG9jo1cC",
+        "ed25519:WZ8RTex9An1w5Ujrv7Vfeiu4Rtb6L7vTAUbMoNkw8swawTGg94RjjPdgWHPQR2Nu2CxXRyN3XXznNvMB8rjVFHA",
+        "ed25519:4wR7rCZ1GmF5CrvyjdwYnzdPWC4tY4Zy4FpPT2HrebEFyY8EyYefWHEMtnNRk6tvWHE83e1KjZqkrSAjAkfFe8BZ",
+        "ed25519:5dKsJ3u4uSLFkvusnpENqqiEhLmZG43Qa8jJYRbgfGCTRRRXGXLykHVv6nLePe1ixdzt46KoHawbyPiq2UbJxpQE",
+        "ed25519:5Xt5jvgvyycbjBGjJakBBqevTxKtxqSDHRiDJNG5QhNH5vhmwqXrCetLh8ozpVXMmqas5wQpVkyLS4mppugJpDvN",
+        "ed25519:Fj5L2awUuuRtp5TSeWMGas1J2k7zpfpw9CaqPr79DPgeQWDArssTUgpwadg2aeA4PggWABuCw4oktdp8xj49Q4n",
+        "ed25519:eAdr5du43xuxYm8Wm5esF2iAjmXieEe8jiK1Qyb8XyKU4f5XjPdAVX7DrZT9nNBMDEDCBVo5RisFDMYhsFqy115",
+        "ed25519:7LnqGcjJybNwsaKy6tPMuuYLwn7Ra82dnjLWv9kXaFrDdc18JMBegzfzPGmae3KDMFRswznXzU2Mwk2ai1Pv6Dr",
+        "ed25519:2sEg2YyRHNxYX3yFctiS7dt8VMXiouivJYBkD3D3ES47f6ajf49zRaFfgEnELXzMeoSPLZdZvWNFaHNe2Vx1BK5j",
+        "ed25519:54c6ZiyFebmifTz2Tg5sVfD2skmqPp9Co5QhwsUsYMymatchX2TRCXpE14gF5RQA1baYtbn7z1rB4XgBRfdnPj9N",
+        null,
+        "ed25519:5jF8Lr5q79tqKHtxSaxJUUWJ1nNENtEwurVDFTuQ94nTnLwMcWMTKW7XWFeWGETu2XYxJUVH99udSsZpQBMMB9MF",
+        "ed25519:yMabhstfhsqEEu6RoAzRWxa8DSz48gHcNrZ8EVLC769SFfRkGKjAoDsdpGMkHTzewyEVh6pSgj1MQxb39JNjpJD",
+        "ed25519:3k9yGUgnbNk9xygL5dqv4Hbx81uTBMF1woVbi8eNrVxN2aNa7rU3LnrCjJwfjxX5GvCFfCSFJZATpNFdKc9Qg3Lc",
+        "ed25519:3PUy9mRzaAFPivTiN3hD5RNbCHhK7ci2B7ghh62K2M2u9ysPENykEt48qSQsejb1BBv8yo1emjXqYhDThp6gFU4C",
+        null,
+        "ed25519:41L6XiAU6rvzbEuqt6YjbyUQmxGx3ySFU7EF6btVkW3jzqzRKazbMD85pi5nVVejrLwvENTyoR2ZtVWfbUYAr6TY",
+        "ed25519:5Z52kLsreVpAHvnfjPhRxAM5U1hqmVAbmnWL2A14Dk8JSN4Q9VBGdCmHHGpkBJAGfTKcRmG8y1fQVRgTWvfXN3hE",
+        null,
+        null,
+        "ed25519:4Tktuffif2iWNUbCyc5H3zjr1xZDAx2hdWxM2VodcR8hMHFvvxvM1vcp34w2aAut7BCiBdFFPcqebJ4yhybw2qiw",
+        "ed25519:9oTbLzaPf38FH3qLXxnZpPHAGyywZngYKcpCsvodztzZyFHwG68hpxmP55N9CXVyYaNEas6Rt1bw7D4UdV4RfWm",
+        "ed25519:5Gibp6ZGdTAThadbohxe8h5gNPxnawioCbiASPHR7WEdR7Pan2TJeJ6apy2DYEW2JDPnkWiAjtHPJbWw1wiMNnqk",
+        "ed25519:5Tuph6yRFTtBubahBW3wsaz8kcHg5ZcSQwLKyb3G7n6Gk4z5XzDQE53tPz12boKgjBzf4WwcVZEYkhf1o9j6Q4VW",
+        "ed25519:2qcPTFjPu4ytTHUSeMyhsKK56b3CZ7jYnHaPr5q49yeX5PeARMr6gKv8eBWUg6PM7W5Ai8tw14yzgtv1hxuR3YRt",
+        "ed25519:4Vpbgsna4vRYQXVWAaCMueamjFvU27GFmR334xuLuriK2v7KfGvaViLueWqBqagSoHfkz6Vy3VunYr6JZ3U1iSjv",
+        null,
+        null,
+        "ed25519:JJJ7kW9xARLjczQHwqYjfZj8Ns2zZRUUyBvPzMuCoZX4C387YaLYBojRRSsKMQc5BxvYNDxD9qBPJjpha28S65r",
+        "ed25519:3yzUtRaHtgCovv3VrVaJngNJQTvK9CTepxJQBH2vB5cEmuHL3FD9B2SrpGSGVN3Qp7T1cnxwCVsciFvyYAfWQYWw",
+        null,
+        null,
+        null,
+        "ed25519:3f4kjhpjDqWxsjdk1XYh8pzeKnY2a91yedqqgwL7sutoSgpgkpPrxHpuDbrUsnH5FEXN4cT3B7rpHJcjBxuAVnxC"
+      ],
+      "signature": "ed25519:4oySsMtUVALHyruKhZAbHennqbazkWRPCWZdXW3WdRdYDNkCiMc7gF1Xv8BgfZkkpGBdY4smbPAWVr4ZhsF54h31",
+      "latest_protocol_version": 55
+    }
+  },
+  "shards": [
+    {
+      "shard_id": 0,
+      "chunk": {
+        "author": "bisontrails.poolv1.near",
+        "header": {
+          "chunk_hash": "9RuBwsHrs2BKVM1QNmeMhm6p76bPyW44y2NABvxk17Di",
+          "prev_block_hash": "5njXB5DwrUbiPtt39FP4JbQZCF58J4bLijhr6L6vPVY",
+          "outcome_root": "H8eQMwx9TrosHgXRiRTy3oiTLWnXwNTWvPUjS8z1JCkw",
+          "prev_state_root": "8jhLQ9mk6gMxyTxkurRpkhYYiMdKendkMbqHmrXwN7KM",
+          "encoded_merkle_root": "9DeRDEJ4CXhpk17gBQLztF9dJ11QKrtBtXqw9L39G3rS",
+          "encoded_length": 1328,
+          "height_created": 71771951,
+          "height_included": 71771951,
+          "shard_id": 0,
+          "gas_used": 7746142133874,
+          "gas_limit": 1000000000000000,
+          "validator_reward": 0,
+          "balance_burnt": "672287259613700000000",
+          "outgoing_receipts_root": "8Kh5PjE9kEy8iE7fDdHaBp2dpjxxcLHHaotFBkSg4Fig",
+          "tx_root": "p9Ew6V978DukwKwJQNhP1NDDWuoS32gfuuWiQkLLrVc",
+          "validator_proposals": [],
+          "signature": "ed25519:qsgMWUWzRMWSyVpYkWcEtuG2q6GCPdRJzAmo969sFdirsFxJ1FEjyahAFaGDs8VcKHfPgXbTkv8zTYiXrhFbWeZ"
+        },
+        "transactions": [
+          {
+            "transaction": {
+              "signer_id": "34dfa9e4766e2237cc2780205d6cd13ccd26e9c84ec68f8b13159135a1db0e66",
+              "public_key": "ed25519:Gh9RQcDV6kocfhAF7qVz7jZy18JuAHB1n3uCXzji2uRi",
+              "nonce": 71371181000015,
+              "receiver_id": "dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near",
+              "actions": [
+                {
+                  "FunctionCall": {
+                    "method_name": "ft_transfer_call",
+                    "args": "eyJyZWNlaXZlcl9pZCI6InYxLnBlbWJyb2NrLm5lYXIiLCJhbW91bnQiOiI3OTgyMjQ4MzE5IiwibXNnIjoiZGVwb3NpdCJ9",
+                    "gas": 100000000000000,
+                    "deposit": "1"
+                  }
+                }
+              ],
+              "signature": "ed25519:2Q8bSY6SrAL533Rt1RjDwb3gLhchdDjYXvebdxTFuobygu7jY1XzfMd8ksaM3dzPQC51VfDhocRyNtKzdMYVwY5z",
+              "hash": "EwRXEQj2gLVgF147v7s9ktUDFsSVFVJv9PpgHNy9yymT"
+            },
+            "outcome": {
+              "execution_outcome": {
+                "proof": [
+                  {
+                    "hash": "BVeBJ6ctPBcgCGzeiaZDPUBaZJSRi2z4qjhoJTjffEvA",
+                    "direction": "Right"
+                  },
+                  {
+                    "hash": "58EhJdZUr9dotrG3yQ1o7n45FvqGs2k4rtXifDL4XCR5",
+                    "direction": "Right"
+                  },
+                  {
+                    "hash": "84te5Hoy3jcuZ53h96za2aCMyHgFoBRBFY8DJBBog39M",
+                    "direction": "Right"
+                  }
+                ],
+                "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+                "id": "EwRXEQj2gLVgF147v7s9ktUDFsSVFVJv9PpgHNy9yymT",
+                "outcome": {
+                  "logs": [],
+                  "receipt_ids": [
+                    "C3MxtAQmKknB5FPuB9d1t9Hv3Dv6wxqGE3S3HinCHQUY"
+                  ],
+                  "gas_burnt": 2428117762192,
+                  "tokens_burnt": "242811776219200000000",
+                  "executor_id": "34dfa9e4766e2237cc2780205d6cd13ccd26e9c84ec68f8b13159135a1db0e66",
+                  "status": {
+                    "SuccessReceiptId": "C3MxtAQmKknB5FPuB9d1t9Hv3Dv6wxqGE3S3HinCHQUY"
+                  },
+                  "metadata": {
+                    "version": 1,
+                    "gas_profile": null
+                  }
+                }
+              },
+              "receipt": null
+            }
+          },
+          {
+            "transaction": {
+              "signer_id": "app.nearcrowd.near",
+              "public_key": "ed25519:AF6pRVbEqTF7aPNxBssgNg44w4Vkm1e5rKg5Ecb1pKUj",
+              "nonce": 42862382951770,
+              "receiver_id": "app.nearcrowd.near",
+              "actions": [
+                {
+                  "FunctionCall": {
+                    "method_name": "finalize_task",
+                    "args": "eyJ0YXNrX29yZGluYWwiOjEsImlzX2hvbmV5cG90IjpmYWxzZSwiaG9uZXlwb3RfcHJlaW1hZ2UiOlsxMTUsMTA3LDEwMywxMTksMTA2LDk3LDEwNywxMDUsMTExLDExMSwxMTgsMTIxLDEwOCwxMjEsMTE1LDEwNF0sInRhc2tfcHJlaW1hZ2UiOlsyMzIsMjIyLDI1NSwxNzYsMjIsMTY0LDkwLDExMSwxNDksMTE2LDExOSw1MCw3OCwyNTUsMTMwLDEzOSwzMywyMzQsNDAsMjUwLDEyNSwxNDEsMjcsMTQ0LDE1MywxNjAsMjM5LDg1LDI0MiwxMjgsMTA5LDExNl19",
+                    "gas": 200000000000000,
+                    "deposit": "0"
+                  }
+                }
+              ],
+              "signature": "ed25519:eWwbBo2FD3tj5uVRgsm7HLTBww9cCg9XhJgCS9DPqS7ysj6TcVr5CMMGZTJAknncnTtNebc4zUDnbPPuL1iVq7z",
+              "hash": "Aw87EbuQ61iC2ef3tmoTrbnA7kyX2V8rj1LX6eM4mFoy"
+            },
+            "outcome": {
+              "execution_outcome": {
+                "proof": [
+                  {
+                    "hash": "CYPaVmpcvFkA8x51Et3toVT6fb6gVWx71NY6mKYRXbX1",
+                    "direction": "Left"
+                  },
+                  {
+                    "hash": "58EhJdZUr9dotrG3yQ1o7n45FvqGs2k4rtXifDL4XCR5",
+                    "direction": "Right"
+                  },
+                  {
+                    "hash": "84te5Hoy3jcuZ53h96za2aCMyHgFoBRBFY8DJBBog39M",
+                    "direction": "Right"
+                  }
+                ],
+                "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+                "id": "Aw87EbuQ61iC2ef3tmoTrbnA7kyX2V8rj1LX6eM4mFoy",
+                "outcome": {
+                  "logs": [],
+                  "receipt_ids": [
+                    "CfWW6scvGc5GCPhVam77Bb8ULgH74uHjPZs3Ud2hXqaF"
+                  ],
+                  "gas_burnt": 2428533645916,
+                  "tokens_burnt": "242853364591600000000",
+                  "executor_id": "app.nearcrowd.near",
+                  "status": {
+                    "SuccessReceiptId": "CfWW6scvGc5GCPhVam77Bb8ULgH74uHjPZs3Ud2hXqaF"
+                  },
+                  "metadata": {
+                    "version": 1,
+                    "gas_profile": null
+                  }
+                }
+              },
+              "receipt": null
+            }
+          }
+        ],
+        "receipts": [
+          {
+            "predecessor_id": "app.nearcrowd.near",
+            "receiver_id": "app.nearcrowd.near",
+            "receipt_id": "CfWW6scvGc5GCPhVam77Bb8ULgH74uHjPZs3Ud2hXqaF",
+            "receipt": {
+              "Action": {
+                "signer_id": "app.nearcrowd.near",
+                "signer_public_key": "ed25519:AF6pRVbEqTF7aPNxBssgNg44w4Vkm1e5rKg5Ecb1pKUj",
+                "gas_price": "335989893",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "finalize_task",
+                      "args": "eyJ0YXNrX29yZGluYWwiOjEsImlzX2hvbmV5cG90IjpmYWxzZSwiaG9uZXlwb3RfcHJlaW1hZ2UiOlsxMTUsMTA3LDEwMywxMTksMTA2LDk3LDEwNywxMDUsMTExLDExMSwxMTgsMTIxLDEwOCwxMjEsMTE1LDEwNF0sInRhc2tfcHJlaW1hZ2UiOlsyMzIsMjIyLDI1NSwxNzYsMjIsMTY0LDkwLDExMSwxNDksMTE2LDExOSw1MCw3OCwyNTUsMTMwLDEzOSwzMywyMzQsNDAsMjUwLDEyNSwxNDEsMjcsMTQ0LDE1MywxNjAsMjM5LDg1LDI0MiwxMjgsMTA5LDExNl19",
+                      "gas": 200000000000000,
+                      "deposit": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "predecessor_id": "000000000b8acb32e2682d41857e8bc61a58048253dc8349437615712de34e8f",
+            "receiver_id": "aurora",
+            "receipt_id": "Fu7UjCpmCj7fK3YYhsZbRubCJmC7kxBL8Z94ADh4exri",
+            "receipt": {
+              "Action": {
+                "signer_id": "000000000b8acb32e2682d41857e8bc61a58048253dc8349437615712de34e8f",
+                "signer_public_key": "ed25519:11117tMZHZEfeF9RN9MiD66mnfp9VE64Vy6kE1mvg6",
+                "gas_price": "625040174",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "submit",
+                      "args": "",
+                      "gas": 300000000000000,
+                      "deposit": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "predecessor_id": "system",
+            "receiver_id": "worker5.near",
+            "receipt_id": "EA6pr1FbuyPdiz2VTFAxQb23WLu2Ax8YKu5cH66j7Gxa",
+            "receipt": {
+              "Action": {
+                "signer_id": "worker5.near",
+                "signer_public_key": "ed25519:7uoofBburTbKNPZeiLJavh59tS9NbX5j8BmR2sgM1geD",
+                "gas_price": "0",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "Transfer": {
+                      "deposit": "3478740903506317854228"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "receipt_execution_outcomes": [
+        {
+          "execution_outcome": {
+            "proof": [
+              {
+                "hash": "FLHwWUfou9q2ie13sdgzEpiuS5PnvV8kVF3RgZaiAzBA",
+                "direction": "Right"
+              },
+              {
+                "hash": "8RGzsWM5X32zJVx74Jz44HzeAFidGoSUekcoP4HGW76B",
+                "direction": "Left"
+              },
+              {
+                "hash": "84te5Hoy3jcuZ53h96za2aCMyHgFoBRBFY8DJBBog39M",
+                "direction": "Right"
+              }
+            ],
+            "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+            "id": "CfWW6scvGc5GCPhVam77Bb8ULgH74uHjPZs3Ud2hXqaF",
+            "outcome": {
+              "logs": [],
+              "receipt_ids": [
+                "DH9Q8tYNXMjz9Z7QjGvqRjv2AfCVymgTHXByrRNuTaqr"
+              ],
+              "gas_burnt": 4506503213317,
+              "tokens_burnt": "450650321331700000000",
+              "executor_id": "app.nearcrowd.near",
+              "status": {
+                "SuccessValue": ""
+              },
+              "metadata": {
+                "version": 1,
+                "gas_profile": [
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "BASE",
+                    "gas_used": "8472579552"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "CONTRACT_LOADING_BASE",
+                    "gas_used": "35445963"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "CONTRACT_LOADING_BYTES",
+                    "gas_used": "87131332500"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_CACHED_TRIE_NODE",
+                    "gas_used": "335160000000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_MEMORY_BASE",
+                    "gas_used": "33928221600"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_MEMORY_BYTE",
+                    "gas_used": "2041315821"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_REGISTER_BASE",
+                    "gas_used": "27688817046"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_REGISTER_BYTE",
+                    "gas_used": "101518860"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "SHA256_BASE",
+                    "gas_used": "9081940500"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "SHA256_BYTE",
+                    "gas_used": "1953505431"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_BASE",
+                    "gas_used": "169070537250"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_KEY_BYTE",
+                    "gas_used": "1423816518"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_VALUE_BYTE",
+                    "gas_used": "1615969440"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_REMOVE_BASE",
+                    "gas_used": "106946061000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_REMOVE_KEY_BYTE",
+                    "gas_used": "2904749184"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_REMOVE_RET_VALUE_BYTE",
+                    "gas_used": "1487570724"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_BASE",
+                    "gas_used": "192590208000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_EVICTED_BYTE",
+                    "gas_used": "9249784416"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_KEY_BYTE",
+                    "gas_used": "3242211882"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_VALUE_BYTE",
+                    "gas_used": "8933339232"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "TOUCHING_TRIE_NODE",
+                    "gas_used": "869505620004"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WASM_INSTRUCTION",
+                    "gas_used": "133474060368"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_MEMORY_BASE",
+                    "gas_used": "33645538332"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_MEMORY_BYTE",
+                    "gas_used": "2849065512"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_REGISTER_BASE",
+                    "gas_used": "31520747346"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_REGISTER_BYTE",
+                    "gas_used": "3915610920"
+                  }
+                ]
+              }
+            }
+          },
+          "receipt": {
+            "predecessor_id": "app.nearcrowd.near",
+            "receiver_id": "app.nearcrowd.near",
+            "receipt_id": "CfWW6scvGc5GCPhVam77Bb8ULgH74uHjPZs3Ud2hXqaF",
+            "receipt": {
+              "Action": {
+                "signer_id": "app.nearcrowd.near",
+                "signer_public_key": "ed25519:AF6pRVbEqTF7aPNxBssgNg44w4Vkm1e5rKg5Ecb1pKUj",
+                "gas_price": "335989893",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "finalize_task",
+                      "args": "eyJ0YXNrX29yZGluYWwiOjEsImlzX2hvbmV5cG90IjpmYWxzZSwiaG9uZXlwb3RfcHJlaW1hZ2UiOlsxMTUsMTA3LDEwMywxMTksMTA2LDk3LDEwNywxMDUsMTExLDExMSwxMTgsMTIxLDEwOCwxMjEsMTE1LDEwNF0sInRhc2tfcHJlaW1hZ2UiOlsyMzIsMjIyLDI1NSwxNzYsMjIsMTY0LDkwLDExMSwxNDksMTE2LDExOSw1MCw3OCwyNTUsMTMwLDEzOSwzMywyMzQsNDAsMjUwLDEyNSwxNDEsMjcsMTQ0LDE1MywxNjAsMjM5LDg1LDI0MiwxMjgsMTA5LDExNl19",
+                      "gas": 200000000000000,
+                      "deposit": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "execution_outcome": {
+            "proof": [
+              {
+                "hash": "aueAZNVCBSpPXV1xjUKfndWN3juJJTfB2ZgmMeCL4jS",
+                "direction": "Left"
+              },
+              {
+                "hash": "8RGzsWM5X32zJVx74Jz44HzeAFidGoSUekcoP4HGW76B",
+                "direction": "Left"
+              },
+              {
+                "hash": "84te5Hoy3jcuZ53h96za2aCMyHgFoBRBFY8DJBBog39M",
+                "direction": "Right"
+              }
+            ],
+            "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+            "id": "NzgGubgKteKz4PUcSgFdYU6DLqP3p9owkEuNsdstLdY",
+            "outcome": {
+              "logs": [],
+              "receipt_ids": [
+                "6WwYsCqKSpCYEnMcW8mgVbL7XPRCEPJ6xknAiXsbu9xT"
+              ],
+              "gas_burnt": 424555062500,
+              "tokens_burnt": "42455506250000000000",
+              "executor_id": "14c09e71856e44e37bd44912018ffd7477ca0900614bbde50d26d2004758b7e9",
+              "status": {
+                "SuccessValue": ""
+              },
+              "metadata": {
+                "version": 1,
+                "gas_profile": []
+              }
+            }
+          },
+          "receipt": {
+            "predecessor_id": "sweat_welcome.near",
+            "receiver_id": "14c09e71856e44e37bd44912018ffd7477ca0900614bbde50d26d2004758b7e9",
+            "receipt_id": "NzgGubgKteKz4PUcSgFdYU6DLqP3p9owkEuNsdstLdY",
+            "receipt": {
+              "Action": {
+                "signer_id": "sweat_welcome.near",
+                "signer_public_key": "ed25519:6XkFcphbiZMAYeD1nk9FiLpA9CWm4Y4ep9vjpm9csiao",
+                "gas_price": "103000000",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "Transfer": {
+                      "deposit": "50000000000000000000000"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "execution_outcome": {
+            "proof": [
+              {
+                "hash": "26bBoYRshD6vp3CWXRoeHDUAgyYnfRzQMFoR7XYBp5xp",
+                "direction": "Right"
+              },
+              {
+                "hash": "725nHD5j3xYLkyF9r86d7FGYKyymP8QMAGYaFhN7YnkF",
+                "direction": "Left"
+              }
+            ],
+            "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+            "id": "B69bsYkaVH2Nj3pMUMygUMeEkxPAtSVtcbEGVscSD6qD",
+            "outcome": {
+              "logs": [],
+              "receipt_ids": [
+                "6n6FmEs9hfr6UVWB4Kw22AqzgbNuJrvquvTnCbw1dt7r"
+              ],
+              "gas_burnt": 4645178549088,
+              "tokens_burnt": "464517854908800000000",
+              "executor_id": "app.nearcrowd.near",
+              "status": {
+                "SuccessValue": "ZmFsc2U="
+              },
+              "metadata": {
+                "version": 1,
+                "gas_profile": [
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "BASE",
+                    "gas_used": "12444101217"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "CONTRACT_LOADING_BASE",
+                    "gas_used": "35445963"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "CONTRACT_LOADING_BYTES",
+                    "gas_used": "87131332500"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_CACHED_TRIE_NODE",
+                    "gas_used": "396720000000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_MEMORY_BASE",
+                    "gas_used": "46977537600"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_MEMORY_BYTE",
+                    "gas_used": "2159157144"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_REGISTER_BASE",
+                    "gas_used": "35240312604"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_REGISTER_BYTE",
+                    "gas_used": "100631802"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_HAS_KEY_BASE",
+                    "gas_used": "54039896625"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_HAS_KEY_BYTE",
+                    "gas_used": "800561970"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_BASE",
+                    "gas_used": "225427383000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_KEY_BYTE",
+                    "gas_used": "3683351427"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_VALUE_BYTE",
+                    "gas_used": "3220716870"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_REMOVE_BASE",
+                    "gas_used": "106946061000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_REMOVE_KEY_BYTE",
+                    "gas_used": "1070170752"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_REMOVE_RET_VALUE_BYTE",
+                    "gas_used": "761082696"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_BASE",
+                    "gas_used": "320983680000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_EVICTED_BYTE",
+                    "gas_used": "8061444057"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_KEY_BYTE",
+                    "gas_used": "5145249291"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_VALUE_BYTE",
+                    "gas_used": "9832876863"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "TOUCHING_TRIE_NODE",
+                    "gas_used": "708486060744"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WASM_INSTRUCTION",
+                    "gas_used": "98962737192"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_MEMORY_BASE",
+                    "gas_used": "42056922915"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_MEMORY_BYTE",
+                    "gas_used": "2824551564"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_REGISTER_BASE",
+                    "gas_used": "40117314804"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_REGISTER_BYTE",
+                    "gas_used": "3881396844"
+                  }
+                ]
+              }
+            }
+          },
+          "receipt": {
+            "predecessor_id": "worker20211.near",
+            "receiver_id": "app.nearcrowd.near",
+            "receipt_id": "B69bsYkaVH2Nj3pMUMygUMeEkxPAtSVtcbEGVscSD6qD",
+            "receipt": {
+              "Action": {
+                "signer_id": "worker20211.near",
+                "signer_public_key": "ed25519:65Y8X8eX8MAHbh5WrkPDBcxUCEEMrFt4TEV1G5aJqcGF",
+                "gas_price": "122987387",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "claim_assignment",
+                      "args": "eyJ0YXNrX29yZGluYWwiOjEsImJpZCI6IjMwNjM4MDU0ODk5NTUwNzc4MTM1MTIwIn0=",
+                      "gas": 30000000000000,
+                      "deposit": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "execution_outcome": {
+            "proof": [
+              {
+                "hash": "13i2q9yH2rYKtX77igy466LeHvi5w5jnFrQe5rqFsTPV",
+                "direction": "Left"
+              },
+              {
+                "hash": "725nHD5j3xYLkyF9r86d7FGYKyymP8QMAGYaFhN7YnkF",
+                "direction": "Left"
+              }
+            ],
+            "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+            "id": "BWWmgTpF2Ywi7daTEz2yLNdteFVmKTSqZZ4wEtL6Yxnt",
+            "outcome": {
+              "logs": [],
+              "receipt_ids": [
+                "CCe2CukmsEk9N6ECsZcZ1g68GfA5wQ2dEeRN9cEjNYfz"
+              ],
+              "gas_burnt": 3891416310657,
+              "tokens_burnt": "389141631065700000000",
+              "executor_id": "app.nearcrowd.near",
+              "status": {
+                "SuccessValue": ""
+              },
+              "metadata": {
+                "version": 1,
+                "gas_profile": [
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "BASE",
+                    "gas_used": "10061188218"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "CONTRACT_LOADING_BASE",
+                    "gas_used": "35445963"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "CONTRACT_LOADING_BYTES",
+                    "gas_used": "87131332500"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_CACHED_TRIE_NODE",
+                    "gas_used": "239400000000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_MEMORY_BASE",
+                    "gas_used": "33928221600"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_MEMORY_BYTE",
+                    "gas_used": "1900666500"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_REGISTER_BASE",
+                    "gas_used": "27688817046"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_REGISTER_BYTE",
+                    "gas_used": "73428690"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_BASE",
+                    "gas_used": "112713691500"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_KEY_BYTE",
+                    "gas_used": "773813325"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_VALUE_BYTE",
+                    "gas_used": "1256865120"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_REMOVE_BASE",
+                    "gas_used": "53473030500"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_REMOVE_KEY_BYTE",
+                    "gas_used": "764407680"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_REMOVE_RET_VALUE_BYTE",
+                    "gas_used": "369009792"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_BASE",
+                    "gas_used": "320983680000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_EVICTED_BYTE",
+                    "gas_used": "9057080574"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_KEY_BYTE",
+                    "gas_used": "7189252434"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_VALUE_BYTE",
+                    "gas_used": "10949544267"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "TOUCHING_TRIE_NODE",
+                    "gas_used": "386446942224"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WASM_INSTRUCTION",
+                    "gas_used": "88845306660"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_MEMORY_BASE",
+                    "gas_used": "33645538332"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_MEMORY_BYTE",
+                    "gas_used": "2072790492"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_REGISTER_BASE",
+                    "gas_used": "31520747346"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_REGISTER_BYTE",
+                    "gas_used": "2832165180"
+                  }
+                ]
+              }
+            }
+          },
+          "receipt": {
+            "predecessor_id": "jblkolonka.near",
+            "receiver_id": "app.nearcrowd.near",
+            "receipt_id": "BWWmgTpF2Ywi7daTEz2yLNdteFVmKTSqZZ4wEtL6Yxnt",
+            "receipt": {
+              "Action": {
+                "signer_id": "jblkolonka.near",
+                "signer_public_key": "ed25519:41oa1RErvJrmZYt9938qkmHozhYbA5Y77Dz5nbUnCC6o",
+                "gas_price": "122987387",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "submit_approved_solution",
+                      "args": "eyJ0YXNrX29yZGluYWwiOjEsInNvbHV0aW9uX2hhc2giOlsxNDcsMTk0LDIyNyw4Miw3MSwxNjUsMTkzLDE2NCwyMzYsNzcsOTgsMTI5LDE0Miw1Miw3NiwxOTcsNSw4MSwyMzksMTczLDIyNCwyMSwxNjUsOTYsMjM2LDIwLDM4LDYzLDE4LDU1LDg4LDIxMF19",
+                      "gas": 30000000000000,
+                      "deposit": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "state_changes": [
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "NzgGubgKteKz4PUcSgFdYU6DLqP3p9owkEuNsdstLdY"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "14c09e71856e44e37bd44912018ffd7477ca0900614bbde50d26d2004758b7e9",
+            "amount": "50000000000000000000000",
+            "locked": "0",
+            "code_hash": "11111111111111111111111111111111",
+            "storage_usage": 182,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "transaction_processing",
+            "tx_hash": "EwRXEQj2gLVgF147v7s9ktUDFsSVFVJv9PpgHNy9yymT"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "34dfa9e4766e2237cc2780205d6cd13ccd26e9c84ec68f8b13159135a1db0e66",
+            "amount": "1536291026515652921592591",
+            "locked": "0",
+            "code_hash": "11111111111111111111111111111111",
+            "storage_usage": 3019,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "transaction_processing",
+            "tx_hash": "Aw87EbuQ61iC2ef3tmoTrbnA7kyX2V8rj1LX6eM4mFoy"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "amount": "6439914028578617750834864845",
+            "locked": "0",
+            "code_hash": "Cbo4E9kvgJRZvUaKzjVKxGbXMDiov3ABCNodRebLZaUW",
+            "storage_usage": 3353785,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "CfWW6scvGc5GCPhVam77Bb8ULgH74uHjPZs3Ud2hXqaF"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "amount": "6439914028578617750834864845",
+            "locked": "0",
+            "code_hash": "Cbo4E9kvgJRZvUaKzjVKxGbXMDiov3ABCNodRebLZaUW",
+            "storage_usage": 3353500,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "action_receipt_gas_reward",
+            "receipt_hash": "CfWW6scvGc5GCPhVam77Bb8ULgH74uHjPZs3Ud2hXqaF"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "amount": "6439914090917704772834864845",
+            "locked": "0",
+            "code_hash": "Cbo4E9kvgJRZvUaKzjVKxGbXMDiov3ABCNodRebLZaUW",
+            "storage_usage": 3353500,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "B69bsYkaVH2Nj3pMUMygUMeEkxPAtSVtcbEGVscSD6qD"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "amount": "6439914090917704772834864845",
+            "locked": "0",
+            "code_hash": "Cbo4E9kvgJRZvUaKzjVKxGbXMDiov3ABCNodRebLZaUW",
+            "storage_usage": 3353446,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "action_receipt_gas_reward",
+            "receipt_hash": "B69bsYkaVH2Nj3pMUMygUMeEkxPAtSVtcbEGVscSD6qD"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "amount": "6439914157431004096134864845",
+            "locked": "0",
+            "code_hash": "Cbo4E9kvgJRZvUaKzjVKxGbXMDiov3ABCNodRebLZaUW",
+            "storage_usage": 3353446,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "BWWmgTpF2Ywi7daTEz2yLNdteFVmKTSqZZ4wEtL6Yxnt"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "amount": "6439914157431004096134864845",
+            "locked": "0",
+            "code_hash": "Cbo4E9kvgJRZvUaKzjVKxGbXMDiov3ABCNodRebLZaUW",
+            "storage_usage": 3353557,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "action_receipt_gas_reward",
+            "receipt_hash": "BWWmgTpF2Ywi7daTEz2yLNdteFVmKTSqZZ4wEtL6Yxnt"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "amount": "6439914201324393074334864845",
+            "locked": "0",
+            "code_hash": "Cbo4E9kvgJRZvUaKzjVKxGbXMDiov3ABCNodRebLZaUW",
+            "storage_usage": 3353557,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "NzgGubgKteKz4PUcSgFdYU6DLqP3p9owkEuNsdstLdY"
+          },
+          "type": "access_key_update",
+          "change": {
+            "account_id": "14c09e71856e44e37bd44912018ffd7477ca0900614bbde50d26d2004758b7e9",
+            "public_key": "ed25519:2Q1WQu8MycSjswDqhoXWYsxSfqGbpbVdwS9UUqHCtzMv",
+            "access_key": {
+              "nonce": 71771950000000,
+              "permission": "FullAccess"
+            }
+          }
+        },
+        {
+          "cause": {
+            "type": "transaction_processing",
+            "tx_hash": "EwRXEQj2gLVgF147v7s9ktUDFsSVFVJv9PpgHNy9yymT"
+          },
+          "type": "access_key_update",
+          "change": {
+            "account_id": "34dfa9e4766e2237cc2780205d6cd13ccd26e9c84ec68f8b13159135a1db0e66",
+            "public_key": "ed25519:Gh9RQcDV6kocfhAF7qVz7jZy18JuAHB1n3uCXzji2uRi",
+            "access_key": {
+              "nonce": 71371181000015,
+              "permission": "FullAccess"
+            }
+          }
+        },
+        {
+          "cause": {
+            "type": "transaction_processing",
+            "tx_hash": "Aw87EbuQ61iC2ef3tmoTrbnA7kyX2V8rj1LX6eM4mFoy"
+          },
+          "type": "access_key_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "public_key": "ed25519:AF6pRVbEqTF7aPNxBssgNg44w4Vkm1e5rKg5Ecb1pKUj",
+            "access_key": {
+              "nonce": 42862382951770,
+              "permission": "FullAccess"
+            }
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "CfWW6scvGc5GCPhVam77Bb8ULgH74uHjPZs3Ud2hXqaF"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "UwwAAABzbGl0bG9sLm5lYXI=",
+            "value_base64": "n/ANA/ojkg0QNAAAAAAAAONw+RPU/KYN4jsAAAAAAAAJAAAAAgAAAGAdAABGHQAAVGFXHFQBBQAAAAAAAAAAAA=="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "BWWmgTpF2Ywi7daTEz2yLNdteFVmKTSqZZ4wEtL6Yxnt"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "Uw8AAABqYmxrb2xvbmthLm5lYXI=",
+            "value_base64": "AAAAAAAAAAAAAAAAAAAAANYjgdaGfZeOitgAAAAAAAAAAAAAAAAAANkOAACrDgAAVFVVVF1FFFVVVVUBAAAAAA=="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "CfWW6scvGc5GCPhVam77Bb8ULgH74uHjPZs3Ud2hXqaF"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "UxMAAABwb2xvdmluYWdydXNoaS5uZWFy",
+            "value_base64": "JFYDnhCthE/axwIAAAAAANBBnlxWewlertwAAAAAAABnAAAACQAAANkYAACdGAAAVFVBVTVFUUFVVVFVRFURAA=="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "BWWmgTpF2Ywi7daTEz2yLNdteFVmKTSqZZ4wEtL6Yxnt"
+          },
+          "type": "data_deletion",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "YQ8AAABqYmxrb2xvbmthLm5lYXI="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "CfWW6scvGc5GCPhVam77Bb8ULgH74uHjPZs3Ud2hXqaF"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "cAEAAAA=",
+            "value_base64": "AABAe6XwY4GWCgAAAAAAAAAA9ESCkWNFAAAAAAAAAAAsAQAAAAAAAHn/mU5T8RzntwYAAAAAAACgPZthJEcKF/2whQAAAAAABgAAAHQBAAAAYnfdhQAAAAAABgAAAHQBAAAAYjsCAAAAAAAABgAAAHQBAAAAYwYAAAB0AQAAAGUGAAAAdAEAAABmBgAAAHQBAAAAZwEGAAAAdAEAAABtAA=="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "B69bsYkaVH2Nj3pMUMygUMeEkxPAtSVtcbEGVscSD6qD"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "cAEAAAA=",
+            "value_base64": "AABAe6XwY4GWCgAAAAAAAAAA9ESCkWNFAAAAAAAAAAAsAQAAAAAAAHn/mU5T8RzntwYAAAAAAACgPZthJEcKF/2whQAAAAAABgAAAHQBAAAAYnfdhQAAAAAABgAAAHQBAAAAYjoCAAAAAAAABgAAAHQBAAAAYwYAAAB0AQAAAGUGAAAAdAEAAABmBgAAAHQBAAAAZwEGAAAAdAEAAABtAA=="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "BWWmgTpF2Ywi7daTEz2yLNdteFVmKTSqZZ4wEtL6Yxnt"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "cAEAAAA=",
+            "value_base64": "AABAe6XwY4GWCgAAAAAAAAAA9ESCkWNFAAAAAAAAAAAsAQAAAAAAADBe9Nf4r5aAwAYAAAAAAAD2JZLfJEcKF/2whQAAAAAABgAAAHQBAAAAYnfdhQAAAAAABgAAAHQBAAAAYjsCAAAAAAAABgAAAHQBAAAAYwYAAAB0AQAAAGUGAAAAdAEAAABmBgAAAHQBAAAAZwEGAAAAdAEAAABtAA=="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "B69bsYkaVH2Nj3pMUMygUMeEkxPAtSVtcbEGVscSD6qD"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "dAEAAABjEwIAAAAAAAA=",
+            "value_base64": "S4alwqamIqVp3r0wuHYsh5gHy9qt80n2CDRKW73T8PkE"
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "B69bsYkaVH2Nj3pMUMygUMeEkxPAtSVtcbEGVscSD6qD"
+          },
+          "type": "data_deletion",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "dAEAAABjOgIAAAAAAAA="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "BWWmgTpF2Ywi7daTEz2yLNdteFVmKTSqZZ4wEtL6Yxnt"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "dAEAAABjOgIAAAAAAAA=",
+            "value_base64": "HgYe1I0JayQTBS75370kQJJ3M9BOZ3/Rat6SnTgfD2QB"
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "B69bsYkaVH2Nj3pMUMygUMeEkxPAtSVtcbEGVscSD6qD"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "dAEAAABjyAEAAAAAAAA=",
+            "value_base64": "eO7UuOE3hIRyincuWe2PTJg9PHxgwzX41K/CQYh57uAB"
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "CfWW6scvGc5GCPhVam77Bb8ULgH74uHjPZs3Ud2hXqaF"
+          },
+          "type": "data_deletion",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "dAEAAABlSP1s26zKXnrDobkJQHmp9wTmSGUHua9RRMmCfsmxMrg="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "BWWmgTpF2Ywi7daTEz2yLNdteFVmKTSqZZ4wEtL6Yxnt"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "dAEAAABmHgYe1I0JayQTBS75370kQJJ3M9BOZ3/Rat6SnTgfD2Q=",
+            "value_base64": "DwAAAGpibGtvbG9ua2EubmVhctgOAACTwuNSR6XBpOxNYoGONEzFBVHvreAVpWDsFCY/EjdY0koSRWULMBOt5QQAAAAAAAA="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "CfWW6scvGc5GCPhVam77Bb8ULgH74uHjPZs3Ud2hXqaF"
+          },
+          "type": "data_deletion",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "dAEAAABmSP1s26zKXnrDobkJQHmp9wTmSGUHua9RRMmCfsmxMrg="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "BWWmgTpF2Ywi7daTEz2yLNdteFVmKTSqZZ4wEtL6Yxnt"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "dAEAAABnDwAAAGpibGtvbG9ua2EubmVhcg==",
+            "value_base64": "AvYlkt8kRwoXMF701/ivloDABgAAAAAAAA=="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "B69bsYkaVH2Nj3pMUMygUMeEkxPAtSVtcbEGVscSD6qD"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "app.nearcrowd.near",
+            "key_base64": "dAEAAABnEAAAAHdvcmtlcjIwMjExLm5lYXI=",
+            "value_base64": "A7j9x34ckeCpMCCL0wkyrmOUnZOvG1w0vDPQHgJQ2PRPAhuSXC8iRwoXKMk2gOJdNnI+AwAAAAAAAA=="
+          }
+        }
+      ]
+    },
+    {
+      "shard_id": 1,
+      "chunk": {
+        "author": "bisontrails.poolv1.near",
+        "header": {
+          "chunk_hash": "BfevsGHzr295dbsNzPLmkdwTDrQGwrNYjaVpgg3it5N9",
+          "prev_block_hash": "5njXB5DwrUbiPtt39FP4JbQZCF58J4bLijhr6L6vPVY",
+          "outcome_root": "3HkxfeW9CQaknGfHjAm1BQZVtdAuhNodbEu2gd9dGxoc",
+          "prev_state_root": "B7qtnBYPF9jC1YiBz4H2nERoZAUUV6K5jqPKA1BFV9Xy",
+          "encoded_merkle_root": "7QxX9R8o7gX3tsSs1TonhGdLwdPgSsAnAGTLv9cKDdvR",
+          "encoded_length": 161,
+          "height_created": 71771951,
+          "height_included": 71771951,
+          "shard_id": 1,
+          "gas_used": 3459870912873,
+          "gas_limit": 1000000000000000,
+          "validator_reward": 0,
+          "balance_burnt": "315036039561400000000",
+          "outgoing_receipts_root": "8oJU6HkXzxrMu5eWhA6QgZ8WwwZE8jCwwms4xZiT1jLG",
+          "tx_root": "11111111111111111111111111111111",
+          "validator_proposals": [],
+          "signature": "ed25519:j9rXr8tWUqZCytifyNvJXsXLYQTTtATz8RyBMqHqpqWsQ2pE3WD5s4NQynSU4o6UUU9uGbEMpu1LgDXBuktwMD4"
+        },
+        "transactions": [],
+        "receipts": [
+          {
+            "predecessor_id": "system",
+            "receiver_id": "relay.aurora",
+            "receipt_id": "CTGFrDBAK4jY6bwfaXNTye9CJNVRCan8TByHrumFXeM4",
+            "receipt": {
+              "Action": {
+                "signer_id": "relay.aurora",
+                "signer_public_key": "ed25519:7FxXbeHhyxSh41XvrSWonkdXnUjx86saj1eij9ubxVmT",
+                "gas_price": "0",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "Transfer": {
+                      "deposit": "188683768400902935789276"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "receipt_execution_outcomes": [
+        {
+          "execution_outcome": {
+            "proof": [
+              {
+                "hash": "G6yXu3ErX9YeHwArU4ZvnLj9JvQUgR5AhMQ9YtyRmoDA",
+                "direction": "Right"
+              }
+            ],
+            "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+            "id": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS",
+            "outcome": {
+              "logs": [
+                "signer_address Address(0x1220a50706b347fc69da0458897f28acab50a700)",
+                "total_writes_count 9",
+                "total_written_bytes 288"
+              ],
+              "receipt_ids": [
+                "FW8dZxb8DvEBKEjiZ3Zs3uZn4NvEzjFUQpFRqTqANMPR"
+              ],
+              "gas_burnt": 9406307933107,
+              "tokens_burnt": "940630793310700000000",
+              "executor_id": "aurora",
+              "status": {
+                "SuccessValue": "BwAAAAAAOh0BAAAAAAAAAAAA"
+              },
+              "metadata": {
+                "version": 1,
+                "gas_profile": [
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "BASE",
+                    "gas_used": "26741579211"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "CONTRACT_LOADING_BASE",
+                    "gas_used": "35445963"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "CONTRACT_LOADING_BYTES",
+                    "gas_used": "222334347000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "ECRECOVER_BASE",
+                    "gas_used": "278821988457"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "KECCAK256_BASE",
+                    "gas_used": "17638473825"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "KECCAK256_BYTE",
+                    "gas_used": "9619055040"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "LOG_BASE",
+                    "gas_used": "10629939150"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "LOG_BYTE",
+                    "gas_used": "1438668219"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_CACHED_TRIE_NODE",
+                    "gas_used": "891480000000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_MEMORY_BASE",
+                    "gas_used": "151372065600"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_MEMORY_BYTE",
+                    "gas_used": "9351279180"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_REGISTER_BASE",
+                    "gas_used": "78032120766"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_REGISTER_BYTE",
+                    "gas_used": "1107344070"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_BASE",
+                    "gas_used": "1465277989500"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_KEY_BYTE",
+                    "gas_used": "28383472761"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_VALUE_BYTE",
+                    "gas_used": "59414931945"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_BASE",
+                    "gas_used": "770360832000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_EVICTED_BYTE",
+                    "gas_used": "12333045888"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_KEY_BYTE",
+                    "gas_used": "38906542584"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_VALUE_BYTE",
+                    "gas_used": "11911118976"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "TOUCHING_TRIE_NODE",
+                    "gas_used": "1304258430006"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "UTF8_DECODING_BASE",
+                    "gas_used": "9335337183"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "UTF8_DECODING_BYTE",
+                    "gas_used": "31782272211"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WASM_INSTRUCTION",
+                    "gas_used": "1264903428888"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_MEMORY_BASE",
+                    "gas_used": "84113845830"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_MEMORY_BYTE",
+                    "gas_used": "30427257012"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_REGISTER_BASE",
+                    "gas_used": "123217466898"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_REGISTER_BYTE",
+                    "gas_used": "44170372116"
+                  }
+                ]
+              }
+            }
+          },
+          "receipt": {
+            "predecessor_id": "relay.aurora",
+            "receiver_id": "aurora",
+            "receipt_id": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS",
+            "receipt": {
+              "Action": {
+                "signer_id": "relay.aurora",
+                "signer_public_key": "ed25519:9DGuSSBpsLausScrigDngbbBiW2iNaNWxMocukYwMeMW",
+                "gas_price": "625040174",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "submit",
+                      "args": "+QGxggU2hAQsHYCEAcnDgJTzFaXMkTOKOIbTw6Eee0lPMwKz+oC5AUTGroP/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD54uM5tFwQQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgMoqyMUhILj/wmABPs1xTK/9BDNoAFkJdHCYNxBflLwAARvPIwgHOEjf/Pk3iFKY/QAS8ADSMhSi//5DQ5Ig+QDyAG3WWAESxyAE5gAT08RrIE5VkRJDkfFAMDSOwASvAQAWjLJguiTP1ZEkMcDABDVCEiAAYAAKcmCOJYBjSHMAhQAJVDC+IdGEoUsyC6No6CgJQADPLM1iXQtBEDLNRwEIJU7AAyRDBnAg0QAM0SwAAAABKANAgAAElwDG8BydAL4ADzQAmAAM/JCrJRHxvJQ8TxIDJD5G4gDbONBBTGoCEnIqCyKDj/pZdRXfZmRe6LsxmiaKh5W6PxXSP5zzWYeR8jkZXCqAR0jhxgp0WrhcaQBLEhtz6YzR0X8GBC8UPsOWkorZ+8w==",
+                      "gas": 300000000000000,
+                      "deposit": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "execution_outcome": {
+            "proof": [
+              {
+                "hash": "6d8GeBSA2gdoZvfbdVTPyYAUHKcc3Ua4EhPygGnrMtQK",
+                "direction": "Left"
+              }
+            ],
+            "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+            "id": "Fu7UjCpmCj7fK3YYhsZbRubCJmC7kxBL8Z94ADh4exri",
+            "outcome": {
+              "logs": [],
+              "receipt_ids": [
+                "6hzfwFMCcZoG9eDuR9YdLa8KDRb13ewfNrfe8wvxc41Y"
+              ],
+              "gas_burnt": 2820793924464,
+              "tokens_burnt": "282079392446400000000",
+              "executor_id": "aurora",
+              "status": {
+                "Failure": {
+                  "ActionError": {
+                    "index": 0,
+                    "kind": {
+                      "FunctionCallError": {
+                        "ExecutionError": "Smart contract panicked: index out of bounds: the len is 0 but the index is 0 [engine-transactions/src/lib.rs:26:12]"
+                      }
+                    }
+                  }
+                }
+              },
+              "metadata": {
+                "version": 1,
+                "gas_profile": [
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "BASE",
+                    "gas_used": "3706753554"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "CONTRACT_LOADING_BASE",
+                    "gas_used": "35445963"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "CONTRACT_LOADING_BYTES",
+                    "gas_used": "222334347000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "KECCAK256_BASE",
+                    "gas_used": "5879491275"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "KECCAK256_BYTE",
+                    "gas_used": "1374150720"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_CACHED_TRIE_NODE",
+                    "gas_used": "11400000000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_MEMORY_BASE",
+                    "gas_used": "7829589600"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_MEMORY_BYTE",
+                    "gas_used": "615815946"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_REGISTER_BASE",
+                    "gas_used": "12585825930"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_REGISTER_BYTE",
+                    "gas_used": "15375672"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_BASE",
+                    "gas_used": "56356845750"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_KEY_BYTE",
+                    "gas_used": "216667731"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_VALUE_BYTE",
+                    "gas_used": "302994270"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "UTF8_DECODING_BASE",
+                    "gas_used": "3111779061"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "UTF8_DECODING_BYTE",
+                    "gas_used": "26533823589"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WASM_INSTRUCTION",
+                    "gas_used": "11196063648"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_MEMORY_BASE",
+                    "gas_used": "14018974305"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_MEMORY_BYTE",
+                    "gas_used": "424908432"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_REGISTER_BASE",
+                    "gas_used": "14327612430"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_REGISTER_BYTE",
+                    "gas_used": "593043984"
+                  }
+                ]
+              }
+            }
+          },
+          "receipt": {
+            "predecessor_id": "000000000b8acb32e2682d41857e8bc61a58048253dc8349437615712de34e8f",
+            "receiver_id": "aurora",
+            "receipt_id": "Fu7UjCpmCj7fK3YYhsZbRubCJmC7kxBL8Z94ADh4exri",
+            "receipt": {
+              "Action": {
+                "signer_id": "000000000b8acb32e2682d41857e8bc61a58048253dc8349437615712de34e8f",
+                "signer_public_key": "ed25519:11117tMZHZEfeF9RN9MiD66mnfp9VE64Vy6kE1mvg6",
+                "gas_price": "625040174",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "submit",
+                      "args": "",
+                      "gas": 300000000000000,
+                      "deposit": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "state_changes": [
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "aurora",
+            "amount": "58186784596655358289779898860",
+            "locked": "0",
+            "code_hash": "ntMVzbC1iSrFVFNBjM2cugnkSncVnLweV2RN4cz8FMk",
+            "storage_usage": 3622507865,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "action_receipt_gas_reward",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "aurora",
+            "amount": "58186784805977317798079898860",
+            "locked": "0",
+            "code_hash": "ntMVzbC1iSrFVFNBjM2cugnkSncVnLweV2RN4cz8FMk",
+            "storage_usage": 3622507865,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "action_receipt_gas_reward",
+            "receipt_hash": "Fu7UjCpmCj7fK3YYhsZbRubCJmC7kxBL8Z94ADh4exri"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "aurora",
+            "amount": "58186784817763103063879898860",
+            "locked": "0",
+            "code_hash": "ntMVzbC1iSrFVFNBjM2cugnkSncVnLweV2RN4cz8FMk",
+            "storage_usage": 3622507865,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "aurora",
+            "key_base64": "BwESIKUHBrNH/GnaBFiJfyisq1CnAA==",
+            "value_base64": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABTc="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "aurora",
+            "key_base64": "BwISIKUHBrNH/GnaBFiJfyisq1CnAA==",
+            "value_base64": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAli4FE3E5oA="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "aurora",
+            "key_base64": "BwJrGVnnAwPjNNfLV3IixilrwTL67Q==",
+            "value_base64": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACxawdu8V7VRI="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "aurora",
+            "key_base64": "BwTzFaXMkTOKOIbTw6Eee0lPMwKz+gEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQ==",
+            "value_base64": "AAAAAAAAAAAAAAAAAAAAAAAAAAAOWf4Eqvf4K2L06Rg="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "aurora",
+            "key_base64": "BwTzFaXMkTOKOIbTw6Eee0lPMwKz+gEAAAATVk22CUyADC+XzkDbLtB2ZnO5yhwa3GFIAHTyVEOV2A==",
+            "value_base64": "MoqyMUhILj/wmABPs1xTK/9BDNoAFkJdHCYNxBflLwA="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "aurora",
+            "key_base64": "BwTzFaXMkTOKOIbTw6Eee0lPMwKz+gEAAAATVk22CUyADC+XzkDbLtB2ZnO5yhwa3GFIAHTyVEOV2Q==",
+            "value_base64": "AEbzyMIBzhI3/z5N4hSmP0AEvAA0jIUov/+Q0OSIPkA="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "aurora",
+            "key_base64": "BwTzFaXMkTOKOIbTw6Eee0lPMwKz+gEAAAATVk22CUyADC+XzkDbLtB2ZnO5yhwa3GFIAHTyVEOV2g==",
+            "value_base64": "PIAbdZYARLHIATmABPTxGsgTlWREkOR8UAwNI7ABK8A="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "aurora",
+            "key_base64": "BwTzFaXMkTOKOIbTw6Eee0lPMwKz+gEAAAATVk22CUyADC+XzkDbLtB2ZnO5yhwa3GFIAHTyVEOV2w==",
+            "value_base64": "QAWjLJguiTP1ZEkMcDABDVCEiAAYAAKcmCOJYBjSHMA="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "aurora",
+            "key_base64": "BwTzFaXMkTOKOIbTw6Eee0lPMwKz+gEAAAATVk22CUyADC+XzkDbLtB2ZnO5yhwa3GFIAHTyVEOV3A==",
+            "value_base64": "IUACVQwviHRhKFLMgujaOgoCUAAzyzNYl0LQRAyzUcA="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "aurora",
+            "key_base64": "BwTzFaXMkTOKOIbTw6Eee0lPMwKz+gEAAAATVk22CUyADC+XzkDbLtB2ZnO5yhwa3GFIAHTyVEOV3Q==",
+            "value_base64": "QglTsADJEMGcCDRAAzRLAAAAAEoA0CAAASXAMbwHJ0A="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "aurora",
+            "key_base64": "BwTzFaXMkTOKOIbTw6Eee0lPMwKz+gEAAAATVk22CUyADC+XzkDbLtB2ZnO5yhwa3GFIAHTyVEOV3g==",
+            "value_base64": "L4ADzQAmAAM/JCrJRHxvJQ8TxIDJD5G4gDbONBBTGoA="
+          }
+        }
+      ]
+    },
+    {
+      "shard_id": 2,
+      "chunk": {
+        "author": "bisontrails.poolv1.near",
+        "header": {
+          "chunk_hash": "ECkfHu5cYU9Q6k19wbQsWkKhLMNE3P7GRiCyPY7XkUEb",
+          "prev_block_hash": "5njXB5DwrUbiPtt39FP4JbQZCF58J4bLijhr6L6vPVY",
+          "outcome_root": "FUHhuQ6eUmDbKKVNry93ZRhfpz2r2w95C632aGMNGS43",
+          "prev_state_root": "FnjbLjoq8ZUaDEYCaoECEExwjnGACr2YW5JiNZvVo7D9",
+          "encoded_merkle_root": "7bMEK4eEPhksaX2VqHuBWhqkeTT7EwGWpvTiQaNxkKAA",
+          "encoded_length": 1168,
+          "height_created": 71771951,
+          "height_included": 71771951,
+          "shard_id": 2,
+          "gas_used": 16852232618883,
+          "gas_limit": 1000000000000000,
+          "validator_reward": 0,
+          "balance_burnt": "1325346501720300000000",
+          "outgoing_receipts_root": "BzEQT7eXmne1a46vMrUT7a55rLTYMAPAvM7dSaBDQizi",
+          "tx_root": "11111111111111111111111111111111",
+          "validator_proposals": [],
+          "signature": "ed25519:FKsk9RTAS3WQJAkFfekHRZ5rwXX2BeR5ApntLP9PxUiAvjUghc79fMCMYk9f4PBXUiqMhkjh2Y9t2LSipV6bWGs"
+        },
+        "transactions": [],
+        "receipts": [
+          {
+            "predecessor_id": "jblkolonka.near",
+            "receiver_id": "app.nearcrowd.near",
+            "receipt_id": "BWWmgTpF2Ywi7daTEz2yLNdteFVmKTSqZZ4wEtL6Yxnt",
+            "receipt": {
+              "Action": {
+                "signer_id": "jblkolonka.near",
+                "signer_public_key": "ed25519:41oa1RErvJrmZYt9938qkmHozhYbA5Y77Dz5nbUnCC6o",
+                "gas_price": "122987387",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "submit_approved_solution",
+                      "args": "eyJ0YXNrX29yZGluYWwiOjEsInNvbHV0aW9uX2hhc2giOlsxNDcsMTk0LDIyNyw4Miw3MSwxNjUsMTkzLDE2NCwyMzYsNzcsOTgsMTI5LDE0Miw1Miw3NiwxOTcsNSw4MSwyMzksMTczLDIyNCwyMSwxNjUsOTYsMjM2LDIwLDM4LDYzLDE4LDU1LDg4LDIxMF19",
+                      "gas": 30000000000000,
+                      "deposit": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "predecessor_id": "contract.main.burrow.near",
+            "receiver_id": "usn",
+            "receipt_id": "Fykyk57QT43awzVZBtnVzRMwbFMTrDMpxeDGyZscE56K",
+            "receipt": {
+              "Action": {
+                "signer_id": "niemtin.near",
+                "signer_public_key": "ed25519:BasU3mpya6AiZtQ7AjNnE923doYN2TBwvbS2mdHFdB6J",
+                "gas_price": "250008035",
+                "output_data_receivers": [
+                  {
+                    "data_id": "5Q2ywKVKCfVy3MYk46MX1WcgMuggYY2pPSetZFd9LbfX",
+                    "receiver_id": "contract.main.burrow.near"
+                  }
+                ],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "ft_transfer",
+                      "args": "eyJyZWNlaXZlcl9pZCI6Im5pZW10aW4ubmVhciIsImFtb3VudCI6IjQ3NDE5NDYzNDg5MTY1NTQ5MyIsIm1lbW8iOm51bGx9",
+                      "gas": 10000000000000,
+                      "deposit": "1"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "predecessor_id": "contract.main.burrow.near",
+            "receiver_id": "contract.main.burrow.near",
+            "receipt_id": "A29wvwQJzH9Xe8qk4jdnz6UgcVtjxrYLfsp5K28khUwd",
+            "receipt": {
+              "Action": {
+                "signer_id": "niemtin.near",
+                "signer_public_key": "ed25519:BasU3mpya6AiZtQ7AjNnE923doYN2TBwvbS2mdHFdB6J",
+                "gas_price": "250008035",
+                "output_data_receivers": [],
+                "input_data_ids": [
+                  "5Q2ywKVKCfVy3MYk46MX1WcgMuggYY2pPSetZFd9LbfX"
+                ],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "after_ft_transfer",
+                      "args": "eyJhY2NvdW50X2lkIjoibmllbXRpbi5uZWFyIiwidG9rZW5faWQiOiJ1c24iLCJhbW91bnQiOiI0NzQxOTQ2MzQ4OTE2NTU0OTMifQ==",
+                      "gas": 20000000000000,
+                      "deposit": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "predecessor_id": "system",
+            "receiver_id": "niemtin.near",
+            "receipt_id": "9Gk3vtYC6AEajEpFPq7nUFFwZ5wuesFEh5xvu52wKmyi",
+            "receipt": {
+              "Action": {
+                "signer_id": "niemtin.near",
+                "signer_public_key": "ed25519:BasU3mpya6AiZtQ7AjNnE923doYN2TBwvbS2mdHFdB6J",
+                "gas_price": "0",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "Transfer": {
+                      "deposit": "27951502198056114518440"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "receipt_execution_outcomes": [],
+      "state_changes": []
+    },
+    {
+      "shard_id": 3,
+      "chunk": {
+        "author": "bisontrails.poolv1.near",
+        "header": {
+          "chunk_hash": "8xN6ET9LRfoMAzrFDLNLfU37NBiHKyjNGmNcmUvUbuoB",
+          "prev_block_hash": "5njXB5DwrUbiPtt39FP4JbQZCF58J4bLijhr6L6vPVY",
+          "outcome_root": "H8CUQH1tvHNB8MNVSTciiuUERJh4LKwuYJ419CGimikM",
+          "prev_state_root": "6atZRtRkxMqj59bkkmWQEFsG7hHBGDqs8QTsc9sMEmk7",
+          "encoded_merkle_root": "6tojYcz8dVAtBmZYiTkiApypig5EEbUehUAvEM7J2Qp9",
+          "encoded_length": 1246,
+          "height_created": 71771951,
+          "height_included": 71771951,
+          "shard_id": 3,
+          "gas_used": 13942077847086,
+          "gas_limit": 1000000000000000,
+          "validator_reward": 0,
+          "balance_burnt": "1261038800934300000000",
+          "outgoing_receipts_root": "9pUzRR7bVDx4BJ9vBXKDZmGCTReZRxLpd5KsMbsCeGis",
+          "tx_root": "11111111111111111111111111111111",
+          "validator_proposals": [],
+          "signature": "ed25519:4LJEHTWEqSBdGBSEk8tvQr6fFxtqZ1i8RoZbt3odNebqWhKEUrhnZjdhhJLLL3caUjAvBwyRPar64uitG1zastuJ"
+        },
+        "transactions": [],
+        "receipts": [
+          {
+            "predecessor_id": "sweat_welcome.near",
+            "receiver_id": "14c09e71856e44e37bd44912018ffd7477ca0900614bbde50d26d2004758b7e9",
+            "receipt_id": "NzgGubgKteKz4PUcSgFdYU6DLqP3p9owkEuNsdstLdY",
+            "receipt": {
+              "Action": {
+                "signer_id": "sweat_welcome.near",
+                "signer_public_key": "ed25519:6XkFcphbiZMAYeD1nk9FiLpA9CWm4Y4ep9vjpm9csiao",
+                "gas_price": "103000000",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "Transfer": {
+                      "deposit": "50000000000000000000000"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "predecessor_id": "worker20211.near",
+            "receiver_id": "app.nearcrowd.near",
+            "receipt_id": "B69bsYkaVH2Nj3pMUMygUMeEkxPAtSVtcbEGVscSD6qD",
+            "receipt": {
+              "Action": {
+                "signer_id": "worker20211.near",
+                "signer_public_key": "ed25519:65Y8X8eX8MAHbh5WrkPDBcxUCEEMrFt4TEV1G5aJqcGF",
+                "gas_price": "122987387",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "claim_assignment",
+                      "args": "eyJ0YXNrX29yZGluYWwiOjEsImJpZCI6IjMwNjM4MDU0ODk5NTUwNzc4MTM1MTIwIn0=",
+                      "gas": 30000000000000,
+                      "deposit": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "predecessor_id": "relay.aurora",
+            "receiver_id": "aurora",
+            "receipt_id": "6TknY3psuiY3UWiMyxQ8xWoU1kszG144LA7BvLYREErS",
+            "receipt": {
+              "Action": {
+                "signer_id": "relay.aurora",
+                "signer_public_key": "ed25519:9DGuSSBpsLausScrigDngbbBiW2iNaNWxMocukYwMeMW",
+                "gas_price": "625040174",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "submit",
+                      "args": "+QGxggU2hAQsHYCEAcnDgJTzFaXMkTOKOIbTw6Eee0lPMwKz+oC5AUTGroP/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD54uM5tFwQQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgMoqyMUhILj/wmABPs1xTK/9BDNoAFkJdHCYNxBflLwAARvPIwgHOEjf/Pk3iFKY/QAS8ADSMhSi//5DQ5Ig+QDyAG3WWAESxyAE5gAT08RrIE5VkRJDkfFAMDSOwASvAQAWjLJguiTP1ZEkMcDABDVCEiAAYAAKcmCOJYBjSHMAhQAJVDC+IdGEoUsyC6No6CgJQADPLM1iXQtBEDLNRwEIJU7AAyRDBnAg0QAM0SwAAAABKANAgAAElwDG8BydAL4ADzQAmAAM/JCrJRHxvJQ8TxIDJD5G4gDbONBBTGoCEnIqCyKDj/pZdRXfZmRe6LsxmiaKh5W6PxXSP5zzWYeR8jkZXCqAR0jhxgp0WrhcaQBLEhtz6YzR0X8GBC8UPsOWkorZ+8w==",
+                      "gas": 300000000000000,
+                      "deposit": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "predecessor_id": "system",
+            "receiver_id": "thebe.near",
+            "receipt_id": "CLrKsMaJKdt46MZBRDKy6pXbh9paiJ23zdKqfF3jCJTf",
+            "receipt": {
+              "Action": {
+                "signer_id": "thebe.near",
+                "signer_public_key": "ed25519:D5uGx8RdcGg7E1L4sjYExfwKwfCmEU4FEFbiM588Jo4A",
+                "gas_price": "0",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "Transfer": {
+                      "deposit": "17961771710252718488848"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "receipt_execution_outcomes": [
+        {
+          "execution_outcome": {
+            "proof": [
+              {
+                "hash": "7eGv8gh4Rvwsw31ZesTQcdTeDQ1NGA9N6R6cVxVcyrsc",
+                "direction": "Right"
+              },
+              {
+                "hash": "ZuSG5pfz7CEGRf5y4n9Vdy79ng3sABwqXfEnuVw7SCA",
+                "direction": "Right"
+              },
+              {
+                "hash": "EjMEB892FT3tcWNTQhX4Xzo2RDJeWTPF9dJ6cWBoK9Ro",
+                "direction": "Right"
+              }
+            ],
+            "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+            "id": "CLrKsMaJKdt46MZBRDKy6pXbh9paiJ23zdKqfF3jCJTf",
+            "outcome": {
+              "logs": [],
+              "receipt_ids": [],
+              "gas_burnt": 223182562500,
+              "tokens_burnt": "0",
+              "executor_id": "thebe.near",
+              "status": {
+                "SuccessValue": ""
+              },
+              "metadata": {
+                "version": 1,
+                "gas_profile": []
+              }
+            }
+          },
+          "receipt": {
+            "predecessor_id": "system",
+            "receiver_id": "thebe.near",
+            "receipt_id": "CLrKsMaJKdt46MZBRDKy6pXbh9paiJ23zdKqfF3jCJTf",
+            "receipt": {
+              "Action": {
+                "signer_id": "thebe.near",
+                "signer_public_key": "ed25519:D5uGx8RdcGg7E1L4sjYExfwKwfCmEU4FEFbiM588Jo4A",
+                "gas_price": "0",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "Transfer": {
+                      "deposit": "17961771710252718488848"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "execution_outcome": {
+            "proof": [
+              {
+                "hash": "C6vtYgKCZbJw8eHf5kJuHmZ8wkUL1SLymV6FkZXuAN6w",
+                "direction": "Left"
+              },
+              {
+                "hash": "ZuSG5pfz7CEGRf5y4n9Vdy79ng3sABwqXfEnuVw7SCA",
+                "direction": "Right"
+              },
+              {
+                "hash": "EjMEB892FT3tcWNTQhX4Xzo2RDJeWTPF9dJ6cWBoK9Ro",
+                "direction": "Right"
+              }
+            ],
+            "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+            "id": "Fykyk57QT43awzVZBtnVzRMwbFMTrDMpxeDGyZscE56K",
+            "outcome": {
+              "logs": [
+                "EVENT_JSON:{\"standard\":\"nep141\",\"version\":\"1.0.0\",\"event\":\"ft_transfer\",\"data\":[{\"old_owner_id\":\"contract.main.burrow.near\",\"new_owner_id\":\"niemtin.near\",\"amount\":\"474194634891655493\"}]}"
+              ],
+              "receipt_ids": [
+                "HwAdakL4kM2CKUvvjtyQo4iW8aEefKkWUzWqQQvcz5YV"
+              ],
+              "gas_burnt": 3877288869683,
+              "tokens_burnt": "387728886968300000000",
+              "executor_id": "usn",
+              "status": {
+                "SuccessValue": ""
+              },
+              "metadata": {
+                "version": 1,
+                "gas_profile": [
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "BASE",
+                    "gas_used": "6354434664"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "CONTRACT_LOADING_BASE",
+                    "gas_used": "35445963"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "CONTRACT_LOADING_BYTES",
+                    "gas_used": "104791038750"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "LOG_BASE",
+                    "gas_used": "3543313050"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "LOG_BYTE",
+                    "gas_used": "2454975126"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_CACHED_TRIE_NODE",
+                    "gas_used": "205200000000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_MEMORY_BASE",
+                    "gas_used": "28708495200"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_MEMORY_BYTE",
+                    "gas_used": "3257742381"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_REGISTER_BASE",
+                    "gas_used": "15102991116"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "READ_REGISTER_BYTE",
+                    "gas_used": "64952358"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_BASE",
+                    "gas_used": "225427383000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_KEY_BYTE",
+                    "gas_used": "2538107706"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_READ_VALUE_BYTE",
+                    "gas_used": "2923333605"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_BASE",
+                    "gas_used": "192590208000"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_EVICTED_BYTE",
+                    "gas_used": "16733116947"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_KEY_BYTE",
+                    "gas_used": "3665109084"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "STORAGE_WRITE_VALUE_BYTE",
+                    "gas_used": "16656955443"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "TOUCHING_TRIE_NODE",
+                    "gas_used": "450854765928"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "UTF8_DECODING_BASE",
+                    "gas_used": "3111779061"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "UTF8_DECODING_BYTE",
+                    "gas_used": "54233969094"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WASM_INSTRUCTION",
+                    "gas_used": "64985382660"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_MEMORY_BASE",
+                    "gas_used": "19626564027"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_MEMORY_BYTE",
+                    "gas_used": "1838546100"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_REGISTER_BASE",
+                    "gas_used": "20058657402"
+                  },
+                  {
+                    "cost_category": "WASM_HOST_COST",
+                    "cost": "WRITE_REGISTER_BYTE",
+                    "gas_used": "4425020496"
+                  }
+                ]
+              }
+            }
+          },
+          "receipt": {
+            "predecessor_id": "contract.main.burrow.near",
+            "receiver_id": "usn",
+            "receipt_id": "Fykyk57QT43awzVZBtnVzRMwbFMTrDMpxeDGyZscE56K",
+            "receipt": {
+              "Action": {
+                "signer_id": "niemtin.near",
+                "signer_public_key": "ed25519:BasU3mpya6AiZtQ7AjNnE923doYN2TBwvbS2mdHFdB6J",
+                "gas_price": "250008035",
+                "output_data_receivers": [
+                  {
+                    "data_id": "5Q2ywKVKCfVy3MYk46MX1WcgMuggYY2pPSetZFd9LbfX",
+                    "receiver_id": "contract.main.burrow.near"
+                  }
+                ],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "FunctionCall": {
+                      "method_name": "ft_transfer",
+                      "args": "eyJyZWNlaXZlcl9pZCI6Im5pZW10aW4ubmVhciIsImFtb3VudCI6IjQ3NDE5NDYzNDg5MTY1NTQ5MyIsIm1lbW8iOm51bGx9",
+                      "gas": 10000000000000,
+                      "deposit": "1"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "execution_outcome": {
+            "proof": [
+              {
+                "hash": "GkaqzNEKrWWwnUX8PaU6dVTGHE8JBvCe44oH1jZetswX",
+                "direction": "Right"
+              },
+              {
+                "hash": "DRArNGz55jmSkFEbZeLQxb3kkTuYAHKHGksm5Mgy2Y2c",
+                "direction": "Left"
+              },
+              {
+                "hash": "EjMEB892FT3tcWNTQhX4Xzo2RDJeWTPF9dJ6cWBoK9Ro",
+                "direction": "Right"
+              }
+            ],
+            "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+            "id": "9Gk3vtYC6AEajEpFPq7nUFFwZ5wuesFEh5xvu52wKmyi",
+            "outcome": {
+              "logs": [],
+              "receipt_ids": [],
+              "gas_burnt": 223182562500,
+              "tokens_burnt": "0",
+              "executor_id": "niemtin.near",
+              "status": {
+                "SuccessValue": ""
+              },
+              "metadata": {
+                "version": 1,
+                "gas_profile": []
+              }
+            }
+          },
+          "receipt": {
+            "predecessor_id": "system",
+            "receiver_id": "niemtin.near",
+            "receipt_id": "9Gk3vtYC6AEajEpFPq7nUFFwZ5wuesFEh5xvu52wKmyi",
+            "receipt": {
+              "Action": {
+                "signer_id": "niemtin.near",
+                "signer_public_key": "ed25519:BasU3mpya6AiZtQ7AjNnE923doYN2TBwvbS2mdHFdB6J",
+                "gas_price": "0",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "Transfer": {
+                      "deposit": "27951502198056114518440"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "execution_outcome": {
+            "proof": [
+              {
+                "hash": "BpaSNVDvxb6u9chSSEMD4q8foJeG9ydbuhhdu1J7GdKB",
+                "direction": "Left"
+              },
+              {
+                "hash": "DRArNGz55jmSkFEbZeLQxb3kkTuYAHKHGksm5Mgy2Y2c",
+                "direction": "Left"
+              },
+              {
+                "hash": "EjMEB892FT3tcWNTQhX4Xzo2RDJeWTPF9dJ6cWBoK9Ro",
+                "direction": "Right"
+              }
+            ],
+            "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+            "id": "CTGFrDBAK4jY6bwfaXNTye9CJNVRCan8TByHrumFXeM4",
+            "outcome": {
+              "logs": [],
+              "receipt_ids": [],
+              "gas_burnt": 223182562500,
+              "tokens_burnt": "0",
+              "executor_id": "relay.aurora",
+              "status": {
+                "SuccessValue": ""
+              },
+              "metadata": {
+                "version": 1,
+                "gas_profile": []
+              }
+            }
+          },
+          "receipt": {
+            "predecessor_id": "system",
+            "receiver_id": "relay.aurora",
+            "receipt_id": "CTGFrDBAK4jY6bwfaXNTye9CJNVRCan8TByHrumFXeM4",
+            "receipt": {
+              "Action": {
+                "signer_id": "relay.aurora",
+                "signer_public_key": "ed25519:7FxXbeHhyxSh41XvrSWonkdXnUjx86saj1eij9ubxVmT",
+                "gas_price": "0",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "Transfer": {
+                      "deposit": "188683768400902935789276"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "execution_outcome": {
+            "proof": [
+              {
+                "hash": "8S5YdVoCB46FFdK8qDNuin5YUG55EJgQZ2WwokUiu5sm",
+                "direction": "Left"
+              }
+            ],
+            "block_hash": "CGcv3L6jKPXVoKruVxXn1RJk2VNchdxST6svnywP1XNN",
+            "id": "EA6pr1FbuyPdiz2VTFAxQb23WLu2Ax8YKu5cH66j7Gxa",
+            "outcome": {
+              "logs": [],
+              "receipt_ids": [],
+              "gas_burnt": 223182562500,
+              "tokens_burnt": "0",
+              "executor_id": "worker5.near",
+              "status": {
+                "SuccessValue": ""
+              },
+              "metadata": {
+                "version": 1,
+                "gas_profile": []
+              }
+            }
+          },
+          "receipt": {
+            "predecessor_id": "system",
+            "receiver_id": "worker5.near",
+            "receipt_id": "EA6pr1FbuyPdiz2VTFAxQb23WLu2Ax8YKu5cH66j7Gxa",
+            "receipt": {
+              "Action": {
+                "signer_id": "worker5.near",
+                "signer_public_key": "ed25519:7uoofBburTbKNPZeiLJavh59tS9NbX5j8BmR2sgM1geD",
+                "gas_price": "0",
+                "output_data_receivers": [],
+                "input_data_ids": [],
+                "actions": [
+                  {
+                    "Transfer": {
+                      "deposit": "3478740903506317854228"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "state_changes": [
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "9Gk3vtYC6AEajEpFPq7nUFFwZ5wuesFEh5xvu52wKmyi"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "niemtin.near",
+            "amount": "576567390268868731697678",
+            "locked": "0",
+            "code_hash": "11111111111111111111111111111111",
+            "storage_usage": 2630,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "CTGFrDBAK4jY6bwfaXNTye9CJNVRCan8TByHrumFXeM4"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "relay.aurora",
+            "amount": "4423209083156510862483259461",
+            "locked": "0",
+            "code_hash": "11111111111111111111111111111111",
+            "storage_usage": 148718,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "CLrKsMaJKdt46MZBRDKy6pXbh9paiJ23zdKqfF3jCJTf"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "thebe.near",
+            "amount": "4011432603799906870558612",
+            "locked": "0",
+            "code_hash": "55E7imniT2uuYrECn17qJAk9fLcwQW4ftNSwmCJL5Di",
+            "storage_usage": 361081,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "Fykyk57QT43awzVZBtnVzRMwbFMTrDMpxeDGyZscE56K"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "usn",
+            "amount": "4848063622012041012048986652769",
+            "locked": "0",
+            "code_hash": "27au14xVQHYPzGK3tJY5XhM6wAWsR4KigTJvYJLg9HYy",
+            "storage_usage": 761090,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "action_receipt_gas_reward",
+            "receipt_hash": "Fykyk57QT43awzVZBtnVzRMwbFMTrDMpxeDGyZscE56K"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "usn",
+            "amount": "4848063622055516480663786652769",
+            "locked": "0",
+            "code_hash": "27au14xVQHYPzGK3tJY5XhM6wAWsR4KigTJvYJLg9HYy",
+            "storage_usage": 761090,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "EA6pr1FbuyPdiz2VTFAxQb23WLu2Ax8YKu5cH66j7Gxa"
+          },
+          "type": "account_update",
+          "change": {
+            "account_id": "worker5.near",
+            "amount": "374551912973371873449416",
+            "locked": "0",
+            "code_hash": "11111111111111111111111111111111",
+            "storage_usage": 9154,
+            "storage_paid_at": 0
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "EA6pr1FbuyPdiz2VTFAxQb23WLu2Ax8YKu5cH66j7Gxa"
+          },
+          "type": "access_key_update",
+          "change": {
+            "account_id": "worker5.near",
+            "public_key": "ed25519:7uoofBburTbKNPZeiLJavh59tS9NbX5j8BmR2sgM1geD",
+            "access_key": {
+              "nonce": 69882695003059,
+              "permission": {
+                "FunctionCall": {
+                  "allowance": "21435459951986000000000",
+                  "receiver_id": "app.nearcrowd.near",
+                  "method_names": []
+                }
+              }
+            }
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "Fykyk57QT43awzVZBtnVzRMwbFMTrDMpxeDGyZscE56K"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "usn",
+            "key_base64": "AQwAAABuaWVtdGluLm5lYXI=",
+            "value_base64": "RfkcD4KtlAYAAAAAAAAAAA=="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "Fykyk57QT43awzVZBtnVzRMwbFMTrDMpxeDGyZscE56K"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "usn",
+            "key_base64": "ARkAAABjb250cmFjdC5tYWluLmJ1cnJvdy5uZWFy",
+            "value_base64": "MvlMAXMl/Gn0kQAAAAAAAA=="
+          }
+        },
+        {
+          "cause": {
+            "type": "receipt_processing",
+            "receipt_hash": "Fykyk57QT43awzVZBtnVzRMwbFMTrDMpxeDGyZscE56K"
+          },
+          "type": "data_update",
+          "change": {
+            "account_id": "usn",
+            "key_base64": "U1RBVEU=",
+            "value_base64": "HgAAAGRlY2VudHJhbGJhbmsuc3B1dG5pay1kYW8ubmVhch4AAABkZWNlbnRyYWxiYW5rLnNwdXRuaWstZGFvLm5lYXICAAAAAGkDAAAAAAAAAAIAAAAAZQEAAAABEkDdstryG6SiBmYAAAAAAH0AAAAAAAAAAQAAAAIBAAAAAwAAAIgTAAAAAAAAAAAAAAAAAABdjxZjCiczcBJMAAAAAAAAH0T2NhOJ8YxHinKMAAAAAAEAAAAEALhk2UUAAAAAoLgwRgMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYR/gNAAAAALhk2UUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuGTZRQAAAACguDBGAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFhH+A0AAAAAuGTZRQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEUgwAAAAAAAAAAAAAAAAAAHAHMggAAAAAAAAAAAAAAAAAAHAG3S+sTAAAAAAAAAAAAAAAAIAGGCO0TAAAAAAAAAAAAAAAAID0piVWdqv0WAgAAAAVpAQAAAAAAAAACAAAABWsBAAAAAAAAAAIAAAAFdg=="
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/engine/src/tests.rs
+++ b/engine/src/tests.rs
@@ -6,6 +6,33 @@ use engine_standalone_storage::sync::TransactionExecutionResult;
 use engine_standalone_storage::Storage;
 use std::collections::HashMap;
 
+/// This test confirms that the engine is able to process `submit` transactions
+/// with empty input (which failed on NEAR) without crashing.
+#[test]
+fn test_empty_submit_input() {
+    let mut test_context =
+        TestContext::load_snapshot("src/res/contract.aurora.block66381606.minimal.json");
+    let block: NEARBlock = {
+        let file = std::fs::File::open("src/res/block_71771951.json").unwrap();
+        serde_json::from_reader(file).unwrap()
+    };
+    let mut data_id_mapping = lru::LruCache::new(1000);
+    let mut outcomes_map = HashMap::new();
+    let chain_id = aurora_engine_types::types::u256_to_arr(&(1313161554.into()));
+
+    crate::sync::consume_near_block(
+        &mut test_context.storage,
+        &block,
+        &mut data_id_mapping,
+        &test_context.engine_account_id,
+        chain_id,
+        Some(&mut outcomes_map),
+    )
+    .unwrap();
+
+    test_context.close()
+}
+
 /// This test processes a real block from mainnet:
 /// https://explorer.mainnet.near.org/blocks/GHxXqSq9RsV4UY6Cz4Hp64bBrqLtSAPXuzRck1KHZHH7
 /// It includes a batched transaction, as well as some normal transactions from the relayer.


### PR DESCRIPTION
This prevents a crash where empty input on submit transactions panics on parsing.