### PR TITLE
Chore: Avoid duplicating dependency versions using workspace inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.16",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,6 @@ tempfile = "3.2.0"
 tokio = "1"
 tokio-stream = "0.1"
 tracing = "0.1.32"
-tracing-subscriber = "0.2.4"
+tracing-subscriber = "0.3"
 triehash-ethereum = { git = "https://github.com/openethereum/openethereum" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,52 @@ members = [
     "refiner-types",
     "refiner-app",
 ]
+
+[workspace.package]
+authors = ["Aurora <hello@aurora.dev>"]
+edition = "2021"
+homepage = "https://github.com/aurora-is-near/aurora-standalone"
+repository = "https://github.com/aurora-is-near/aurora-standalone"
+license = "CC0-1.0"
+
+[workspace.dependencies]
+actix = "0.13.0"
+actix-rt = "2.7.0"
+aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
+aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std", "impl-serde"] }
+aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std", "impl-serde"] }
+aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std"] }
+base64 = "0.13.0"
+borsh = { version = "0.9.3" }
+byteorder = "1.4.3"
+clap = { version = "3.2.7", features = ["derive"] }
+derive_builder = "0.10.2"
+engine-standalone-storage = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false }
+fixed-hash = "0.7.0"
+futures = "0.3.5"
+hex = "0.4.3"
+impl-serde = "0.3.2"
+itertools = "0.10.3"
+keccak-hasher = "0.15.3"
+lazy_static = "1.4.0"
+lru = "0.7.3"
+near-crypto = { git = "https://github.com/near/nearcore", tag = "1.26.1" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "313693c442c3081537b51ebc9044800d590aea6b" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "1.26.1" }
+near-lake-framework = "0.3.0"
+primitive-types = "0.7.2"
+prometheus = "0.13.0"
+rlp = "0.5.1"
+rocksdb = { version = "0.19.0", default-features = false, features = ["snappy", "zstd", "zlib", "bzip2"] }
+serde = { version = "1", features = [ "derive" ] }
+serde_cbor = "0.11.2"
+serde_json = "1"
+sha3 = "0.10.1"
+strum = {version = "0.24.0", features = ["derive"]}
+tempfile = "3.2.0"
+tokio = "1"
+tokio-stream = "0.1"
+tracing = "0.1.32"
+tracing-subscriber = "0.2.4"
+triehash-ethereum = { git = "https://github.com/openethereum/openethereum" }
+

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ aurora-engine-sdk.workspace = true
 aurora-refiner-types = { path = "../refiner-types" }
 base64.workspace = true
 borsh.workspace = true
-engine-standalone-storage.workspace = true
+engine-standalone-storage = { workspace = true, features = ["snappy", "zstd", "zlib", "bzip2"] }
 lru.workspace = true
 tracing.workspace = true
 strum.workspace = true

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
 name = "aurora-standalone-engine"
 version = "0.1.0"
-authors = ["Aurora <hello@aurora.dev>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 description = "A library for interacting with the Aurora Engine deployed locally (standalone), as opposed to on-chain as a NEAR smart contract."
-homepage = "https://github.com/aurora-is-near/aurora-standalone"
-repository = "https://github.com/aurora-is-near/aurora-standalone"
-license = "CC0-1.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [lib]
 crate-type = ["rlib"]
 
 [dependencies]
-aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
-aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std"] }
+aurora-engine.workspace = true
+aurora-engine-transactions.workspace = true
+aurora-engine-types.workspace = true
+aurora-engine-sdk.workspace = true
 aurora-refiner-types = { path = "../refiner-types" }
-base64 = "0.13.0"
-borsh = { version = "0.9.3" }
-engine-standalone-storage = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["snappy", "zstd", "zlib", "bzip2"] }
-lru = "0.7.3"
-tracing = "0.1"
-strum = {version = "0.24.0", features = ["derive"]}
+base64.workspace = true
+borsh.workspace = true
+engine-standalone-storage.workspace = true
+lru.workspace = true
+tracing.workspace = true
+strum.workspace = true
 
 [dev-dependencies]
-hex = "0.4.3"
-serde_json = "1.0.55"
-tempfile = "3.2.0"
+hex.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
 
 [features]

--- a/refiner-app/Cargo.toml
+++ b/refiner-app/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
 name = "aurora-refiner"
 version = "0.1.0"
-authors = ["Aurora <hello@aurora.dev>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 description = "An application for creating data about Aurora transactions by consuming data from a NEAR RPC endpoint."
-homepage = "https://github.com/aurora-is-near/aurora-standalone"
-repository = "https://github.com/aurora-is-near/aurora-standalone"
-license = "CC0-1.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]
-near-indexer = { git = "https://github.com/near/nearcore", rev = "313693c442c3081537b51ebc9044800d590aea6b" }
+near-indexer.workspace = true
 aurora-refiner-lib = { path = "../refiner-lib" }
 aurora-refiner-types = { path = "../refiner-types" }
 
-serde_json = "1.0.83"
-serde = { version = "1", features = [ "derive" ] }
-clap = { version = "3.2.7", features = ["derive"] }
+serde_json.workspace = true
+serde.workspace = true
+clap.workspace = true
 
-tracing = "0.1.13"
-tracing-subscriber = "0.2.4"
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
-futures = "0.3.5"
-itertools = "0.10.3"
-tokio = { version = "1.1", features = ["sync", "time", "macros", "rt-multi-thread"] }
-tokio-stream = { version = "0.1" }
-actix-rt = "2.7.0"
-actix = "0.13.0"
+futures.workspace = true
+itertools.workspace = true
+tokio = { workspace = true, features = ["sync", "time", "macros", "rt-multi-thread"] }
+tokio-stream.workspace = true
+actix-rt.workspace = true
+actix.workspace = true
 
 # NEAR Lake Framework
-near-lake-framework = "0.3.0"
+near-lake-framework.workspace = true

--- a/refiner-lib/Cargo.toml
+++ b/refiner-lib/Cargo.toml
@@ -1,43 +1,43 @@
 [package]
 name = "aurora-refiner-lib"
 version = "0.1.0"
-authors = ["Aurora <hello@aurora.dev>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 description = "A library containing logic for parsing information about Aurora transactions from full NEAR blocks."
-homepage = "https://github.com/aurora-is-near/aurora-standalone"
-repository = "https://github.com/aurora-is-near/aurora-standalone"
-license = "CC0-1.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
-aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std"] }
+aurora-engine.workspace = true
+aurora-engine-transactions.workspace = true
+aurora-engine-types.workspace = true
+aurora-engine-sdk.workspace = true
 aurora-refiner-types = { path = "../refiner-types" }
 aurora-standalone-engine = { path = "../engine" }
-engine-standalone-storage = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false }
+engine-standalone-storage.workspace = true
 
-base64 = "0.13.0"
-borsh = { version = "0.9.3", default-features = false }
-triehash-ethereum = { git = "https://github.com/openethereum/openethereum" }
-primitive-types = "0.7.2"
-byteorder = "1.4.3"
-derive_builder = "0.10.2"
-hex = "0.4.3"
-keccak-hasher = "0.15.3"
-lazy_static = "1.4.0"
-prometheus = "0.13.0"
-rlp = "0.5.1"
-serde = { version = "1", features = [ "derive" ] }
-sha3 = "0.10.1"
-tracing = "0.1.32"
-fixed-hash = "0.7.0"
-impl-serde = "0.3.2"
-tokio = { version = "1.19.2", features = ["sync"] }
-rocksdb = { version = "0.19.0", default-features = false, features = ["snappy", "zstd", "zlib", "bzip2"] }
+base64.workspace = true
+borsh.workspace = true
+triehash-ethereum.workspace = true
+primitive-types.workspace = true
+byteorder.workspace = true
+derive_builder.workspace = true
+hex.workspace = true
+keccak-hasher.workspace = true
+lazy_static.workspace = true
+prometheus.workspace = true
+rlp.workspace = true
+serde.workspace = true
+sha3.workspace = true
+tracing.workspace = true
+fixed-hash.workspace = true
+impl-serde.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+rocksdb.workspace = true
 
 [dev-dependencies]
-serde_cbor = "0.11.2"
-serde_json = "1"
+serde_cbor.workspace = true
+serde_json.workspace = true

--- a/refiner-types/Cargo.toml
+++ b/refiner-types/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
 name = "aurora-refiner-types"
 version = "0.1.0"
-authors = ["Aurora <hello@aurora.dev>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 description = "A library containing definitions of data structures relating to NEAR and Aurora blocks."
-homepage = "https://github.com/aurora-is-near/aurora-standalone"
-repository = "https://github.com/aurora-is-near/aurora-standalone"
-license = "CC0-1.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [lib]
 crate-type = ["rlib"]
 
 [dependencies]
-aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = [ "std", "impl-serde" ] }
-aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = [ "std" ] }
-aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = [ "std", "impl-serde" ]  }
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false,  features = [ "std", "impl-serde" ] }
-derive_builder = "0.10.2"
-fixed-hash = "0.7.0"
-impl-serde = "0.3.2"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "1.26.1" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "1.26.1" }
-serde = { version = "1", features = [ "derive" ] }
-sha3 = "0.10.1"
+aurora-engine.workspace = true
+aurora-engine-sdk.workspace = true
+aurora-engine-transactions.workspace = true
+aurora-engine-types.workspace = true
+derive_builder.workspace = true
+fixed-hash.workspace = true
+impl-serde.workspace = true
+near-crypto.workspace = true
+near-primitives.workspace = true
+serde.workspace = true
+sha3.workspace = true
 
 [dev-dependencies]
 


### PR DESCRIPTION
Uses the recent [cargo feature](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspacedependencies-table) to avoid duplicating the version of our dependencies in multiple Cargo.toml files. This make changing those versions across all crates in the workspace much easier going forward.