### PR TITLE
Chore: Update to aurora-engine version 2.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,8 +420,8 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine"
-version = "2.8.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.8.0#d9b911187b20b931610a02ed8a5670a0462b87b5"
+version = "2.8.1"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.8.1#70063c90bd63b09f71bc707115ae8ac7031bfbc7"
 dependencies = [
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
@@ -443,7 +443,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-precompiles"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.8.0#d9b911187b20b931610a02ed8a5670a0462b87b5"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.8.1#70063c90bd63b09f71bc707115ae8ac7031bfbc7"
 dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-types",
@@ -462,7 +462,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-sdk"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.8.0#d9b911187b20b931610a02ed8a5670a0462b87b5"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.8.1#70063c90bd63b09f71bc707115ae8ac7031bfbc7"
 dependencies = [
  "aurora-engine-types",
  "borsh",
@@ -473,7 +473,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-transactions"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.8.0#d9b911187b20b931610a02ed8a5670a0462b87b5"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.8.1#70063c90bd63b09f71bc707115ae8ac7031bfbc7"
 dependencies = [
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
@@ -486,7 +486,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-types"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.8.0#d9b911187b20b931610a02ed8a5670a0462b87b5"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.8.1#70063c90bd63b09f71bc707115ae8ac7031bfbc7"
 dependencies = [
  "borsh",
  "hex",
@@ -2023,7 +2023,7 @@ dependencies = [
 [[package]]
 name = "engine-standalone-storage"
 version = "0.1.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.8.0#d9b911187b20b931610a02ed8a5670a0462b87b5"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.8.1#70063c90bd63b09f71bc707115ae8ac7031bfbc7"
 dependencies = [
  "aurora-engine",
  "aurora-engine-precompiles",
@@ -2201,7 +2201,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.37.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.1-aurora#12a268120c0f6d4b3c3f35043e7f9482e7a6fd43"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.3-aurora#ad17d1c242356e25692573a5eea4b50ee80f6de3"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -2221,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.37.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.1-aurora#12a268120c0f6d4b3c3f35043e7f9482e7a6fd43"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.3-aurora#ad17d1c242356e25692573a5eea4b50ee80f6de3"
 dependencies = [
  "parity-scale-codec 3.2.1",
  "primitive-types 0.12.1",
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.37.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.1-aurora#12a268120c0f6d4b3c3f35043e7f9482e7a6fd43"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.3-aurora#ad17d1c242356e25692573a5eea4b50ee80f6de3"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2243,7 +2243,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.37.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.1-aurora#12a268120c0f6d4b3c3f35043e7f9482e7a6fd43"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.3-aurora#ad17d1c242356e25692573a5eea4b50ee80f6de3"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ license = "CC0-1.0"
 [workspace.dependencies]
 actix = "0.13.0"
 actix-rt = "2.7.0"
-aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
-aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false, features = ["std"] }
+aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.1", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
+aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.1", default-features = false, features = ["std", "impl-serde"] }
+aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.1", default-features = false, features = ["std", "impl-serde"] }
+aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.1", default-features = false, features = ["std"] }
 base64 = "0.13.0"
 borsh = { version = "0.9.3" }
 byteorder = "1.4.3"
 clap = { version = "4", features = ["derive"] }
 derive_builder = "0.12.0"
-engine-standalone-storage = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.0", default-features = false }
+engine-standalone-storage = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.8.1", default-features = false }
 fixed-hash = "0.8.0"
 futures = "0.3.5"
 hex = "0.4.3"


### PR DESCRIPTION
Engine version 2.8.1 includes a fix to a bug in the tracing functionality which is important for Borealis Engine.