### PR TITLE
Fix(types): Use u64 for gas a nonce types

### DIFF
--- a/refiner-lib/src/refiner_inner.rs
+++ b/refiner-lib/src/refiner_inner.rs
@@ -1,6 +1,6 @@
 use crate::legacy::decode_submit_result;
 use crate::metrics::{record_metric, LATEST_BLOCK_PROCESSED};
-use crate::utils::{as_h256, keccak256, TxMetadata};
+use crate::utils::{self, as_h256, keccak256, TxMetadata};
 use aurora_engine::parameters::{CallArgs, ResultLog, SubmitResult};
 use aurora_engine_sdk::sha256;
 use aurora_engine_sdk::types::near_account_to_evm_address;
@@ -115,9 +115,9 @@ impl Refiner {
             height,
             miner: near_account_to_evm_address(b""),
             timestamp: next_block.block.header.timestamp,
-            gas_limit: U256::max_value(),
-            size: U256::zero(),
-            gas_used: U256::zero(),
+            gas_limit: u64::MAX,
+            size: 0,
+            gas_used: 0,
             transactions_root: self.empty_merkle_tree_root,
             receipts_root: self.empty_merkle_tree_root,
             transactions: vec![],
@@ -189,7 +189,10 @@ impl Refiner {
 
                             let result_hash = sha256(transaction.output.as_slice());
                             tracing::trace!(target: "transactions", "New transaction: {}", transaction.hash);
-                            self.partial_state.total_gas += transaction.gas_used;
+                            self.partial_state.total_gas = self
+                                .partial_state
+                                .total_gas
+                                .saturating_add(transaction.gas_used);
                             self.partial_state
                                 .bloom_filter
                                 .accrue_bloom(&transaction.logs_bloom);
@@ -262,10 +265,10 @@ impl Refiner {
             height: block.header.height,
             miner: near_account_to_evm_address(block.author.as_bytes()),
             timestamp: block.header.timestamp,
-            gas_limit: U256::max_value(),
+            gas_limit: u64::MAX,
             state_root: self.prev_state_root,
-            size: U256::from(self.partial_state.size),
-            gas_used: U256::from(self.partial_state.total_gas),
+            size: self.partial_state.size,
+            gas_used: self.partial_state.total_gas,
             transactions_root,
             receipts_root,
             transactions: self.partial_state.transactions.drain(..).collect(),
@@ -361,12 +364,14 @@ fn build_transaction(
                             .map_err(RefinerError::ParseTransaction)?;
 
                     hash = keccak256(bytes.as_slice()); // https://ethereum.stackexchange.com/a/46579/45323
+                    let tx_nonce = utils::saturating_cast(eth_tx.nonce);
+                    let tx_gas_limit = utils::saturating_cast(eth_tx.gas_limit);
                     tx = tx
                         .hash(hash)
                         .from(eth_tx.address)
                         .to(eth_tx.to)
-                        .nonce(eth_tx.nonce)
-                        .gas_limit(eth_tx.gas_limit)
+                        .nonce(tx_nonce)
+                        .gas_limit(tx_gas_limit)
                         .gas_price(eth_tx.max_fee_per_gas)
                         .max_priority_fee_per_gas(eth_tx.max_priority_fee_per_gas)
                         .max_fee_per_gas(eth_tx.max_fee_per_gas)
@@ -402,8 +407,8 @@ fn build_transaction(
 
                         tx = tx
                             .to(Some(address))
-                            .nonce(U256::zero())
-                            .gas_limit(U256::zero())
+                            .nonce(0)
+                            .gas_limit(0)
                             .max_priority_fee_per_gas(U256::zero())
                             .max_fee_per_gas(U256::zero())
                             .value(value.into())
@@ -454,8 +459,8 @@ fn build_transaction(
                 ))
                 .to(Some(near_account_to_evm_address(b"aurora")))
                 .contract_address(None)
-                .nonce(U256::zero())
-                .gas_limit(U256::max_value())
+                .nonce(0)
+                .gas_limit(0)
                 .gas_used(0)
                 .max_priority_fee_per_gas(U256::zero())
                 .max_fee_per_gas(U256::zero())
@@ -605,8 +610,8 @@ fn fill_tx(
     input: Vec<u8>,
 ) -> AuroraTransactionBuilder {
     tx.to(None)
-        .nonce(U256::zero())
-        .gas_limit(U256::zero())
+        .nonce(0)
+        .gas_limit(0)
         .max_priority_fee_per_gas(U256::zero())
         .max_fee_per_gas(U256::zero())
         .value(Wei::new(U256::zero()))

--- a/refiner-lib/src/utils.rs
+++ b/refiner-lib/src/utils.rs
@@ -5,6 +5,8 @@ use rlp::{DecoderError, Rlp};
 use sha3::Digest;
 use std::convert::TryFrom;
 
+const U64_MAX: U256 = U256([u64::MAX, 0, 0, 0]);
+
 pub fn keccak256(input: &[u8]) -> H256 {
     let mut hasher = sha3::Keccak256::default();
     hasher.update(input);
@@ -15,6 +17,15 @@ pub fn as_h256(data: &[u8]) -> H256 {
     let buffer = &mut [0u8; 32];
     buffer.copy_from_slice(data);
     H256::from(buffer)
+}
+
+/// Cast a U256 value down to u64; if the value is too large then return u64::MAX.
+pub fn saturating_cast(x: U256) -> u64 {
+    if x < U64_MAX {
+        x.as_u64()
+    } else {
+        u64::MAX
+    }
 }
 
 pub struct TxMetadata {

--- a/refiner-types/src/aurora_block.rs
+++ b/refiner-types/src/aurora_block.rs
@@ -35,14 +35,14 @@ pub struct AuroraBlock {
     pub miner: Address,
     /// Timestamp where the block was generated
     pub timestamp: u64,
-    /// Gas limit will be always U256::MAX
-    pub gas_limit: U256,
+    /// Gas limit will be always u64::MAX
+    pub gas_limit: u64,
     /// Sum of the gas used for each tx included in the block.
-    pub gas_used: U256,
+    pub gas_used: u64,
     /// Logs bloom of the block. Aggregation of transactions logs bloom.
     pub logs_bloom: Bloom,
     /// Integer the size of this block in bytes.
-    pub size: U256,
+    pub size: u64,
     /// Transaction root using Ethereum rules
     pub transactions_root: H256,
     /// State root: Uses NEAR state root of the block. While this doesn't match Ethereum rules to compute
@@ -108,11 +108,11 @@ pub struct AuroraTransaction {
     /// Target address of the transaction. It will be None in case it is a deploy transaction.
     pub to: Option<Address>,
     /// Nonce of the transaction to keep the order.
-    pub nonce: U256,
+    pub nonce: u64,
     /// Gas price for the transaction. Related to Aurora Gas not NEAR Gas.
     pub gas_price: U256,
     /// Gas limit of the transaction. In the context of Aurora it should be U256::MAX
-    pub gas_limit: U256,
+    pub gas_limit: u64,
     /// Gas used by the transaction
     pub gas_used: u64,
     pub max_priority_fee_per_gas: U256,


### PR DESCRIPTION
The go-ethereum implementation of the transaction and block types uses u64 for these quantities. We should follow suit for compatibility reasons.