### PR TITLE
Feat(refiner): Track the transaction hash the caused each receipt to be created

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,7 @@ dependencies = [
 name = "aurora-refiner-lib"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "aurora-engine",
  "aurora-engine-sdk",
  "aurora-engine-transactions",
@@ -535,6 +536,7 @@ dependencies = [
  "impl-serde 0.4.0",
  "keccak-hasher 0.15.3",
  "lazy_static",
+ "lru 0.8.1",
  "prometheus",
  "rlp 0.5.2",
  "rocksdb",
@@ -542,6 +544,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sha3",
+ "tempfile",
  "tokio",
  "tracing",
  "triehash-ethereum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ license = "CC0-1.0"
 [workspace.dependencies]
 actix = "0.13.0"
 actix-rt = "2.7.0"
+anyhow = "1"
 aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "2beee0ed08c874f59eebeca94e2740d11d6f7b78", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
 aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "2beee0ed08c874f59eebeca94e2740d11d6f7b78", default-features = false, features = ["std", "impl-serde"] }
 aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "2beee0ed08c874f59eebeca94e2740d11d6f7b78", default-features = false, features = ["std", "impl-serde"] }

--- a/default_config.json
+++ b/default_config.json
@@ -2,6 +2,7 @@
     "refiner": {
         "chain_id": 1313161554,
         "engine_path": "output/engine",
+        "tx_tracker_path": "output/tx_tracker",
         "engine_account_id": "aurora"
     },
     "input_mode": {

--- a/refiner-app/src/config.rs
+++ b/refiner-app/src/config.rs
@@ -14,6 +14,7 @@ pub struct Refiner {
     pub chain_id: u64,
     pub engine_path: String,
     pub engine_account_id: String,
+    pub tx_tracker_path: String,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/refiner-app/src/main.rs
+++ b/refiner-app/src/main.rs
@@ -69,6 +69,7 @@ async fn main() -> Result<(), tokio::io::Error> {
             aurora_refiner_lib::run_refiner::<_, ()>(
                 config.refiner.chain_id,
                 config.refiner.engine_path,
+                config.refiner.tx_tracker_path,
                 config.refiner.engine_account_id.parse().unwrap(),
                 input_stream,
                 output_stream,

--- a/refiner-lib/Cargo.toml
+++ b/refiner-lib/Cargo.toml
@@ -19,6 +19,7 @@ aurora-refiner-types = { path = "../refiner-types" }
 aurora-standalone-engine = { path = "../engine" }
 engine-standalone-storage.workspace = true
 
+anyhow.workspace = true
 base64.workspace = true
 borsh.workspace = true
 triehash-ethereum.workspace = true
@@ -27,6 +28,7 @@ derive_builder.workspace = true
 hex.workspace = true
 keccak-hasher.workspace = true
 lazy_static.workspace = true
+lru.workspace = true
 prometheus.workspace = true
 rlp.workspace = true
 serde.workspace = true
@@ -40,3 +42,4 @@ rocksdb.workspace = true
 [dev-dependencies]
 serde_cbor.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true

--- a/refiner-lib/src/lib.rs
+++ b/refiner-lib/src/lib.rs
@@ -3,6 +3,7 @@ pub mod near_stream;
 mod refiner;
 mod refiner_inner;
 pub mod storage;
+pub mod tx_hash_tracker;
 mod utils;
 pub use refiner::*;
 mod legacy;

--- a/refiner-lib/src/metrics.rs
+++ b/refiner-lib/src/metrics.rs
@@ -163,6 +163,11 @@ lazy_static! {
         "Number of blocks processed"
     )
     .unwrap();
+    pub static ref UNKNOWN_TX_FOR_RECEIPT: IntCounter = register_int_counter!(
+        "refiner_unknown_tx_for_receipt",
+        "Number of receipts where the transaction provenance was not known (should be 0)."
+    )
+    .unwrap();
 
     pub static ref TRANSACTION_TYPE_FACTORY_UPDATE: IntCounter = register_int_counter!(
                 "refiner_tx_type_factory_update",

--- a/refiner-lib/src/near_stream.rs
+++ b/refiner-lib/src/near_stream.rs
@@ -1,5 +1,6 @@
 use crate::metrics::{PROCESSED_BLOCKS, SKIP_BLOCKS};
 use crate::refiner_inner::Refiner;
+use crate::tx_hash_tracker::TxHashTracker;
 use aurora_refiner_types::aurora_block::AuroraBlock;
 use aurora_refiner_types::near_block::NEARBlock;
 use aurora_standalone_engine::EngineContext;
@@ -11,14 +12,22 @@ pub struct NearStream {
     handler: Refiner,
     /// Context used to access engine
     context: EngineContext,
+    /// Helper to track the NEAR transaction hash associated with each NEAR receipt.
+    tx_tracker: TxHashTracker,
 }
 
 impl NearStream {
-    pub fn new(chain_id: u64, last_block_height: Option<u64>, context: EngineContext) -> Self {
+    pub fn new(
+        chain_id: u64,
+        last_block_height: Option<u64>,
+        context: EngineContext,
+        tx_tracker: TxHashTracker,
+    ) -> Self {
         Self {
             last_block_height,
             handler: Refiner::new(chain_id),
             context,
+            tx_tracker,
         }
     }
 
@@ -31,6 +40,11 @@ impl NearStream {
         aurora_standalone_engine::consume_near_block(near_block, &mut self.context, Some(&mut txs))
             .unwrap();
 
+        // Panic if transaction hash tracker cannot consume the block
+        self.tx_tracker
+            .consume_near_block(near_block)
+            .expect("Transaction tracker consume_near_block error");
+
         near_block
             .shards
             .iter()
@@ -39,10 +53,23 @@ impl NearStream {
                 outcome.receipt.receiver_id.as_bytes() == self.context.engine_account_id.as_bytes()
             })
             .for_each(|outcome| {
-                self.handler.on_execution_outcome(near_block, outcome, &txs);
+                let rx_hash = &outcome.receipt.receipt_id;
+                let near_tx_hash = match self.tx_tracker.get_tx_hash(rx_hash) {
+                    Some(tx_hash) => tx_hash,
+                    None => {
+                        tracing::warn!("Transaction provenance unknown for receipt {}", rx_hash);
+                        Default::default()
+                    }
+                };
+                self.handler
+                    .on_execution_outcome(near_block, near_tx_hash, outcome, &txs);
             });
 
-        self.handler.on_block_end(near_block)
+        let aurora_block = self.handler.on_block_end(near_block);
+        self.tx_tracker
+            .on_block_end(near_block.block.header.height)
+            .expect("Transaction tracker on_block_end error");
+        aurora_block
     }
 
     pub fn next_block(&mut self, near_block: &NEARBlock) -> Vec<AuroraBlock> {

--- a/refiner-lib/src/refiner.rs
+++ b/refiner-lib/src/refiner.rs
@@ -1,4 +1,5 @@
 use crate::near_stream::NearStream;
+use crate::tx_hash_tracker;
 use aurora_engine_types::account_id::AccountId;
 use aurora_refiner_types::aurora_block::AuroraBlock;
 use aurora_refiner_types::near_block::NEARBlock;
@@ -21,13 +22,17 @@ impl<B: Debug, M: Debug + Clone> BlockWithMetadata<B, M> {
 pub async fn run_refiner<P: AsRef<Path>, M: Debug + Clone>(
     chain_id: u64,
     engine_storage_path: P,
+    tx_storage_path: P,
     engine_account_id: AccountId,
     mut input: tokio::sync::mpsc::Receiver<BlockWithMetadata<NEARBlock, M>>,
     output: tokio::sync::mpsc::Sender<BlockWithMetadata<AuroraBlock, M>>,
     last_block: Option<u64>,
 ) {
     let ctx = EngineContext::new(engine_storage_path, engine_account_id, chain_id).unwrap();
-    let mut stream = NearStream::new(chain_id, last_block, ctx);
+    let tx_tracker =
+        tx_hash_tracker::TxHashTracker::new(tx_storage_path, last_block.unwrap_or_default())
+            .expect("Failed to start transaction tracker");
+    let mut stream = NearStream::new(chain_id, last_block, ctx, tx_tracker);
 
     while let Some(message) = input.recv().await {
         let BlockWithMetadata { block, metadata } = message;

--- a/refiner-lib/src/refiner_inner.rs
+++ b/refiner-lib/src/refiner_inner.rs
@@ -141,7 +141,7 @@ impl Refiner {
     pub fn on_execution_outcome(
         &mut self,
         block: &NEARBlock,
-        near_tx_hash: CryptoHash,
+        near_tx_hash: Option<CryptoHash>,
         execution_outcome: &ExecutionOutcomeWithReceipt,
         txs: &HashMap<H256, TransactionIncludedOutcome>,
     ) {
@@ -315,7 +315,7 @@ fn build_transaction(
     action_index: usize,
     action: &ActionView,
     outcome: &ExecutionOutcomeWithReceipt,
-    near_tx_hash: CryptoHash,
+    near_tx_hash: Option<CryptoHash>,
     chain_id: u64,
     transaction_index: u32,
     virtual_receipt_id: CryptoHash,

--- a/refiner-lib/src/refiner_inner.rs
+++ b/refiner-lib/src/refiner_inner.rs
@@ -141,6 +141,7 @@ impl Refiner {
     pub fn on_execution_outcome(
         &mut self,
         block: &NEARBlock,
+        near_tx_hash: CryptoHash,
         execution_outcome: &ExecutionOutcomeWithReceipt,
         txs: &HashMap<H256, TransactionIncludedOutcome>,
     ) {
@@ -177,6 +178,7 @@ impl Refiner {
                         index,
                         action,
                         execution_outcome,
+                        near_tx_hash,
                         self.chain_id,
                         self.partial_state.transactions.len() as u32,
                         virtual_receipt_id,
@@ -313,6 +315,7 @@ fn build_transaction(
     action_index: usize,
     action: &ActionView,
     outcome: &ExecutionOutcomeWithReceipt,
+    near_tx_hash: CryptoHash,
     chain_id: u64,
     transaction_index: u32,
     virtual_receipt_id: CryptoHash,
@@ -331,6 +334,7 @@ fn build_transaction(
         .near_metadata(NearTransaction {
             action_index,
             receipt_hash: outcome.receipt.receipt_id,
+            transaction_hash: near_tx_hash,
         });
 
     // Hash used to build transactions merkle tree

--- a/refiner-lib/src/tx_hash_tracker.rs
+++ b/refiner-lib/src/tx_hash_tracker.rs
@@ -1,0 +1,257 @@
+use aurora_refiner_types::{near_block::NEARBlock, near_primitives::hash::CryptoHash};
+use std::path::Path;
+
+/// A helper object for tracking the NEAR transaction hash that caused each NEAR receipt
+/// to be produced (potentially indirectly via a number of other receipts). The main interface
+/// includes the `get_tx_hash` function to query the helper for the transaction hash associated
+/// with a given receipt hash, and two functions to mutate the tracker's state:
+/// `consume_near_block` and `on_block_end`. The purpose of `consume_near_block` is to update
+/// the tracker's state with the new receipts that are created in that block. The purpose of
+/// `on_block_end` is to give the tracker an opportunity to prune away old state that is no
+/// longer needed since the block at the given height is finished processing.
+pub struct TxHashTracker {
+    inner: TxHashTrackerImpl,
+}
+
+impl TxHashTracker {
+    pub fn new<P: AsRef<Path>>(storage_path: P, start_height: u64) -> anyhow::Result<Self> {
+        let inner = TxHashTrackerImpl::new(storage_path, start_height)?;
+        Ok(Self { inner })
+    }
+
+    pub fn get_tx_hash(&mut self, rx_hash: &CryptoHash) -> Option<CryptoHash> {
+        self.inner.get_tx_hash(rx_hash)
+    }
+
+    pub fn consume_near_block(&mut self, near_block: &NEARBlock) -> anyhow::Result<()> {
+        let block_height = near_block.block.header.height;
+
+        let tx_iter = near_block
+            .shards
+            .iter()
+            .filter_map(|s| s.chunk.as_ref())
+            .flat_map(|c| c.transactions.iter());
+
+        // Track receipts created from transactions
+        for tx in tx_iter {
+            let tx_hash = tx.transaction.hash;
+            for rx_hash in tx.outcome.execution_outcome.outcome.receipt_ids.iter() {
+                self.inner.record_rx(*rx_hash, tx_hash, block_height)?;
+            }
+        }
+
+        let rx_iter = near_block
+            .shards
+            .iter()
+            .flat_map(|s| s.receipt_execution_outcomes.iter());
+
+        // Track receipts created from other receipts
+        for rx in rx_iter {
+            let rx_hash = &rx.receipt.receipt_id;
+            let tx_hash = match self.get_tx_hash(rx_hash) {
+                Some(tx_hash) => tx_hash,
+                None => {
+                    tracing::warn!("Transaction provenance unknown for receipt {}", rx_hash);
+                    continue;
+                }
+            };
+            for rx_hash in rx.execution_outcome.outcome.receipt_ids.iter() {
+                self.inner.record_rx(*rx_hash, tx_hash, block_height)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn on_block_end(&mut self, block_height: u64) -> anyhow::Result<()> {
+        self.inner.prune_state(block_height)
+    }
+}
+
+/// This struct is intentionally private and contains the core state-management logic of the
+/// transaction hash tracker. The reason to separate this from the public struct above is to
+/// allow the implementation details of the state to change without impacting the public
+/// interface.
+/// The cache in the implementation allows for fast (in-memory) look-ups, while the rocksdb
+/// storage layer enables crash recovery without data loss.
+struct TxHashTrackerImpl {
+    cache: lru::LruCache<CryptoHash, CryptoHash>,
+    persistent_storage: rocksdb::DB,
+}
+
+/// At 64 bytes per entry (two 32-byte hashes), this caps the memory footprint of the tracker
+/// at around 70 MB, which seems reasonable. One million entries should also be sufficient to
+/// ensure the cache never miss under normal conditions; it would require a receipt to be
+/// created and then not included in a block before one million other receipts we created first.
+/// With the maximum daily number of transactions ever observed on NEAR at just over two million,
+/// this means the receipt would not have been included in a block for at least 8 hours; an
+/// extremely unlikely event (typically receipts are included in the next block after they are
+/// created, less than 2 seconds later).
+const CACHE_SIZE: usize = 1_000_000;
+
+/// This is the number of block heights into the past the DB will remember receipt hashes.
+/// With a 1 second block time, this corresponds to 5 days of transactions, or 10 "epochs"
+/// since NEAR epochs tend to be around 12 hours. Keeping data for 5 epochs is the standard for
+/// non-archival nearcore nodes, so 10 epochs should be more than enough for us. At NEAR's peak of
+/// two million transactions per day, and assuming each transaction has 5 receipts on average
+/// (likely an overestimate), then this will mean fifty million entries in the DB at most.
+/// With 72 bytes per entry (two 32-byte hashes plus one 8-byte height), this will cap the
+/// storage used by this DB at under 4 GB.
+const PERSISTENT_HISTORY_SIZE: u64 = 432_000;
+
+impl TxHashTrackerImpl {
+    fn new<P: AsRef<Path>>(storage_path: P, start_height: u64) -> anyhow::Result<Self> {
+        let mut cache = lru::LruCache::new(CACHE_SIZE.try_into()?);
+        let persistent_storage = rocksdb::DB::open_default(storage_path)?;
+
+        // Read out enough data from the DB to fill the cache
+        let opts = {
+            let mut tmp = rocksdb::ReadOptions::default();
+            let db_key = [start_height.to_be_bytes().as_slice(), &[0xff_u8; 32]].concat();
+            tmp.set_iterate_upper_bound(db_key);
+            tmp
+        };
+        let iter = persistent_storage
+            .iterator_opt(rocksdb::IteratorMode::End, opts)
+            .take(CACHE_SIZE);
+        let mut cache_data = iter.collect::<Vec<_>>();
+        // Consume the data from the DB in reverse order to get right LRU structure
+        cache_data.reverse();
+        for entry in cache_data {
+            let (k, v) = entry?;
+            if k.len() < 8 {
+                return Err(anyhow::anyhow!(
+                    "Invalid transaction tracker DB key: {}",
+                    hex::encode(k)
+                ));
+            }
+            cache.put(slice_to_crypto_hash(&k[8..])?, slice_to_crypto_hash(&v)?);
+        }
+
+        Ok(Self {
+            cache,
+            persistent_storage,
+        })
+    }
+
+    /// Uses the LRU cache to get the transaction hash associated with the given receipt hash.
+    ///
+    /// We intentionally do not fall back on the rocksdb storage layer in the event of a cache
+    /// miss. This is because the rocksdb storage layer is optimized for fast pruning by
+    /// prepending each receipt hash with the block height where it was created (this means the
+    /// keys are chronologically ordered and thus pruning old keys acts on a contiguous section
+    /// of the DB). However, this optimization means we cannot look up a transaction hash from
+    /// a receipt hash alone, we need the block height the receipt was created at as well, but
+    /// that information is not easily available. Note that fast pruning is required to ensure
+    /// the size of the state needed to run the refiner stays bounded.
+    ///
+    /// Therefore, the cache must be large enough such that misses never happen under normal
+    /// conditions and the cache must be populated eagerly from the rocksdb storage layer
+    /// on start-up.
+    fn get_tx_hash(&mut self, rx_hash: &CryptoHash) -> Option<CryptoHash> {
+        self.cache.get(rx_hash).copied()
+    }
+
+    fn record_rx(
+        &mut self,
+        rx_hash: CryptoHash,
+        tx_hash: CryptoHash,
+        block_height: u64,
+    ) -> anyhow::Result<()> {
+        self.cache.put(rx_hash, tx_hash);
+
+        let db_key = [&block_height.to_be_bytes(), rx_hash.as_ref()].concat();
+        self.persistent_storage.put(db_key, tx_hash)?;
+        Ok(())
+    }
+
+    fn prune_state(&mut self, completed_block_height: u64) -> anyhow::Result<()> {
+        let prune_height = completed_block_height.saturating_sub(PERSISTENT_HISTORY_SIZE);
+
+        let start_key = vec![0u8; 40];
+        let end_key = [prune_height.to_be_bytes().as_slice(), &[0xff_u8; 32]].concat();
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.delete_range(start_key, end_key);
+        self.persistent_storage.write(batch)?;
+
+        Ok(())
+    }
+}
+
+fn slice_to_crypto_hash(slice: &[u8]) -> anyhow::Result<CryptoHash> {
+    slice
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("Invalid hash: {}", hex::encode(slice)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aurora_refiner_types::near_primitives::serialize::BaseDecode;
+
+    #[test]
+    fn test_transaction_hash_tracker() {
+        let db_dir = tempfile::tempdir().unwrap();
+        let mut tracker = TxHashTracker::new(db_dir.path(), 0).unwrap();
+
+        let block_1 = read_block("blocks/block-34834053.json");
+        let block_2 = read_block("blocks/block-51188689.json");
+        let block_3 = read_block("blocks/block-51188690.json");
+
+        tracker.consume_near_block(&block_1).unwrap();
+
+        // Receipt <-> Transaction mapping should be present after consuming a block
+        let rx_hash_1 =
+            CryptoHash::from_base("EkdeeCvozyK5zXZSd3tk2VpakH4kiGfLHCBzfXZVAVvd").unwrap();
+        let expected_tx_hash_1 =
+            CryptoHash::from_base("uQ6hiGNnVW371JKwnLLQM4iMdBNE7xJqVjPGecbmL4D").unwrap();
+        assert_eq!(tracker.get_tx_hash(&rx_hash_1).unwrap(), expected_tx_hash_1,);
+
+        tracker.on_block_end(34834053).unwrap();
+
+        // Mapping should still be present on restart
+        drop(tracker);
+        let mut tracker = TxHashTracker::new(db_dir.path(), 34834053).unwrap();
+        assert_eq!(tracker.get_tx_hash(&rx_hash_1).unwrap(), expected_tx_hash_1,);
+
+        // Try consuming another block
+        tracker.consume_near_block(&block_2).unwrap();
+
+        let rx_hash_2 =
+            CryptoHash::from_base("9qNqNxE6LenxsFMFmzf9RdQwH6MqhU7Hfqnq7GoibYK8").unwrap();
+        let expected_tx_hash_2 =
+            CryptoHash::from_base("DEtAE5d6M8NtBMsCaZVCzjg8C2a5wqduhwVkioseUhT4").unwrap();
+        assert_eq!(tracker.get_tx_hash(&rx_hash_2).unwrap(), expected_tx_hash_2,);
+
+        tracker.on_block_end(51188689).unwrap();
+
+        // After restart the first block should have been pruned since it is a much lower height
+        drop(tracker);
+        let mut tracker = TxHashTracker::new(db_dir.path(), 51188689).unwrap();
+        assert_eq!(tracker.get_tx_hash(&rx_hash_1), None,);
+        // But the just consumed block is still present
+        assert_eq!(tracker.get_tx_hash(&rx_hash_2).unwrap(), expected_tx_hash_2,);
+
+        // Consume the next block
+        tracker.consume_near_block(&block_3).unwrap();
+
+        // This receipt comes from receipt `rx_hash_2`, which in turn came from transaction `expected_tx_hash_2`.
+        // Therefore, we expect this receipt also should be associated with `expected_tx_hash_2`.
+        let rx_hash_3 =
+            CryptoHash::from_base("3d43nGKmmbXbCCtt12NAAPLfEoaRo3j31CEKaiQCK3Bt").unwrap();
+        assert_eq!(tracker.get_tx_hash(&rx_hash_3).unwrap(), expected_tx_hash_2,);
+
+        tracker.on_block_end(51188690).unwrap();
+
+        // And both receipts are still present after restart
+        drop(tracker);
+        let mut tracker = TxHashTracker::new(db_dir.path(), 51188690).unwrap();
+        assert_eq!(tracker.get_tx_hash(&rx_hash_2).unwrap(), expected_tx_hash_2,);
+        assert_eq!(tracker.get_tx_hash(&rx_hash_3).unwrap(), expected_tx_hash_2,);
+    }
+
+    fn read_block(path: &str) -> NEARBlock {
+        let data = std::fs::read_to_string(path).unwrap();
+        serde_json::from_str(&data).unwrap()
+    }
+}

--- a/refiner-lib/src/tx_hash_tracker.rs
+++ b/refiner-lib/src/tx_hash_tracker.rs
@@ -133,10 +133,15 @@ impl TxHashTrackerImpl {
             cache.put(slice_to_crypto_hash(&k[8..])?, slice_to_crypto_hash(&v)?);
         }
 
-        Ok(Self {
+        let mut result = Self {
             cache,
             persistent_storage,
-        })
+        };
+
+        // Prune state on start in case a crash occurred before we had a chance to prune.
+        result.prune_state(start_height.saturating_sub(1))?;
+
+        Ok(result)
     }
 
     /// Uses the LRU cache to get the transaction hash associated with the given receipt hash.

--- a/refiner-lib/src/tx_hash_tracker.rs
+++ b/refiner-lib/src/tx_hash_tracker.rs
@@ -233,14 +233,14 @@ mod tests {
             CryptoHash::from_base("EkdeeCvozyK5zXZSd3tk2VpakH4kiGfLHCBzfXZVAVvd").unwrap();
         let expected_tx_hash_1 =
             CryptoHash::from_base("uQ6hiGNnVW371JKwnLLQM4iMdBNE7xJqVjPGecbmL4D").unwrap();
-        assert_eq!(tracker.get_tx_hash(&rx_hash_1).unwrap(), expected_tx_hash_1,);
+        assert_eq!(tracker.get_tx_hash(&rx_hash_1).unwrap(), expected_tx_hash_1);
 
         tracker.on_block_end(34834053).unwrap();
 
         // Mapping should still be present on restart
         drop(tracker);
         let mut tracker = TxHashTracker::new(db_dir.path(), 34834053).unwrap();
-        assert_eq!(tracker.get_tx_hash(&rx_hash_1).unwrap(), expected_tx_hash_1,);
+        assert_eq!(tracker.get_tx_hash(&rx_hash_1).unwrap(), expected_tx_hash_1);
 
         // Try consuming another block
         tracker.consume_near_block(&block_2).unwrap();
@@ -249,7 +249,7 @@ mod tests {
             CryptoHash::from_base("9qNqNxE6LenxsFMFmzf9RdQwH6MqhU7Hfqnq7GoibYK8").unwrap();
         let expected_tx_hash_2 =
             CryptoHash::from_base("DEtAE5d6M8NtBMsCaZVCzjg8C2a5wqduhwVkioseUhT4").unwrap();
-        assert_eq!(tracker.get_tx_hash(&rx_hash_2).unwrap(), expected_tx_hash_2,);
+        assert_eq!(tracker.get_tx_hash(&rx_hash_2).unwrap(), expected_tx_hash_2);
 
         tracker.on_block_end(51188689).unwrap();
 
@@ -258,7 +258,7 @@ mod tests {
         let mut tracker = TxHashTracker::new(db_dir.path(), 51188689).unwrap();
         assert_eq!(tracker.get_tx_hash(&rx_hash_1), None,);
         // But the just consumed block is still present
-        assert_eq!(tracker.get_tx_hash(&rx_hash_2).unwrap(), expected_tx_hash_2,);
+        assert_eq!(tracker.get_tx_hash(&rx_hash_2).unwrap(), expected_tx_hash_2);
 
         // Consume the next block
         tracker.consume_near_block(&block_3).unwrap();
@@ -267,15 +267,15 @@ mod tests {
         // Therefore, we expect this receipt also should be associated with `expected_tx_hash_2`.
         let rx_hash_3 =
             CryptoHash::from_base("3d43nGKmmbXbCCtt12NAAPLfEoaRo3j31CEKaiQCK3Bt").unwrap();
-        assert_eq!(tracker.get_tx_hash(&rx_hash_3).unwrap(), expected_tx_hash_2,);
+        assert_eq!(tracker.get_tx_hash(&rx_hash_3).unwrap(), expected_tx_hash_2);
 
         tracker.on_block_end(51188690).unwrap();
 
         // And both receipts are still present after restart
         drop(tracker);
         let mut tracker = TxHashTracker::new(db_dir.path(), 51188690).unwrap();
-        assert_eq!(tracker.get_tx_hash(&rx_hash_2).unwrap(), expected_tx_hash_2,);
-        assert_eq!(tracker.get_tx_hash(&rx_hash_3).unwrap(), expected_tx_hash_2,);
+        assert_eq!(tracker.get_tx_hash(&rx_hash_2).unwrap(), expected_tx_hash_2);
+        assert_eq!(tracker.get_tx_hash(&rx_hash_3).unwrap(), expected_tx_hash_2);
     }
 
     fn read_block(path: &str) -> NEARBlock {

--- a/refiner-types/src/aurora_block.rs
+++ b/refiner-types/src/aurora_block.rs
@@ -151,4 +151,7 @@ pub struct NearTransaction {
     pub action_index: usize,
     /// Receipt hash on NEAR
     pub receipt_hash: CryptoHash,
+    /// Transaction hash on NEAR that caused the receipt to be produced
+    /// (potentially indirectly via a number of other receipts).
+    pub transaction_hash: CryptoHash,
 }

--- a/refiner-types/src/aurora_block.rs
+++ b/refiner-types/src/aurora_block.rs
@@ -153,5 +153,8 @@ pub struct NearTransaction {
     pub receipt_hash: CryptoHash,
     /// Transaction hash on NEAR that caused the receipt to be produced
     /// (potentially indirectly via a number of other receipts).
-    pub transaction_hash: CryptoHash,
+    /// Field is optional for backwards compatibility, but is
+    /// expected to be set for call newly produced data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transaction_hash: Option<CryptoHash>,
 }

--- a/refiner-types/src/lib.rs
+++ b/refiner-types/src/lib.rs
@@ -4,5 +4,5 @@ pub mod near_block;
 pub mod utils;
 
 pub mod near_primitives {
-    pub use ::near_primitives::{errors, hash, types, views};
+    pub use ::near_primitives::{errors, hash, serialize, types, views};
 }


### PR DESCRIPTION
The bridge needs to know the NEAR transaction hash for each Aurora transaction; the NEAR receipt hash is not good enough for their system. This PR introduces a new stateful component to the Refiner which keeps track of the transaction hash for each receipt. This is needed because there is no way to correlate receipt hashes with transaction hashes using the information available from a single block, therefore we must build up this relationship as we consume blocks.

This has a few impacts to users of the Refiner and its output:

1. There is a new config field to set the directory where the receipt/transaction mapping data will be stored on-disk (we store it on disk so that it is still present after restart).
2. There is now a `transaction_hash` field that is part of the `near_metadata` of the `AuroraTransaction` type.