### PR TITLE
Fix(refiner): Atomically update last block file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "near-lake-framework",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/refiner-app/Cargo.toml
+++ b/refiner-app/Cargo.toml
@@ -30,3 +30,6 @@ actix.workspace = true
 
 # NEAR Lake Framework
 near-lake-framework.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/refiner-app/src/store.rs
+++ b/refiner-app/src/store.rs
@@ -88,7 +88,7 @@ pub async fn load_last_block_height<P: AsRef<std::path::Path>>(storage_path: P) 
         let mut file = tokio::fs::File::open(&store_file).await.unwrap();
         let mut buffer = String::new();
         file.read_to_string(&mut buffer).await.unwrap();
-        serde_json::from_str(&buffer).unwrap()
+        Some(buffer.parse().unwrap())
     } else {
         None
     }
@@ -107,7 +107,7 @@ async fn save_last_block_height<P: AsRef<std::path::Path>>(storage_path: P, bloc
 
     {
         let mut writer = tokio::io::BufWriter::new(temp_file);
-        let data = serde_json::to_string(&block_height).unwrap();
+        let data = block_height.to_string();
         writer.write_all(data.as_bytes()).await.unwrap();
         writer.flush().await.unwrap();
     }
@@ -116,4 +116,19 @@ async fn save_last_block_height<P: AsRef<std::path::Path>>(storage_path: P, bloc
     tokio::fs::rename(temp_path, file_path).await.unwrap();
 
     tracing::trace!("Last block height {} saved.", block_height);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{load_last_block_height, save_last_block_height};
+
+    #[tokio::test]
+    async fn test_save_last_block_height() {
+        const HEIGHT: u64 = 11111;
+        let tmp_dir = tempfile::tempdir().unwrap();
+        save_last_block_height(tmp_dir.path(), HEIGHT).await;
+        let block_height = load_last_block_height(tmp_dir.path()).await;
+
+        assert_eq!(block_height, Some(HEIGHT))
+    }
 }


### PR DESCRIPTION
Fixes #33 

This PR changes the logic for saving the last processed block height to a file so that it writes to a new file and then moves onto the main file. This ensures the main file is atomically updated (there is never a state where the file is cleared, but not yet written to).