### PR TITLE
Fix: configuring the transaction tracker path is optional

### DIFF
--- a/refiner-app/src/config.rs
+++ b/refiner-app/src/config.rs
@@ -14,7 +14,8 @@ pub struct Refiner {
     pub chain_id: u64,
     pub engine_path: String,
     pub engine_account_id: String,
-    pub tx_tracker_path: String,
+    #[serde(default)]
+    pub tx_tracker_path: Option<String>,
 }
 
 #[derive(Deserialize, Clone, Debug)]


### PR DESCRIPTION
Adding non-optional field to the config is a breaking change to partners (we cannot update their configs remotely). In this PR the new field for the transaction tracker is made optional, with the default value being a sub-directory of the engine storage.