### PR TITLE
Chore: Update Cargo.toml to current release version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "aurora-engine",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurora-standalone-engine"
-version = "0.19.0"
+version = "0.19.2"
 authors.workspace = true
 edition.workspace = true
 description = "A library for interacting with the Aurora Engine deployed locally (standalone), as opposed to on-chain as a NEAR smart contract."

--- a/refiner-app/Cargo.toml
+++ b/refiner-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurora-refiner"
-version = "0.19.0"
+version = "0.19.2"
 authors.workspace = true
 edition.workspace = true
 description = "An application for creating data about Aurora transactions by consuming data from a NEAR RPC endpoint."

--- a/refiner-lib/Cargo.toml
+++ b/refiner-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurora-refiner-lib"
-version = "0.19.0"
+version = "0.19.2"
 authors.workspace = true
 edition.workspace = true
 description = "A library containing logic for parsing information about Aurora transactions from full NEAR blocks."

--- a/refiner-types/Cargo.toml
+++ b/refiner-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurora-refiner-types"
-version = "0.19.0"
+version = "0.19.2"
 authors.workspace = true
 edition.workspace = true
 description = "A library containing definitions of data structures relating to NEAR and Aurora blocks."


### PR DESCRIPTION
Updates to 0.19.2 (0.19.1 is already released and tagged, so we'll skip that one in Cargo.toml since we're about to make the 0.19.2 release anyway).