### PR TITLE
Feat: use generic modexp impl in borealis engine library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,15 +508,15 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine"
-version = "2.9.1"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.9.1#733b1a2562fc4416f7d05d76d939ada144a56456"
+version = "2.9.0"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?rev=ddbde784cece70de7919ef0addba3f9e59af2f23#ddbde784cece70de7919ef0addba3f9e59af2f23"
 dependencies = [
+ "aurora-engine-modexp",
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
  "aurora-engine-transactions",
  "aurora-engine-types",
  "bitflags",
- "borsh 0.10.3",
  "byte-slice-cast 1.2.2",
  "ethabi",
  "evm",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-modexp"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.9.1#733b1a2562fc4416f7d05d76d939ada144a56456"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?rev=ddbde784cece70de7919ef0addba3f9e59af2f23#ddbde784cece70de7919ef0addba3f9e59af2f23"
 dependencies = [
  "hex",
  "num",
@@ -539,12 +539,11 @@ dependencies = [
 [[package]]
 name = "aurora-engine-precompiles"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.9.1#733b1a2562fc4416f7d05d76d939ada144a56456"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?rev=ddbde784cece70de7919ef0addba3f9e59af2f23#ddbde784cece70de7919ef0addba3f9e59af2f23"
 dependencies = [
  "aurora-engine-modexp",
  "aurora-engine-sdk",
  "aurora-engine-types",
- "borsh 0.10.3",
  "ethabi",
  "evm",
  "hex",
@@ -559,11 +558,10 @@ dependencies = [
 [[package]]
 name = "aurora-engine-sdk"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.9.1#733b1a2562fc4416f7d05d76d939ada144a56456"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?rev=ddbde784cece70de7919ef0addba3f9e59af2f23#ddbde784cece70de7919ef0addba3f9e59af2f23"
 dependencies = [
  "aurora-engine-types",
  "base64 0.21.1",
- "borsh 0.10.3",
  "sha2 0.10.6",
  "sha3",
 ]
@@ -571,7 +569,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-transactions"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.9.1#733b1a2562fc4416f7d05d76d939ada144a56456"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?rev=ddbde784cece70de7919ef0addba3f9e59af2f23#ddbde784cece70de7919ef0addba3f9e59af2f23"
 dependencies = [
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
@@ -584,7 +582,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-types"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.9.1#733b1a2562fc4416f7d05d76d939ada144a56456"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?rev=ddbde784cece70de7919ef0addba3f9e59af2f23#ddbde784cece70de7919ef0addba3f9e59af2f23"
 dependencies = [
  "borsh 0.10.3",
  "hex",
@@ -621,6 +619,7 @@ version = "0.20.0"
 dependencies = [
  "anyhow",
  "aurora-engine",
+ "aurora-engine-modexp",
  "aurora-engine-sdk",
  "aurora-engine-transactions",
  "aurora-engine-types",
@@ -672,6 +671,7 @@ version = "0.20.0"
 dependencies = [
  "anyhow",
  "aurora-engine",
+ "aurora-engine-modexp",
  "aurora-engine-sdk",
  "aurora-engine-transactions",
  "aurora-engine-types",
@@ -2320,14 +2320,14 @@ dependencies = [
 [[package]]
 name = "engine-standalone-storage"
 version = "0.1.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.9.1#733b1a2562fc4416f7d05d76d939ada144a56456"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?rev=ddbde784cece70de7919ef0addba3f9e59af2f23#ddbde784cece70de7919ef0addba3f9e59af2f23"
 dependencies = [
  "aurora-engine",
+ "aurora-engine-modexp",
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
  "aurora-engine-transactions",
  "aurora-engine-types",
- "borsh 0.10.3",
  "evm-core",
  "hex",
  "postgres",
@@ -2339,7 +2339,7 @@ dependencies = [
 [[package]]
 name = "engine-standalone-tracing"
 version = "0.1.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.9.1#733b1a2562fc4416f7d05d76d939ada144a56456"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?rev=ddbde784cece70de7919ef0addba3f9e59af2f23#ddbde784cece70de7919ef0addba3f9e59af2f23"
 dependencies = [
  "aurora-engine-types",
  "evm",
@@ -2521,8 +2521,8 @@ dependencies = [
 
 [[package]]
 name = "evm"
-version = "0.37.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.4-aurora#a7a0fb429d5fd479aecaa51687cad1f818772051"
+version = "0.39.0"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#fcc538cc1f7f91156ef66564a8ac032a82bd4b9e"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -2541,8 +2541,8 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.37.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.4-aurora#a7a0fb429d5fd479aecaa51687cad1f818772051"
+version = "0.39.0"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#fcc538cc1f7f91156ef66564a8ac032a82bd4b9e"
 dependencies = [
  "parity-scale-codec 3.5.0",
  "primitive-types 0.12.1",
@@ -2552,8 +2552,8 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.37.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.4-aurora#a7a0fb429d5fd479aecaa51687cad1f818772051"
+version = "0.39.0"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#fcc538cc1f7f91156ef66564a8ac032a82bd4b9e"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2563,8 +2563,8 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.37.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.4-aurora#a7a0fb429d5fd479aecaa51687cad1f818772051"
+version = "0.39.0"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#fcc538cc1f7f91156ef66564a8ac032a82bd4b9e"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,18 @@ license = "CC0-1.0"
 actix = "0.13.0"
 actix-rt = "2.7.0"
 anyhow = "1"
-aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.9.1", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
-aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.9.1", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.9.1", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.9.1", default-features = false, features = ["std"] }
+aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "ddbde784cece70de7919ef0addba3f9e59af2f23", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
+aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "ddbde784cece70de7919ef0addba3f9e59af2f23", default-features = false, features = ["std", "impl-serde"] }
+aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "ddbde784cece70de7919ef0addba3f9e59af2f23", default-features = false, features = ["std", "impl-serde"] }
+aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "ddbde784cece70de7919ef0addba3f9e59af2f23", default-features = false, features = ["std"] }
+aurora-engine-modexp = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "ddbde784cece70de7919ef0addba3f9e59af2f23", default-features = false, features = ["std"] }
 base64 = "0.13.0"
 borsh = "0.10"
 byteorder = "1.4.3"
 clap = { version = "4", features = ["derive"] }
 derive_builder = "0.12.0"
-engine-standalone-storage = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.9.1", default-features = false }
-engine-standalone-tracing = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.9.1", default-features = false, features = ["impl-serde"] }
+engine-standalone-storage = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "ddbde784cece70de7919ef0addba3f9e59af2f23", default-features = false }
+engine-standalone-tracing = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "ddbde784cece70de7919ef0addba3f9e59af2f23", default-features = false, features = ["impl-serde"] }
 fixed-hash = "0.8.0"
 futures = "0.3.5"
 hex = "0.4.3"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["rlib"]
 [dependencies]
 anyhow.workspace = true
 aurora-engine.workspace = true
+aurora-engine-modexp.workspace = true
 aurora-engine-transactions.workspace = true
 aurora-engine-types.workspace = true
 aurora-engine-sdk.workspace = true

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,3 +1,4 @@
+use aurora_engine_modexp::ModExpAlgorithm;
 use aurora_engine_types::{account_id::AccountId, H256};
 use aurora_refiner_types::{near_block::NEARBlock, near_primitives::hash::CryptoHash};
 use engine_standalone_storage::{error, sync::TransactionIncludedOutcome, Storage};
@@ -35,12 +36,12 @@ impl EngineContext {
     }
 }
 
-pub fn consume_near_block(
+pub fn consume_near_block<M: ModExpAlgorithm>(
     block: &NEARBlock,
     context: &mut EngineContext,
     outcomes: Option<&mut HashMap<H256, TransactionIncludedOutcome>>,
 ) -> Result<(), error::Error> {
-    sync::consume_near_block(
+    sync::consume_near_block::<M>(
         &mut context.storage,
         block,
         &mut context.data_id_mapping,

--- a/engine/src/tests.rs
+++ b/engine/src/tests.rs
@@ -1,4 +1,5 @@
 use aurora_engine::parameters::TransactionStatus;
+use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_types::{account_id::AccountId, H256};
 use aurora_refiner_types::near_block::NEARBlock;
 use engine_standalone_storage::json_snapshot::{self, types::JsonSnapshot};
@@ -21,7 +22,7 @@ fn test_empty_submit_input() {
     let mut outcomes_map = HashMap::new();
     let chain_id = aurora_engine_types::types::u256_to_arr(&(1313161554.into()));
 
-    crate::sync::consume_near_block(
+    crate::sync::consume_near_block::<AuroraModExp>(
         &mut test_context.storage,
         &block,
         &mut data_id_mapping,
@@ -50,7 +51,7 @@ fn test_batched_transactions() {
     let mut data_id_mapping = lru::LruCache::new(NonZeroUsize::new(1000).unwrap());
     let mut outcomes_map = HashMap::new();
     let chain_id = aurora_engine_types::types::u256_to_arr(&(1313161554.into()));
-    crate::sync::consume_near_block(
+    crate::sync::consume_near_block::<AuroraModExp>(
         &mut test_context.storage,
         &block,
         &mut data_id_mapping,

--- a/refiner-lib/Cargo.toml
+++ b/refiner-lib/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 aurora-engine.workspace = true
+aurora-engine-modexp.workspace = true
 aurora-engine-transactions.workspace = true
 aurora-engine-types.workspace = true
 aurora-engine-sdk.workspace = true

--- a/refiner-lib/src/near_stream.rs
+++ b/refiner-lib/src/near_stream.rs
@@ -1,6 +1,7 @@
 use crate::metrics::{PROCESSED_BLOCKS, SKIP_BLOCKS};
 use crate::refiner_inner::Refiner;
 use crate::tx_hash_tracker::TxHashTracker;
+use aurora_engine_modexp::AuroraModExp;
 use aurora_refiner_types::aurora_block::AuroraBlock;
 use aurora_refiner_types::near_block::NEARBlock;
 use aurora_standalone_engine::EngineContext;
@@ -36,9 +37,14 @@ impl NearStream {
 
         let mut txs = Default::default();
 
-        // Panic if engine can't consume this block
-        aurora_standalone_engine::consume_near_block(near_block, &mut self.context, Some(&mut txs))
-            .unwrap();
+        // Can specify a concrete modexp algorithm here because only transactions
+        // that executed successfully on-chain are executed again here.
+        aurora_standalone_engine::consume_near_block::<AuroraModExp>(
+            near_block,
+            &mut self.context,
+            Some(&mut txs),
+        )
+        .unwrap(); // Panic if engine can't consume this block
 
         // Panic if transaction hash tracker cannot consume the block
         self.tx_tracker


### PR DESCRIPTION
This change allows downstream users of the Borealis Engine library to choose a different implementation of the modexp precompile.