### PR TITLE
Feat: Implement validation of Near account ID in config.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,7 @@ name = "aurora-refiner"
 version = "0.22.0"
 dependencies = [
  "anyhow",
+ "aurora-engine-types",
  "aurora-refiner-lib",
  "aurora-refiner-types",
  "aurora-standalone-engine",

--- a/refiner-app/Cargo.toml
+++ b/refiner-app/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 
 [dependencies]
 near-indexer.workspace = true
+aurora-engine-types.workspace = true
 aurora-refiner-lib = { path = "../refiner-lib" }
 aurora-refiner-types = { path = "../refiner-types" }
 aurora-standalone-engine = { path = "../engine" }

--- a/refiner-app/src/config.rs
+++ b/refiner-app/src/config.rs
@@ -1,4 +1,6 @@
-use serde::Deserialize;
+use aurora_engine_types::account_id::AccountId;
+use serde::de::Error;
+use serde::{Deserialize, Deserializer};
 use std::path::PathBuf;
 
 use crate::store::OutputStoreConfig;
@@ -15,7 +17,7 @@ pub struct Config {
 pub struct Refiner {
     pub chain_id: u64,
     pub engine_path: PathBuf,
-    pub engine_account_id: String,
+    pub engine_account_id: ValidatedAccountId,
     #[serde(default)]
     pub tx_tracker_path: Option<PathBuf>,
 }
@@ -45,4 +47,52 @@ pub struct SocketServer {
 pub enum Network {
     Mainnet,
     Testnet,
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedAccountId(AccountId);
+
+impl From<ValidatedAccountId> for AccountId {
+    fn from(value: ValidatedAccountId) -> Self {
+        value.0
+    }
+}
+
+impl<'de> Deserialize<'de> for ValidatedAccountId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let account_id = AccountId::deserialize(deserializer)
+            .map_err(|v| Error::custom(format!("invalid Near account ID, error code: {v}")))?;
+
+        Ok(ValidatedAccountId(account_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_near_account_id_does_not_pass_deserialization() {
+        let error =
+            serde_json::from_str::<ValidatedAccountId>("\"invalid id because it contains spaces\"")
+                .unwrap_err();
+
+        let actual_error = format!("{error}");
+        let expected_error = "invalid Near account ID, error code: ERR_ACCOUNT_ID_TO_INVALID";
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_near_account_id_passes_deserialization() {
+        let account_id = serde_json::from_str::<ValidatedAccountId>("\"some_near_id\"").unwrap();
+
+        let actual_near_account_id = account_id.0.to_string();
+        let expected_near_account_id = "some_near_id";
+
+        assert_eq!(actual_near_account_id, expected_near_account_id);
+    }
 }

--- a/refiner-app/src/main.rs
+++ b/refiner-app/src/main.rs
@@ -31,9 +31,9 @@ async fn main() -> anyhow::Result<()> {
 
     let config_path = args.config_path.as_deref().unwrap_or("default_config.json");
     let config: config::Config = {
-        let file = std::fs::File::open(config_path).unwrap();
+        let file = fs::File::open(config_path)?;
         let reader = std::io::BufReader::new(file);
-        serde_json::from_reader(reader).unwrap()
+        serde_json::from_reader(reader).map_err(|e| anyhow!("Cannot parse config, reason: {e}"))?
     };
 
     match args.command {
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
 
             aurora_refiner_lib::storage::init_storage(
                 engine_path.to_path_buf(),
-                config.refiner.engine_account_id.parse().unwrap(),
+                config.refiner.engine_account_id.clone().into(),
                 config.refiner.chain_id,
             );
 
@@ -80,7 +80,7 @@ async fn main() -> anyhow::Result<()> {
 
             let ctx = aurora_standalone_engine::EngineContext::new(
                 engine_path,
-                config.refiner.engine_account_id.parse().unwrap(),
+                config.refiner.engine_account_id.into(),
                 config.refiner.chain_id,
             )
             .unwrap();

--- a/refiner-lib/src/near_stream.rs
+++ b/refiner-lib/src/near_stream.rs
@@ -108,6 +108,7 @@ impl NearStream {
 
 #[cfg(test)]
 mod tests {
+    use aurora_engine_types::account_id::AccountId;
     use aurora_refiner_types::aurora_block::NearBlock;
     use engine_standalone_storage::json_snapshot::{initialize_engine_state, types::JsonSnapshot};
     use std::{collections::HashSet, matches};
@@ -313,9 +314,9 @@ mod tests {
             let engine_path = db_dir.path().join("engine");
             let tracker_path = db_dir.path().join("tracker");
             let chain_id = 1313161554_u64;
-            crate::storage::init_storage(engine_path.clone(), "aurora".into(), chain_id);
-            let engine_context =
-                EngineContext::new(&engine_path, "aurora".parse().unwrap(), chain_id).unwrap();
+            let account_id: AccountId = "aurora".parse().unwrap();
+            crate::storage::init_storage(engine_path.clone(), account_id.clone(), chain_id);
+            let engine_context = EngineContext::new(&engine_path, account_id, chain_id).unwrap();
             let tx_tracker = TxHashTracker::new(tracker_path, 0).unwrap();
             Self {
                 chain_id,

--- a/refiner-lib/src/storage.rs
+++ b/refiner-lib/src/storage.rs
@@ -8,31 +8,24 @@ const VERSION: u8 = 0;
 /// Write to the DB in batches of 100k heights at a time
 const BATCH_SIZE: usize = 100_000;
 
-pub fn init_storage(storage_path: PathBuf, account_id: String, chain_id: u64) {
-    let engine_account_id: AccountId = account_id.parse().unwrap_or_else(|_| {
-        panic!(
-            "Provided engine_account_id={} is not a valid NEAR account ID",
-            account_id
-        )
-    });
-
-    let mut storage = migrate_block_hash(storage_path, &engine_account_id, chain_id);
+pub fn init_storage(storage_path: PathBuf, account_id: AccountId, chain_id: u64) {
+    let mut storage = migrate_block_hash(storage_path, &account_id, chain_id);
 
     match storage.get_engine_account_id() {
         Ok(stored_id) => {
-            if stored_id != engine_account_id {
+            if stored_id != account_id {
                 panic!(
                     "Provided engine_account_id={} is not equal to account_id_stored={}",
-                    engine_account_id, stored_id
+                    account_id, stored_id
                 );
             }
         }
         Err(engine_standalone_storage::Error::EngineAccountIdNotSet) => {
             tracing::info!(
                 "No engine_account_id set in DB. Setting to configured engine_account_id={}",
-                engine_account_id
+                account_id
             );
-            storage.set_engine_account_id(&engine_account_id).unwrap();
+            storage.set_engine_account_id(&account_id).unwrap();
         }
         Err(engine_standalone_storage::Error::EngineAccountIdCorrupted) => {
             panic!("Fatal error, cannot read engine_account_id from DB. The DB may be corrupted.");


### PR DESCRIPTION
- The `AccountId` is validated in its constructor.
- Instance of `AccountId` guarantees valid Near account ID.
- The type `ValidatedAccountId` just adds descriptive error message.

This is one of the issues reported by Hacken audit.

> Only a pre-validated input account can be nominated to be used in specified functions; otherwise, a program or smart contract can go into an invalid state or be hacked.
Input parameter `engine_account_id` is not validated inside the `consume_near_block` function.