### PR TITLE
Refiner hashchain

### DIFF
--- a/refiner-app/src/main.rs
+++ b/refiner-app/src/main.rs
@@ -80,7 +80,7 @@ async fn main() -> anyhow::Result<()> {
 
             let ctx = aurora_standalone_engine::EngineContext::new(
                 engine_path,
-                config.refiner.engine_account_id,
+                config.refiner.engine_account_id.clone(),
                 config.refiner.chain_id,
             )
             .unwrap();
@@ -114,6 +114,7 @@ async fn main() -> anyhow::Result<()> {
                 aurora_refiner_lib::run_refiner::<&Path, ()>(
                     ctx,
                     config.refiner.chain_id,
+                    config.refiner.engine_account_id,
                     tx_tracker_path.as_ref(),
                     input_stream,
                     output_stream,

--- a/refiner-lib/src/near_stream.rs
+++ b/refiner-lib/src/near_stream.rs
@@ -1,8 +1,8 @@
 use crate::metrics::{PROCESSED_BLOCKS, SKIP_BLOCKS};
 use crate::refiner_inner::Refiner;
 use crate::tx_hash_tracker::TxHashTracker;
-use aurora_engine_types::account_id::AccountId;
 use aurora_engine_modexp::AuroraModExp;
+use aurora_engine_types::account_id::AccountId;
 use aurora_refiner_types::aurora_block::AuroraBlock;
 use aurora_refiner_types::near_block::NEARBlock;
 use aurora_standalone_engine::EngineContext;
@@ -319,7 +319,8 @@ mod tests {
             let chain_id = 1313161554_u64;
             let engine_account_id: AccountId = "aurora".parse().unwrap();
             crate::storage::init_storage(engine_path.clone(), engine_account_id.clone(), chain_id);
-            let engine_context = EngineContext::new(&engine_path, engine_account_id.clone(), chain_id).unwrap();
+            let engine_context =
+                EngineContext::new(&engine_path, engine_account_id.clone(), chain_id).unwrap();
             let tx_tracker = TxHashTracker::new(tracker_path, 0).unwrap();
             Self {
                 chain_id,
@@ -339,7 +340,13 @@ mod tests {
         }
 
         fn create_stream(self) -> NearStream {
-            NearStream::new(self.chain_id, self.engine_account_id, None, self.engine_context, self.tx_tracker)
+            NearStream::new(
+                self.chain_id,
+                self.engine_account_id,
+                None,
+                self.engine_context,
+                self.tx_tracker,
+            )
         }
     }
 }

--- a/refiner-lib/src/refiner.rs
+++ b/refiner-lib/src/refiner.rs
@@ -19,6 +19,7 @@ impl<B: Debug, M: Debug + Clone> BlockWithMetadata<B, M> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run_refiner<P: AsRef<Path>, M: Debug + Clone>(
     ctx: EngineContext,
     chain_id: u64,

--- a/refiner-lib/src/refiner.rs
+++ b/refiner-lib/src/refiner.rs
@@ -1,5 +1,6 @@
 use crate::near_stream::NearStream;
 use crate::tx_hash_tracker;
+use aurora_engine_types::account_id::AccountId;
 use aurora_refiner_types::aurora_block::AuroraBlock;
 use aurora_refiner_types::near_block::NEARBlock;
 use aurora_standalone_engine::EngineContext;
@@ -21,6 +22,7 @@ impl<B: Debug, M: Debug + Clone> BlockWithMetadata<B, M> {
 pub async fn run_refiner<P: AsRef<Path>, M: Debug + Clone>(
     ctx: EngineContext,
     chain_id: u64,
+    engine_account_id: AccountId,
     tx_storage_path: P,
     mut input: tokio::sync::mpsc::Receiver<BlockWithMetadata<NEARBlock, M>>,
     output: tokio::sync::mpsc::Sender<BlockWithMetadata<AuroraBlock, M>>,
@@ -30,7 +32,7 @@ pub async fn run_refiner<P: AsRef<Path>, M: Debug + Clone>(
     let tx_tracker =
         tx_hash_tracker::TxHashTracker::new(tx_storage_path, last_block.unwrap_or_default())
             .expect("Failed to start transaction tracker");
-    let mut stream = NearStream::new(chain_id, last_block, ctx, tx_tracker);
+    let mut stream = NearStream::new(chain_id, engine_account_id, last_block, ctx, tx_tracker);
 
     loop {
         tokio::select! {

--- a/refiner-lib/src/refiner_inner.rs
+++ b/refiner-lib/src/refiner_inner.rs
@@ -215,7 +215,12 @@ impl Refiner {
                     match build_transaction(
                         block,
                         action,
-                        &execution_outcome.receipt.predecessor_id.as_bytes().try_into().unwrap(),
+                        &execution_outcome
+                            .receipt
+                            .predecessor_id
+                            .as_bytes()
+                            .try_into()
+                            .unwrap(),
                         near_metadata,
                         status,
                         self.chain_id,
@@ -805,10 +810,7 @@ fn fill_with_submit_result(
     }
 }
 
-fn fill_tx(
-    tx: AuroraTransactionBuilder,
-    input: Vec<u8>,
-) -> AuroraTransactionBuilder {
+fn fill_tx(tx: AuroraTransactionBuilder, input: Vec<u8>) -> AuroraTransactionBuilder {
     tx.to(None)
         .nonce(0)
         .gas_limit(0)

--- a/refiner-types/src/aurora_block.rs
+++ b/refiner-types/src/aurora_block.rs
@@ -1,11 +1,11 @@
 use crate::utils::u64_hex_serde;
 use aurora_engine::parameters::ResultLog;
 use aurora_engine_transactions::eip_2930::AccessTuple;
+use aurora_engine_types::account_id::AccountId;
 use aurora_engine_types::types::{Address, Wei};
 use aurora_engine_types::{H256, U256};
 use derive_builder::Builder;
 use near_primitives::hash::CryptoHash;
-use near_primitives::types::AccountId;
 use serde::{Deserialize, Serialize};
 
 use crate::bloom::Bloom;
@@ -25,6 +25,8 @@ use crate::bloom::Bloom;
 pub struct AuroraBlock {
     /// Chain where this block belongs to
     pub chain_id: u64,
+    /// Account id of the engine contract on the chain
+    pub engine_account_id: AccountId,
     /// Hash of the block
     pub hash: H256,
     /// Hash of the parent block. It is guaranteed that heights from consecutive blocks will be

--- a/refiner-types/src/aurora_block.rs
+++ b/refiner-types/src/aurora_block.rs
@@ -165,6 +165,10 @@ pub struct NearTransaction {
     /// expected to be set for call newly produced data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transaction_hash: Option<CryptoHash>,
+    /// Method name called on the Aurora engine contract on NEAR.
+    /// Filed is Some if and only if NEAR action is a function call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method_name: Option<String>,
 }
 
 #[cfg(test)]

--- a/refiner-types/src/res/aurora_70077007.json
+++ b/refiner-types/src/res/aurora_70077007.json
@@ -1,5 +1,6 @@
 {
   "chain_id": 1313161554,
+  "engine_account_id": "aurora",
   "hash": "0x3ec55f7e9728f6d4613baf7b71916af06dac1e0e5581b0e3960b5f60be64cbd0",
   "parent_hash": "0x0dc96272642311387164195f92bd535fbe5ac8c5c4b9bdfb0e7223ca87d78386",
   "height": 70077007,


### PR DESCRIPTION
Adding a couple of fields to the Aurora Blocks that are need it for Hashchain computation.

`engine_account_id`
- It was added at the top level of the Aurora Block since it is need it also for Skip blocks (that has no near metadata or txs).

`method_name`
- The original Aurora contract method name will be added to the tx included on the Aurora Block, on the `near_metadata` field.
- As part of this, the method name was removed from the other Block txs location that was used for some types of txs. Now, method name is always present and only on the tx `near_metadata`. 