### PR TITLE
Fix: use actix runtime in refiner-app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,7 @@ dependencies = [
 name = "aurora-refiner"
 version = "0.23.1"
 dependencies = [
+ "actix",
  "anyhow",
  "aurora-engine-types",
  "aurora-refiner-lib",
@@ -624,6 +625,17 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "aurora-refiner-app-integration-tests"
+version = "0.23.2"
+dependencies = [
+ "anyhow",
+ "tempfile",
+ "tokio",
+ "toml 0.7.6",
+ "vte",
 ]
 
 [[package]]
@@ -5655,7 +5667,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -6652,6 +6664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7279,10 +7300,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -7291,6 +7327,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -7662,6 +7700,27 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "arrayvec 0.7.4",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "refiner-lib",
     "refiner-types",
     "refiner-app",
+    "etc/integration-tests",
 ]
 resolver = "2"
 
@@ -15,6 +16,7 @@ repository = "https://github.com/aurora-is-near/aurora-standalone"
 license = "CC0-1.0"
 
 [workspace.dependencies]
+actix = "0.13.0"
 anyhow = "1"
 aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.10.1", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
 aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.10.1", default-features = false, features = ["std", "impl-serde"] }
@@ -49,6 +51,7 @@ strum = { version = "0.24.0", features = [ "derive" ] }
 tempfile = "3.2.0"
 tokio = "1"
 tokio-stream = "0.1"
+toml = "0.7.6"
 tracing = "0.1.32"
 tracing-subscriber = "0.3"
 triehash-ethereum = { git = "https://github.com/openethereum/openethereum" }

--- a/etc/integration-tests/Cargo.toml
+++ b/etc/integration-tests/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "aurora-refiner-app-integration-tests"
+version = "0.23.2"
+authors.workspace = true
+edition.workspace = true
+description = "Integration tests for the Aurora Refiner application."
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+anyhow.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["full"] }
+toml.workspace = true
+vte = "0.11.1"

--- a/etc/integration-tests/src/ansi_utils.rs
+++ b/etc/integration-tests/src/ansi_utils.rs
@@ -1,0 +1,22 @@
+/// Removes ANSI control characters from a single line of text ('\n' is ignored).
+pub fn strip_ansi(input: String) -> String {
+    let mut parser = vte::Parser::new();
+    let mut performer = AnsiStripper::default();
+
+    for b in input.bytes() {
+        parser.advance(&mut performer, b);
+    }
+
+    performer.buf
+}
+
+#[derive(Debug, Default)]
+struct AnsiStripper {
+    buf: String,
+}
+
+impl vte::Perform for AnsiStripper {
+    fn print(&mut self, c: char) {
+        self.buf.push(c);
+    }
+}

--- a/etc/integration-tests/src/lib.rs
+++ b/etc/integration-tests/src/lib.rs
@@ -1,0 +1,95 @@
+pub mod ansi_utils;
+pub mod nearcore_utils;
+pub mod parse_logs;
+pub mod refiner_utils;
+pub mod toml_utils;
+
+/// Integration test that just checks refiner-app will start and connect to a Near network.
+/// This test does not check if Aurora blocks are produced from the Near blocks.
+/// This is a fairly heavy test because it downloads and compiles nearcore in order to
+/// set up a local Near network for the refiner to connect to.
+#[tokio::test]
+async fn test_refiner_starts() {
+    use std::path::PathBuf;
+
+    let repository_root = refiner_utils::get_repository_root().await.unwrap();
+    let nearcore_root = tempfile::tempdir().unwrap();
+    let nearcore_version = refiner_utils::get_nearcore_version(&repository_root)
+        .await
+        .unwrap();
+
+    // Compiler refiner
+    let thread_local_path = repository_root.clone();
+    let refiner_binary =
+        tokio::spawn(async move { refiner_utils::compile_refiner(&thread_local_path).await });
+
+    // Clone and build nearcore
+    let thread_local_path: PathBuf = nearcore_root.path().into();
+    let neard_binary = tokio::spawn(async move {
+        let nearcore_repo =
+            nearcore_utils::clone_nearcore(&thread_local_path, &nearcore_version).await?;
+        nearcore_utils::build_neard(&nearcore_repo).await
+    });
+
+    let refiner_binary = refiner_binary.await.unwrap().unwrap();
+    let neard_binary = neard_binary.await.unwrap().unwrap();
+
+    // Setup config files for nearcore localnet
+    nearcore_utils::create_localnet_configs(nearcore_root.path(), &neard_binary)
+        .await
+        .unwrap();
+
+    // Start validator node
+    let neard_home = nearcore_root.path().join("node0");
+    let mut neard_process = nearcore_utils::start_neard(&neard_binary, &neard_home)
+        .await
+        .unwrap();
+    let neard_output = neard_process.stderr.take().unwrap();
+    let (neard_shutdown_sender, neard_shutdown_rx) = tokio::sync::oneshot::channel();
+    let neard_process = tokio::spawn(async move {
+        tokio::select! {
+            _ = neard_process.wait() => (),
+            _ = neard_shutdown_rx => neard_process.kill().await.expect("Failed to shutdown neard"),
+        }
+    });
+
+    // Start refiner
+    let mut refiner_process =
+        refiner_utils::start_refiner(&refiner_binary, &repository_root, nearcore_root.path())
+            .await
+            .unwrap();
+    let refiner_output = refiner_process.stdout.take().unwrap();
+    let (refiner_shutdown_sender, refiner_shutdown_rx) = tokio::sync::oneshot::channel();
+    let (refiner_status_sender, refiner_status_rx) = tokio::sync::oneshot::channel();
+    let refiner_process = tokio::spawn(async move {
+        let status = tokio::select! {
+            status = refiner_process.wait() => status.unwrap(),
+            _ = refiner_shutdown_rx => {
+                refiner_process.start_kill().expect("Failed to send kill signal to refiner");
+                refiner_process.wait().await.unwrap()
+            }
+        };
+        refiner_status_sender.send(status).ok();
+    });
+
+    // Wait for validator to produce at least 100 blocks
+    parse_logs::wait_for_height(neard_output, 100)
+        .await
+        .unwrap();
+
+    // Check refiner has received at least 100 blocks
+    tokio::select! {
+        result = parse_logs::wait_for_height(refiner_output, 100) => result.unwrap(),
+        status = refiner_status_rx => {
+            panic!("Unexpected refiner crash: {status:?}");
+        }
+    };
+
+    // Shutdown refiner
+    refiner_shutdown_sender.send(()).unwrap();
+    refiner_process.await.unwrap();
+
+    // Shutdown validator
+    neard_shutdown_sender.send(()).unwrap();
+    neard_process.await.unwrap();
+}

--- a/etc/integration-tests/src/nearcore_utils.rs
+++ b/etc/integration-tests/src/nearcore_utils.rs
@@ -1,0 +1,115 @@
+//! Helper functions for downloading and compiling nearcore.
+//! These functions are used in the integration tests that require running Near nodes.
+
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+};
+use tokio::process::Command;
+
+pub async fn clone_nearcore(nearcore_root: &Path, tag: &str) -> anyhow::Result<PathBuf> {
+    let status = Command::new("git")
+        .current_dir(nearcore_root)
+        .args(["clone", "https://github.com/near/nearcore.git"])
+        .status()
+        .await?;
+
+    if !status.success() {
+        return Err(anyhow::Error::msg("Failed to clone nearcore"));
+    }
+
+    let expected_path = nearcore_root.join("nearcore");
+
+    if !expected_path.exists() {
+        return Err(anyhow::Error::msg(
+            "nearcore repository not created in the expected location",
+        ));
+    }
+
+    let status = Command::new("git")
+        .current_dir(&expected_path)
+        .args(["checkout", tag])
+        .status()
+        .await?;
+
+    if !status.success() {
+        return Err(anyhow::Error::msg(
+            "Failed to checkout current nearcore version",
+        ));
+    }
+
+    Ok(expected_path)
+}
+
+pub async fn build_neard(nearcore_repository: &Path) -> anyhow::Result<PathBuf> {
+    let status = Command::new("make")
+        .current_dir(nearcore_repository)
+        .arg("neard")
+        .status()
+        .await?;
+
+    if !status.success() {
+        return Err(anyhow::Error::msg("Failed to build neard binary"));
+    }
+
+    let expected_path = nearcore_repository
+        .join("target")
+        .join("release")
+        .join("neard");
+
+    if !expected_path.exists() {
+        return Err(anyhow::Error::msg(
+            "neard binary not created in the expected location",
+        ));
+    }
+
+    Ok(expected_path)
+}
+
+pub async fn create_localnet_configs(
+    nearcore_root: &Path,
+    neard_binary: &Path,
+) -> anyhow::Result<()> {
+    let nearcore_home = nearcore_root
+        .to_str()
+        .ok_or_else(|| anyhow::Error::msg("Corrupt neard_root path"))?;
+    let status = Command::new(neard_binary)
+        .args([
+            "--home",
+            nearcore_home,
+            "localnet",
+            "--non-validators",
+            "1",
+            "--validators",
+            "1",
+            "--shards",
+            "1",
+            "--archival-nodes",
+        ])
+        .status()
+        .await?;
+
+    if !status.success() {
+        return Err(anyhow::Error::msg(
+            "Failed to generate localnet nearcore configs",
+        ));
+    }
+
+    Ok(())
+}
+
+pub async fn start_neard(
+    neard_binary: &Path,
+    neard_home: &Path,
+) -> anyhow::Result<tokio::process::Child> {
+    let neard_home = neard_home
+        .to_str()
+        .ok_or_else(|| anyhow::Error::msg("Corrupt neard_home path"))?;
+
+    let child = Command::new(neard_binary)
+        .args(["--home", neard_home, "run"])
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    Ok(child)
+}

--- a/etc/integration-tests/src/parse_logs.rs
+++ b/etc/integration-tests/src/parse_logs.rs
@@ -1,0 +1,32 @@
+//! Helper functions for parsing information from nearcore logs.
+
+use crate::ansi_utils;
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+
+fn get_height_from_log(line: &str) -> anyhow::Result<u32> {
+    let index = line
+        .find('#')
+        .ok_or_else(|| anyhow::Error::msg("Unknown nearcore log format"))?;
+    let height_str = &line[(index + 1)..(index + 9)];
+    let height = height_str.trim().parse()?;
+    Ok(height)
+}
+
+/// Waits for the stats log to report a block height greater than the given value.
+pub async fn wait_for_height<R: AsyncRead + Unpin>(
+    stdout: R,
+    expected_height: u32,
+) -> anyhow::Result<()> {
+    let mut reader = BufReader::new(stdout).lines();
+    while let Some(line) = reader.next_line().await? {
+        let ascii_only = ansi_utils::strip_ansi(line);
+        if !ascii_only.contains("stats:") {
+            continue;
+        }
+        let height = get_height_from_log(&ascii_only)?;
+        if height > expected_height {
+            break;
+        }
+    }
+    Ok(())
+}

--- a/etc/integration-tests/src/refiner_utils.rs
+++ b/etc/integration-tests/src/refiner_utils.rs
@@ -1,0 +1,86 @@
+//! Helper functions for this repository.
+//! These functions are used in the integration tests which require running
+//! an instance of refiner-app.
+
+use crate::toml_utils;
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+};
+use tokio::process::Command;
+
+pub async fn get_repository_root() -> anyhow::Result<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(anyhow::Error::msg(
+            "Command `git rev-parse --show-toplevel` failed",
+        ));
+    }
+
+    let output = String::from_utf8(output.stdout)?;
+    let path = PathBuf::try_from(output.trim())?;
+    Ok(path)
+}
+
+pub async fn get_nearcore_version(repository_root: &Path) -> anyhow::Result<String> {
+    let cargo_toml = tokio::fs::read_to_string(repository_root.join("Cargo.toml")).await?;
+    let cargo_toml: toml::Table = toml::from_str(&cargo_toml)?;
+
+    let nearcore_tag = toml_utils::toml_recursive_get(
+        &cargo_toml,
+        &["workspace", "dependencies", "near-indexer", "tag"],
+    )?
+    .as_str()
+    .ok_or_else(|| anyhow::Error::msg("Expected nearcore tag to be string"))?;
+    Ok(nearcore_tag.into())
+}
+
+pub async fn compile_refiner(repository_root: &Path) -> anyhow::Result<PathBuf> {
+    let status = Command::new("cargo")
+        .current_dir(repository_root)
+        .args(["build", "-p", "aurora-refiner", "--release"])
+        .status()
+        .await?;
+
+    if !status.success() {
+        return Err(anyhow::Error::msg(
+            "Failed to compile aurora-refiner package",
+        ));
+    }
+
+    let expected_path = repository_root
+        .join("target")
+        .join("release")
+        .join("aurora-refiner");
+
+    if !expected_path.exists() {
+        return Err(anyhow::Error::msg(
+            "Refiner binary not created in the expected location",
+        ));
+    }
+
+    Ok(expected_path)
+}
+
+pub async fn start_refiner(
+    refiner_binary: &Path,
+    repository_root: &Path,
+    nearcore_root: &Path,
+) -> anyhow::Result<tokio::process::Child> {
+    let config = repository_root.join("nearcore_config.json");
+    let config_path = config
+        .to_str()
+        .ok_or_else(|| anyhow::Error::msg("Corrupt refiner config path"))?;
+
+    let child = Command::new(refiner_binary)
+        .current_dir(nearcore_root)
+        .args(["--config-path", config_path, "run"])
+        .stdout(Stdio::piped())
+        .spawn()?;
+
+    Ok(child)
+}

--- a/etc/integration-tests/src/toml_utils.rs
+++ b/etc/integration-tests/src/toml_utils.rs
@@ -1,0 +1,22 @@
+/// Get a value from a toml Table of Tables by recursively looking up values from the
+/// Tables using the provided list of keys (`path`).
+pub fn toml_recursive_get<'a>(
+    table: &'a toml::Table,
+    path: &[&str],
+) -> anyhow::Result<&'a toml::Value> {
+    let first_key = path
+        .first()
+        .ok_or_else(|| anyhow::Error::msg("Empty toml lookup path"))?;
+    let mut current_value = table
+        .get(*first_key)
+        .ok_or_else(|| anyhow::anyhow!("Key {first_key} not found in toml table"))?;
+    for key in &path[1..] {
+        let current_table = current_value.as_table().ok_or_else(|| {
+            anyhow::anyhow!("Cannot look up {key} because toml value is not a Table")
+        })?;
+        current_value = current_table
+            .get(*key)
+            .ok_or_else(|| anyhow::anyhow!("Key {key} not found in toml table"))?;
+    }
+    Ok(current_value)
+}

--- a/nearcore_config.json
+++ b/nearcore_config.json
@@ -6,7 +6,7 @@
     },
     "input_mode": {
         "Nearcore": {
-            "path": "nearcore"
+            "path": "node1"
         }
     },
     "output_storage": {

--- a/refiner-app/Cargo.toml
+++ b/refiner-app/Cargo.toml
@@ -31,6 +31,8 @@ itertools.workspace = true
 tokio = { workspace = true, features = ["sync", "time", "macros", "rt-multi-thread"] }
 tokio-stream.workspace = true
 
+actix.workspace = true
+
 # NEAR Lake Framework
 near-lake-framework.workspace = true
 

--- a/refiner-app/src/main.rs
+++ b/refiner-app/src/main.rs
@@ -23,7 +23,7 @@ fn setup_logs() {
     tracing::subscriber::set_global_default(subscriber).expect("Setting default subscriber failed");
 }
 
-#[tokio::main]
+#[actix::main]
 async fn main() -> anyhow::Result<()> {
     setup_logs();
 


### PR DESCRIPTION
The main purpose of this PR is to make the very minor change in `refiner-app` where we replace `tokio::main` with `actix::main`. This is required because the Actix runtime is used in nearcore, a version of which is started by the refiner (via the near-indexer framework). Without the change refiner-app fails to start. This regression was introduced accidentally because refiner-app does not use Actix itself, so it appeared to be safe to remove `actix:main` previously.

Fixes #84 

The refiner simply failing to start is an unacceptable state of affairs. We must have testing to ensure we do not make an accidentally cause such an issue again. The majority of the lines of code committed as part of this PR (located in `etc/integration-tests`) is an integration test to check that the refiner does start and can connect to a Near network. This test does not check the refiner can create Aurora blocks from the Near blocks, but this is something we could add in the future.