### PR TITLE
Fix: check diff before commiting it to storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,8 +521,8 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine"
-version = "2.10.2"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.10.2#17b6d696d06f7d177cfeea1917a4c0e7f88637fc"
+version = "3.0.0"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.0.0#1a2e7c682b199f1c0940fa71109d1cd9f03d0672"
 dependencies = [
  "aurora-engine-modexp",
  "aurora-engine-precompiles",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-modexp"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.10.2#17b6d696d06f7d177cfeea1917a4c0e7f88637fc"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.0.0#1a2e7c682b199f1c0940fa71109d1cd9f03d0672"
 dependencies = [
  "hex",
  "num",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-precompiles"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.10.2#17b6d696d06f7d177cfeea1917a4c0e7f88637fc"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.0.0#1a2e7c682b199f1c0940fa71109d1cd9f03d0672"
 dependencies = [
  "aurora-engine-modexp",
  "aurora-engine-sdk",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-sdk"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.10.2#17b6d696d06f7d177cfeea1917a4c0e7f88637fc"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.0.0#1a2e7c682b199f1c0940fa71109d1cd9f03d0672"
 dependencies = [
  "aurora-engine-types",
  "base64 0.21.2",
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-transactions"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.10.2#17b6d696d06f7d177cfeea1917a4c0e7f88637fc"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.0.0#1a2e7c682b199f1c0940fa71109d1cd9f03d0672"
 dependencies = [
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-types"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.10.2#17b6d696d06f7d177cfeea1917a4c0e7f88637fc"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.0.0#1a2e7c682b199f1c0940fa71109d1cd9f03d0672"
 dependencies = [
  "base64 0.21.2",
  "borsh 0.10.3",
@@ -2335,7 +2335,7 @@ dependencies = [
 [[package]]
 name = "engine-standalone-storage"
 version = "0.1.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.10.2#17b6d696d06f7d177cfeea1917a4c0e7f88637fc"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.0.0#1a2e7c682b199f1c0940fa71109d1cd9f03d0672"
 dependencies = [
  "aurora-engine",
  "aurora-engine-modexp",
@@ -2355,7 +2355,7 @@ dependencies = [
 [[package]]
 name = "engine-standalone-tracing"
 version = "0.1.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=2.10.2#17b6d696d06f7d177cfeea1917a4c0e7f88637fc"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.0.0#1a2e7c682b199f1c0940fa71109d1cd9f03d0672"
 dependencies = [
  "aurora-engine-types",
  "evm",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.3-aurora#4e2d27d8ff8e5a50a43ed49d86282decce9d39f9"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -2564,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.3-aurora#4e2d27d8ff8e5a50a43ed49d86282decce9d39f9"
 dependencies = [
  "parity-scale-codec 3.6.4",
  "primitive-types 0.12.1",
@@ -2575,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.3-aurora#4e2d27d8ff8e5a50a43ed49d86282decce9d39f9"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2586,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.3-aurora#4e2d27d8ff8e5a50a43ed49d86282decce9d39f9"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,17 +19,17 @@ license = "CC0-1.0"
 [workspace.dependencies]
 actix = "0.13"
 anyhow = "1"
-aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.10.2", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
-aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.10.2", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.10.2", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.10.2", default-features = false, features = ["std"] }
-aurora-engine-modexp = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.10.2", default-features = false, features = ["std"] }
+aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.0.0", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
+aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.0.0", default-features = false, features = ["std", "impl-serde"] }
+aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.0.0", default-features = false, features = ["std", "impl-serde"] }
+aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.0.0", default-features = false, features = ["std"] }
+aurora-engine-modexp = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.0.0", default-features = false, features = ["std"] }
 borsh = "0.10"
 byteorder = "1"
 clap = { version = "4", features = ["derive"] }
 derive_builder = "0.12"
-engine-standalone-storage = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.10.2", default-features = false }
-engine-standalone-tracing = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "2.10.2", default-features = false, features = ["impl-serde"] }
+engine-standalone-storage = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.0.0", default-features = false }
+engine-standalone-tracing = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.0.0", default-features = false, features = ["impl-serde"] }
 fixed-hash = "0.8"
 futures = "0.3"
 hex = "0.4"

--- a/engine/src/batch_tx_processing.rs
+++ b/engine/src/batch_tx_processing.rs
@@ -1,0 +1,69 @@
+use aurora_engine_sdk::io::IO;
+use engine_standalone_storage::{
+    engine_state::{EngineStateAccess, EngineStorageValue},
+    Diff,
+};
+use std::cell::RefCell;
+
+#[derive(Clone, Copy)]
+pub struct BatchIO<'db, 'local> {
+    pub fallback: EngineStateAccess<'db, 'db, 'db>,
+    pub cumulative_diff: &'local Diff,
+    pub current_diff: &'local RefCell<Diff>,
+}
+
+impl<'db, 'local> IO for BatchIO<'db, 'local> {
+    type StorageValue = EngineStorageValue<'db>;
+
+    fn read_input(&self) -> Self::StorageValue {
+        self.fallback.read_input()
+    }
+
+    fn return_output(&mut self, value: &[u8]) {
+        self.fallback.return_output(value)
+    }
+
+    fn read_storage(&self, key: &[u8]) -> Option<Self::StorageValue> {
+        if let Some(diff) = self
+            .current_diff
+            .borrow()
+            .get(key)
+            .or_else(|| self.cumulative_diff.get(key))
+        {
+            return diff
+                .value()
+                .map(|bytes| EngineStorageValue::Vec(bytes.to_vec()));
+        }
+        self.fallback.read_storage(key)
+    }
+
+    fn storage_has_key(&self, key: &[u8]) -> bool {
+        self.read_storage(key).is_some()
+    }
+
+    fn write_storage(&mut self, key: &[u8], value: &[u8]) -> Option<Self::StorageValue> {
+        let original_value = self.read_storage(key);
+
+        self.current_diff
+            .borrow_mut()
+            .modify(key.to_vec(), value.to_vec());
+
+        original_value
+    }
+
+    fn write_storage_direct(
+        &mut self,
+        key: &[u8],
+        value: Self::StorageValue,
+    ) -> Option<Self::StorageValue> {
+        self.write_storage(key, value.as_ref())
+    }
+
+    fn remove_storage(&mut self, key: &[u8]) -> Option<Self::StorageValue> {
+        let original_value = self.read_storage(key);
+
+        self.current_diff.borrow_mut().delete(key.to_vec());
+
+        original_value
+    }
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::path::Path;
 
+mod batch_tx_processing;
 pub mod gas;
 pub mod sync;
 #[cfg(test)]

--- a/engine/src/sync.rs
+++ b/engine/src/sync.rs
@@ -19,11 +19,10 @@ use engine_standalone_storage::{
     BlockMetadata, Diff, Storage,
 };
 use lru::LruCache;
-use std::convert::TryFrom;
-use std::{collections::HashMap, str::FromStr};
+use std::{cell::RefCell, convert::TryFrom, collections::HashMap, str::FromStr};
 use tracing::{debug, warn};
 
-use crate::types::InnerTransactionKind;
+use crate::{batch_tx_processing::BatchIO, types::InnerTransactionKind};
 
 pub fn consume_near_block<M: ModExpAlgorithm>(
     storage: &mut Storage,
@@ -240,22 +239,17 @@ pub fn consume_near_block<M: ModExpAlgorithm>(
                                 || submit_result.as_ref().unwrap() != &expected_result
                             {
                                 warn!(
-                                    "Incorrect result in processing receipt_id={:?} computed={:?} expected={:?}",
-                                    receipt_id,
-                                    submit_result,
-                                    expected_result,
+                                    "Incorrect result in processing receipt_id={receipt_id:?} computed differed from expected",
                                 );
                             }
                         }
                         Err(_) => warn!(
-                            "Unable to deserialize receipt_id={:?} as SubmitResult",
-                            receipt_id
+                            "Unable to deserialize receipt_id={receipt_id:?} as SubmitResult",
                         ),
                     }
                 }
                 None => warn!(
-                    "Expected receipt_id={:?} to have a return result, but there was none",
-                    receipt_id
+                    "Expected receipt_id={receipt_id:?} to have a return result, but there was none",
                 ),
             }
         }
@@ -264,24 +258,18 @@ pub fn consume_near_block<M: ModExpAlgorithm>(
             None => {
                 if !tx_outcome.diff().is_empty() {
                     warn!(
-                        "Receipt {:?} not expected to have changes, but standalone computed diff {:?}",
-                        receipt_id, tx_outcome.diff(),
+                        "Receipt {receipt_id:?} not expected to have changes, but standalone computed a non-empty diff",
                     );
-                    tx_outcome.revert(storage)?;
                 }
             }
             Some(expected_diff) => {
-                if expected_diff != tx_outcome.diff() {
-                    warn!(
-                        "Diff mismatch in receipt_id={:?} computed={:?} ; expected={:?}",
-                        receipt_id,
-                        tx_outcome.diff(),
-                        expected_diff,
-                    );
-                    // Need to delete the incorrect diff before adding the correct diff because it could be
-                    // the case that the incorrect diff wrote some keys that the correct diff did not
-                    // (and these writes need to be undone).
-                    tx_outcome.revert(storage)?;
+                if expected_diff == tx_outcome.diff() {
+                    // Diff was correct, so commit it to the storage
+                    tx_outcome.commit(storage)?;
+                } else {
+                    // Diff was incorrect, so log a warning and commit
+                    // the one from the Near block instead
+                    warn!("Receipt {receipt_id:?} diff mismatch with computed diff");
                     tx_outcome.update_diff(storage, expected_diff)?;
                 }
             }
@@ -390,40 +378,92 @@ impl TransactionBatch {
                 ..
             } => {
                 let mut non_last_outcomes = Vec::with_capacity(non_last_actions.len());
-                for tx in non_last_actions {
-                    match sync::consume_message::<M>(storage, Message::Transaction(Box::new(tx)))? {
-                        ConsumeMessageOutcome::TransactionIncluded(tx_outcome) => {
-                            debug!("COMPLETED {:?}", tx_outcome.hash);
-                            non_last_outcomes.push(*tx_outcome);
-                        }
-                        // We sent a transaction message tagged as successful, so we can only get `TransactionIncluded` back
-                        ConsumeMessageOutcome::BlockAdded
-                        | ConsumeMessageOutcome::FailedTransactionIgnored => unreachable!(),
+                let mut cumulative_diff = Diff::default();
+
+                let block_hash = match last_action.as_ref() {
+                    Some(tx_msg) => tx_msg.block_hash,
+                    None => {
+                        // This case should never come up because empty
+                        // batches are thrown out before processing.
+                        return Ok(TransactionBatchOutcome::Batch {
+                            cumulative_diff: Diff::default(),
+                            non_last_outcomes: Vec::new(),
+                            last_outcome: None,
+                        });
                     }
+                };
+                let block_height = storage.get_block_height_by_hash(block_hash)?;
+                let block_metadata = storage.get_block_metadata(block_hash)?;
+                let engine_account_id = storage.get_engine_account_id()?;
+
+                // We need to use `BatchIO` here instead of simply calling `sync::consume_message` because
+                // the latter no longer persists to the DB right away (we wait util checking the expected diff first now),
+                // but a later transaction in a batch can see earlier ones, therefore we need to keep track all
+                // changes made and expose them as if they had been committed to the DB.
+                for tx in non_last_actions {
+                    let transaction_position = tx.position;
+                    let local_engine_account_id = engine_account_id.clone();
+                    let (tx_hash, diff, result) = storage
+                        .with_engine_access(block_height, transaction_position, &[], |io| {
+                            let local_diff = RefCell::new(Diff::default());
+                            let batch_io = BatchIO {
+                                fallback: io,
+                                cumulative_diff: &cumulative_diff,
+                                current_diff: &local_diff,
+                            };
+                            sync::execute_transaction::<_, M, _>(
+                                &tx,
+                                block_height,
+                                &block_metadata,
+                                local_engine_account_id,
+                                batch_io,
+                                |x| x.current_diff.borrow().clone(),
+                            )
+                        })
+                        .result;
+                    cumulative_diff.append(diff.clone());
+                    let tx_outcome = TransactionIncludedOutcome {
+                        hash: tx_hash,
+                        info: tx,
+                        diff,
+                        maybe_result: result,
+                    };
+                    debug!("COMPLETED {:?}", tx_outcome.hash);
+                    non_last_outcomes.push(tx_outcome);
                 }
                 let last_outcome = match last_action {
                     None => None,
                     Some(tx) => {
-                        match sync::consume_message::<M>(
-                            storage,
-                            Message::Transaction(Box::new(tx)),
-                        )? {
-                            ConsumeMessageOutcome::TransactionIncluded(tx_outcome) => {
-                                debug!("COMPLETED {:?}", tx_outcome.hash);
-                                Some(tx_outcome)
-                            }
-                            ConsumeMessageOutcome::BlockAdded
-                            | ConsumeMessageOutcome::FailedTransactionIgnored => unreachable!(),
-                        }
+                        let transaction_position = tx.position;
+                        let (tx_hash, diff, result) = storage
+                            .with_engine_access(block_height, transaction_position, &[], |io| {
+                                let local_diff = RefCell::new(Diff::default());
+                                let batch_io = BatchIO {
+                                    fallback: io,
+                                    cumulative_diff: &cumulative_diff,
+                                    current_diff: &local_diff,
+                                };
+                                sync::execute_transaction::<_, M, _>(
+                                    &tx,
+                                    block_height,
+                                    &block_metadata,
+                                    engine_account_id,
+                                    batch_io,
+                                    |x| x.current_diff.borrow().clone(),
+                                )
+                            })
+                            .result;
+                        cumulative_diff.append(diff.clone());
+                        let tx_outcome = TransactionIncludedOutcome {
+                            hash: tx_hash,
+                            info: tx,
+                            diff,
+                            maybe_result: result,
+                        };
+                        debug!("COMPLETED {:?}", tx_outcome.hash);
+                        Some(Box::new(tx_outcome))
                     }
                 };
-                let cumulative_diff = non_last_outcomes
-                    .iter()
-                    .chain(last_outcome.iter().map(|x| x.as_ref()))
-                    .fold(Diff::default(), |mut acc, outcome| {
-                        acc.append(outcome.diff.clone());
-                        acc
-                    });
                 Ok(TransactionBatchOutcome::Batch {
                     cumulative_diff,
                     non_last_outcomes,
@@ -453,13 +493,9 @@ impl TransactionBatchOutcome {
         }
     }
 
-    fn revert(&self, storage: &mut Storage) -> Result<(), engine_standalone_storage::Error> {
+    fn commit(&self, storage: &mut Storage) -> Result<(), engine_standalone_storage::Error> {
         match self {
-            Self::Single(tx_outcome) => storage.revert_transaction_included(
-                tx_outcome.hash,
-                &tx_outcome.info,
-                &tx_outcome.diff,
-            ),
+            Self::Single(tx_outcome) => tx_outcome.commit(storage),
             Self::Batch {
                 non_last_outcomes,
                 last_outcome,
@@ -469,11 +505,7 @@ impl TransactionBatchOutcome {
                     .iter()
                     .chain(last_outcome.iter().map(|x| x.as_ref()));
                 for tx_outcome in all_outcomes {
-                    storage.revert_transaction_included(
-                        tx_outcome.hash,
-                        &tx_outcome.info,
-                        &tx_outcome.diff,
-                    )?
+                    tx_outcome.commit(storage)?
                 }
                 Ok(())
             }

--- a/engine/src/sync.rs
+++ b/engine/src/sync.rs
@@ -19,7 +19,7 @@ use engine_standalone_storage::{
     BlockMetadata, Diff, Storage,
 };
 use lru::LruCache;
-use std::{cell::RefCell, convert::TryFrom, collections::HashMap, str::FromStr};
+use std::{cell::RefCell, collections::HashMap, convert::TryFrom, str::FromStr};
 use tracing::{debug, warn};
 
 use crate::{batch_tx_processing::BatchIO, types::InnerTransactionKind};


### PR DESCRIPTION
This fix address the performance issue in the refiner where constantly writing and deleting the same key made reading that key slow. Now the diff of a transaction is checked before committing it to the DB so that only the correct diff is written. Related PR: https://github.com/aurora-is-near/aurora-engine/pull/825