### PR TITLE
Chore: refactore CI - remove matrix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,15 +61,7 @@ jobs:
 
   test:
     name: ${{ matrix.build }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        build: [Linux, macOS]
-        include:
-          - build: Linux
-            os: ubuntu-latest
-          - build: macOS
-            os: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
## Motivation

The CI process is extremely long (30+ min), so the `CI matrix` case is redundant and increases CI execution time.