### PR TITLE
chore: bump nearcore to 1.38.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.28.0-rc.2"
+version = "0.28.0+1.38.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.28.0-rc.2"
+version = "0.28.0+1.38.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.28.0-rc.2"
+version = "0.28.0+1.38.0"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.28.0-rc.2"
+version = "0.28.0+1.38.0"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
@@ -673,8 +673,8 @@ dependencies = [
  "derive_builder 0.20.0",
  "fixed-hash 0.8.0",
  "impl-serde 0.4.0",
- "near-crypto 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
+ "near-crypto 1.38.0",
+ "near-primitives 1.38.0",
  "serde",
  "serde_json",
  "sha3",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.28.0-rc.2"
+version = "0.28.0+1.38.0"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -3528,17 +3528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3749,12 +3738,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
@@ -3923,7 +3906,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.31",
+ "rustix",
 ]
 
 [[package]]
@@ -4072,16 +4055,16 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "derive-enum-from-into",
  "derive_more",
  "futures",
- "near-o11y 1.38.0-rc.2",
+ "near-o11y 1.38.0",
  "near-performance-metrics",
- "near-primitives 1.38.0-rc.2",
+ "near-primitives 1.38.0",
  "once_cell",
  "serde",
  "serde_json",
@@ -4091,16 +4074,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "lru 0.7.8",
 ]
 
 [[package]]
 name = "near-chain"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "assert_matches",
@@ -4117,14 +4100,14 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 1.38.0-rc.2",
+ "near-crypto 1.38.0",
  "near-epoch-manager",
  "near-network",
- "near-o11y 1.38.0-rc.2",
+ "near-o11y 1.38.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 1.38.0-rc.2",
+ "near-primitives 1.38.0",
  "near-store",
  "num-rational 0.3.2",
  "once_cell",
@@ -4139,18 +4122,18 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more",
- "near-config-utils 1.38.0-rc.2",
- "near-crypto 1.38.0-rc.2",
- "near-o11y 1.38.0-rc.2",
- "near-parameters 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
+ "near-config-utils 1.38.0",
+ "near-crypto 1.38.0",
+ "near-o11y 1.38.0",
+ "near-parameters 1.38.0",
+ "near-primitives 1.38.0",
  "num-rational 0.3.2",
  "once_cell",
  "serde",
@@ -4162,20 +4145,20 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "chrono",
- "near-crypto 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
+ "near-crypto 1.38.0",
+ "near-primitives 1.38.0",
  "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "borsh 1.3.1",
@@ -4189,14 +4172,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 1.38.0-rc.2",
+ "near-crypto 1.38.0",
  "near-epoch-manager",
  "near-network",
- "near-o11y 1.38.0-rc.2",
+ "near-o11y 1.38.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 1.38.0-rc.2",
+ "near-primitives 1.38.0",
  "near-store",
  "once_cell",
  "rand 0.8.5",
@@ -4208,17 +4191,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 1.38.0-rc.2",
+ "near-primitives 1.38.0",
 ]
 
 [[package]]
 name = "near-client"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4237,16 +4220,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 1.38.0-rc.2",
+ "near-crypto 1.38.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
- "near-o11y 1.38.0-rc.2",
- "near-parameters 1.38.0-rc.2",
+ "near-o11y 1.38.0",
+ "near-parameters 1.38.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 1.38.0-rc.2",
+ "near-primitives 1.38.0",
  "near-store",
  "near-telemetry",
  "num-rational 0.3.2",
@@ -4271,16 +4254,16 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
+ "near-crypto 1.38.0",
+ "near-primitives 1.38.0",
  "serde",
  "serde_json",
  "strum 0.24.1",
@@ -4303,8 +4286,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4341,8 +4324,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "blake2",
  "borsh 1.3.1",
@@ -4353,8 +4336,8 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 1.38.0-rc.2",
- "near-stdx 1.38.0-rc.2",
+ "near-config-utils 1.38.0",
+ "near-stdx 1.38.0",
  "once_cell",
  "primitive-types 0.10.1",
  "rand 0.7.3",
@@ -4367,13 +4350,13 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "anyhow",
  "near-chain-configs",
- "near-o11y 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
+ "near-o11y 1.38.0",
+ "near-primitives 1.38.0",
  "once_cell",
  "prometheus",
  "serde",
@@ -4385,16 +4368,16 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "borsh 1.3.1",
  "itertools",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
+ "near-crypto 1.38.0",
+ "near-primitives 1.38.0",
  "near-store",
  "num-rational 0.3.2",
  "primitive-types 0.10.1",
@@ -4416,16 +4399,16 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
- "near-primitives-core 1.38.0-rc.2",
+ "near-primitives-core 1.38.0",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "anyhow",
@@ -4433,12 +4416,12 @@ dependencies = [
  "futures",
  "near-chain-configs",
  "near-client",
- "near-crypto 1.38.0-rc.2",
+ "near-crypto 1.38.0",
  "near-dyn-configs",
- "near-indexer-primitives 1.38.0-rc.2",
- "near-o11y 1.38.0-rc.2",
- "near-parameters 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
+ "near-indexer-primitives 1.38.0",
+ "near-o11y 1.38.0",
+ "near-parameters 1.38.0",
+ "near-primitives 1.38.0",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4463,18 +4446,18 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
- "near-primitives 1.38.0-rc.2",
+ "near-primitives 1.38.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4489,9 +4472,9 @@ dependencies = [
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
  "near-network",
- "near-o11y 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
- "near-rpc-error-macro 1.38.0-rc.2",
+ "near-o11y 1.38.0",
+ "near-primitives 1.38.0",
+ "near-rpc-error-macro 1.38.0",
  "once_cell",
  "serde",
  "serde_json",
@@ -4503,29 +4486,29 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 1.38.0-rc.2",
+ "near-primitives 1.38.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
- "near-rpc-error-macro 1.38.0-rc.2",
+ "near-crypto 1.38.0",
+ "near-primitives 1.38.0",
+ "near-rpc-error-macro 1.38.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -4558,19 +4541,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 1.38.0-rc.2",
+ "near-primitives 1.38.0",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "anyhow",
@@ -4589,12 +4572,12 @@ dependencies = [
  "itertools",
  "lru 0.7.8",
  "near-async",
- "near-crypto 1.38.0-rc.2",
- "near-fmt 1.38.0-rc.2",
- "near-o11y 1.38.0-rc.2",
+ "near-crypto 1.38.0",
+ "near-fmt 1.38.0",
+ "near-o11y 1.38.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 1.38.0-rc.2",
+ "near-primitives 1.38.0",
  "near-stable-hasher",
  "near-store",
  "once_cell",
@@ -4648,15 +4631,15 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 1.38.0-rc.2",
- "near-fmt 1.38.0-rc.2",
- "near-primitives-core 1.38.0-rc.2",
+ "near-crypto 1.38.0",
+ "near-fmt 1.38.0",
+ "near-primitives-core 1.38.0",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -4694,14 +4677,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "assert_matches",
  "borsh 1.3.1",
  "enum-map",
  "near-account-id",
- "near-primitives-core 1.38.0-rc.2",
+ "near-primitives-core 1.38.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -4712,8 +4695,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4729,8 +4712,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "quote",
  "syn 2.0.52",
@@ -4738,13 +4721,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "borsh 1.3.1",
- "near-crypto 1.38.0-rc.2",
- "near-o11y 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
+ "near-crypto 1.38.0",
+ "near-o11y 1.38.0",
+ "near-primitives 1.38.0",
  "once_cell",
  "rand 0.8.5",
 ]
@@ -4793,8 +4776,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4806,14 +4789,14 @@ dependencies = [
  "easy-ext",
  "enum-map",
  "hex",
- "near-crypto 1.38.0-rc.2",
- "near-fmt 1.38.0-rc.2",
- "near-o11y 1.38.0-rc.2",
- "near-parameters 1.38.0-rc.2",
- "near-primitives-core 1.38.0-rc.2",
- "near-rpc-error-macro 1.38.0-rc.2",
- "near-stdx 1.38.0-rc.2",
- "near-vm-runner 1.38.0-rc.2",
+ "near-crypto 1.38.0",
+ "near-fmt 1.38.0",
+ "near-o11y 1.38.0",
+ "near-parameters 1.38.0",
+ "near-primitives-core 1.38.0",
+ "near-rpc-error-macro 1.38.0",
+ "near-stdx 1.38.0",
+ "near-vm-runner 1.38.0",
  "num-rational 0.3.2",
  "once_cell",
  "primitive-types 0.10.1",
@@ -4856,8 +4839,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4877,8 +4860,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4892,11 +4875,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 1.38.0-rc.2",
+ "near-crypto 1.38.0",
  "near-network",
- "near-o11y 1.38.0-rc.2",
- "near-parameters 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
+ "near-o11y 1.38.0",
+ "near-parameters 1.38.0",
+ "near-primitives 1.38.0",
  "node-runtime",
  "paperclip",
  "serde",
@@ -4920,8 +4903,8 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "quote",
  "serde",
@@ -4942,19 +4925,19 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "fs2",
- "near-rpc-error-core 1.38.0-rc.2",
+ "near-rpc-error-core 1.38.0",
  "serde",
  "syn 2.0.52",
 ]
 
 [[package]]
 name = "near-stable-hasher"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 
 [[package]]
 name = "near-stdx"
@@ -4964,13 +4947,13 @@ checksum = "855fd5540e3b4ff6fedf12aba2db1ee4b371b36f465da1363a6d022b27cb43b8"
 
 [[package]]
 name = "near-stdx"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 
 [[package]]
 name = "near-store"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4987,13 +4970,13 @@ dependencies = [
  "itoa",
  "lru 0.7.8",
  "near-chain-configs",
- "near-crypto 1.38.0-rc.2",
- "near-fmt 1.38.0-rc.2",
- "near-o11y 1.38.0-rc.2",
- "near-parameters 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
- "near-stdx 1.38.0-rc.2",
- "near-vm-runner 1.38.0-rc.2",
+ "near-crypto 1.38.0",
+ "near-fmt 1.38.0",
+ "near-o11y 1.38.0",
+ "near-parameters 1.38.0",
+ "near-primitives 1.38.0",
+ "near-stdx 1.38.0",
+ "near-vm-runner 1.38.0",
  "num_cpus",
  "once_cell",
  "rand 0.8.5",
@@ -5011,16 +4994,16 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "awc",
  "futures",
- "near-o11y 1.38.0-rc.2",
+ "near-o11y 1.38.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 1.38.0-rc.2",
+ "near-primitives 1.38.0",
  "once_cell",
  "openssl",
  "serde",
@@ -5030,8 +5013,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5047,8 +5030,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5068,8 +5051,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5084,7 +5067,6 @@ dependencies = [
  "region",
  "rkyv",
  "rustc-demangle",
- "rustix 0.37.27",
  "target-lexicon 0.12.14",
  "thiserror",
  "tracing",
@@ -5122,8 +5104,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -5133,10 +5115,11 @@ dependencies = [
  "finite-wasm",
  "loupe",
  "memoffset 0.8.0",
- "near-crypto 1.38.0-rc.2",
- "near-parameters 1.38.0-rc.2",
- "near-primitives-core 1.38.0-rc.2",
- "near-stdx 1.38.0-rc.2",
+ "near-cache",
+ "near-crypto 1.38.0",
+ "near-parameters 1.38.0",
+ "near-primitives-core 1.38.0",
+ "near-stdx 1.38.0",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5173,8 +5156,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "indexmap 1.9.3",
  "num-traits",
@@ -5184,8 +5167,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "backtrace",
  "cc",
@@ -5206,17 +5189,17 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "anyhow",
- "near-vm-runner 1.38.0-rc.2",
+ "near-vm-runner 1.38.0",
 ]
 
 [[package]]
 name = "nearcore"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5239,23 +5222,23 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 1.38.0-rc.2",
- "near-crypto 1.38.0-rc.2",
+ "near-config-utils 1.38.0",
+ "near-crypto 1.38.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
  "near-jsonrpc-primitives",
  "near-mainnet-res",
  "near-network",
- "near-o11y 1.38.0-rc.2",
- "near-parameters 1.38.0-rc.2",
+ "near-o11y 1.38.0",
+ "near-parameters 1.38.0",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 1.38.0-rc.2",
+ "near-primitives 1.38.0",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
- "near-vm-runner 1.38.0-rc.2",
+ "near-vm-runner 1.38.0",
  "node-runtime",
  "num-rational 0.3.2",
  "once_cell",
@@ -5304,19 +5287,19 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.38.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=1.38.0-rc.2#78122a669b8711343f9869e222c82ef969c54e03"
+version = "1.38.0"
+source = "git+https://github.com/near/nearcore?tag=1.38.0#aac5e42fe8975e27faca53e31f53f9c67a5b4e35"
 dependencies = [
  "borsh 1.3.1",
  "hex",
  "near-chain-configs",
- "near-crypto 1.38.0-rc.2",
- "near-o11y 1.38.0-rc.2",
- "near-parameters 1.38.0-rc.2",
- "near-primitives 1.38.0-rc.2",
- "near-primitives-core 1.38.0-rc.2",
+ "near-crypto 1.38.0",
+ "near-o11y 1.38.0",
+ "near-parameters 1.38.0",
+ "near-primitives 1.38.0",
+ "near-primitives-core 1.38.0",
  "near-store",
- "near-vm-runner 1.38.0-rc.2",
+ "near-vm-runner 1.38.0",
  "near-wallet-contract",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -6803,20 +6786,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno 0.3.8",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
@@ -6824,7 +6793,7 @@ dependencies = [
  "bitflags 2.4.2",
  "errno 0.3.8",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -7584,7 +7553,7 @@ checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "rustix 0.38.31",
+ "rustix",
  "windows-sys 0.52.0",
 ]
 
@@ -8777,7 +8746,7 @@ dependencies = [
  "log",
  "object",
  "rustc-demangle",
- "rustix 0.38.31",
+ "rustix",
  "serde",
  "serde_derive",
  "target-lexicon 0.12.14",
@@ -8825,7 +8794,7 @@ dependencies = [
  "memoffset 0.9.0",
  "paste",
  "rand 0.8.5",
- "rustix 0.38.31",
+ "rustix",
  "sptr",
  "wasm-encoder 0.35.0",
  "wasmtime-asm-macros",
@@ -8918,7 +8887,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.31",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.28.0-rc.2"
+version = "0.28.0+1.38.0"
 edition = "2021"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -37,9 +37,9 @@ hex = "0.4"
 impl-serde = "0.4"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "1.38.0-rc.2" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "1.38.0-rc.2" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "1.38.0-rc.2" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "1.38.0" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "1.38.0" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "1.38.0" }
 near-lake-framework = "0.7"
 prometheus = "0.13"
 rlp = "0.5"


### PR DESCRIPTION
In this PR I'm starting to use a new versioning schema for our borealis releases. We use semver standard to include both our `VERSION` and after + `NEARCORE_VERSION`. Tagging and realising will follow the same policy.

Nearcore version is represented by https://semver.org/#spec-item-10 (build information) extension.