### PR TITLE
chore: bump nearcore to 2.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -24,7 +24,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
 ]
 
 [[package]]
@@ -33,14 +33,14 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "futures-core",
  "futures-sink",
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
 ]
 
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb9843d84c775696c37d9a418bbb01b932629d01870722c0f13eb3f95e2536d"
+checksum = "3ae682f693a9cd7b058f2b0b5d9a6d7728a8555779bedbbc35dd88528611d020"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -71,7 +71,7 @@ dependencies = [
  "actix-utils",
  "ahash 0.8.11",
  "base64 0.22.1",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "brotli",
  "bytes",
  "bytestring",
@@ -93,7 +93,7 @@ dependencies = [
  "sha1",
  "smallvec",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
  "zstd",
 ]
@@ -105,7 +105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -179,7 +179,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-openssl",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
 ]
 
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.7.0"
+version = "4.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6316df3fa569627c98b12557a8b6ff0674e5be4bb9b5e4ae2550ddb4964ed6"
+checksum = "1988c02af8d2b718c05bc4aeb6a66395b7cdf32858c2c71131e5637a8c05a9ff"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -243,7 +243,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -254,7 +254,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -463,18 +463,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.28.2+2.0.0-rc.1"
+version = "0.28.2-2.0.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.28.2+2.0.0-rc.1"
+version = "0.28.2-2.0.0-rc.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.28.2+2.0.0-rc.1"
+version = "0.28.2-2.0.0-rc.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -666,12 +666,13 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.28.2+2.0.0-rc.1"
+version = "0.28.2-2.0.0-rc.1"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
  "aurora-engine-transactions",
  "aurora-engine-types",
+ "borsh 1.5.1",
  "derive_builder 0.20.0",
  "fixed-hash 0.8.0",
  "impl-serde 0.4.0",
@@ -684,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.28.2+2.0.0-rc.1"
+version = "0.28.2-2.0.0-rc.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -714,7 +715,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -759,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.5.1"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac9889352d632214df943e26740c46a0f3da6e329fbd28164fe7ae1b061da7b"
+checksum = "caf6cfe2881cb1fcbba9ae946fb9a6480d3b7a714ca84c74925014a89ef3387a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -827,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75588e7ee5e8496eed939adac2035a6dbab9f7eb2acdd9ab2d31856dab6f3955"
+checksum = "87c5f920ffd1e0526ec9e70e50bf444db50b204395a0fa7016bbf9e31ea1698f"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -851,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.34.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724119d8fd2d2638b9979673f3b5c2979fa388c9ca27815e3cb5ad6234fac3f5"
+checksum = "8367c403fdf27690684b926a46ed9524099a69dd5dfcef62028bf4096b5b809f"
 dependencies = [
  "ahash 0.8.11",
  "aws-credential-types",
@@ -886,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.29.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da75cf91cbb46686a27436d639a720a3a198b148efa76dc2467b7e5374a67fc0"
+checksum = "cdcfae7bf8b8f14cade7579ffa8956fcee91dc23633671096b4b5de7d16f682a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -908,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.30.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ec8a6687299685ed0a4a3137c129cdb132b5235bc3aa3443f6cffe468b9ff"
+checksum = "33b30def8f02ba81276d5dbc22e7bf3bed20d62d1b175eef82680d6bdc7a6f4c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -930,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.29.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f1031e094b1411b59b49b19e4118f069e1fe13a9c5b8888e933daaf7ffdd6"
+checksum = "0804f840ad31537d5d1a4ec48d59de5e674ad05f1db7d3def2c9acadaf1f7e60"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -953,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31eed8d45759b2c5fe7fd304dd70739060e9e0de509209036eabea14d0720cce"
+checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -993,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.9"
+version = "0.60.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6242d6a54d3b4b83458f4abd7057ba93c4419dc71e8217e9acd3a748d656d99e"
+checksum = "48c4134cf3adaeacff34d588dbe814200357b0c466d730cf1c0d8054384a2de4"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -1025,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.8"
+version = "0.60.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7de001a1b9a25601016d8057ea16e31a45fdca3751304c8edf4ad72e706c08"
+checksum = "d9cd0ae3d97daa0a2bf377a4d8e8e1362cae590c4a1aad0d40058ebca18eb91e"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -1065,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.5.5"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d3965f6417a92a6d1009c5958a67042f57e46342afb37ca58f9ad26744ec73"
+checksum = "3df4217d39fe940066174e6238310167bf466bfbebf3be0661e53cacccde6313"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1079,6 +1080,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.0",
+ "httparse",
  "hyper",
  "hyper-rustls",
  "once_cell",
@@ -1091,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.6.3"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6dbabc7629fab4e4467f95f119c2e1a9b00b44c893affa98e23b040a0e2567"
+checksum = "30819352ed0a04ecf6a2f3477e344d2d1ba33d43e0f09ad9047c12e0d923616f"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -1129,7 +1131,7 @@ dependencies = [
  "serde",
  "time",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1143,15 +1145,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f734808d43702a67e57d478a12e227d4d038d0b90c9005a78c87890d3805922"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 0.2.12",
  "rustc_version 0.4.0",
  "tracing",
 ]
@@ -1203,16 +1204,16 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line 0.22.0",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.35.0",
+ "object 0.36.1",
  "rustc-demangle",
 ]
 
@@ -1289,7 +1290,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1300,9 +1301,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitmaps"
@@ -1333,17 +1334,6 @@ dependencies = [
  "radium 0.7.0",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "blake2"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -1441,7 +1431,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
  "syn_derive",
 ]
 
@@ -1596,20 +1586,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "c2-chacha"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27dae93fe7b1e0424dc57179ac396908c26b035a87234809f5c4dfd1b47dc80"
-dependencies = [
- "cipher",
- "ppv-lite86",
-]
-
-[[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "eaff6f8ce506b9773fa786672d63fc7a191ffea1be33f72bbd4aeacefca9ffc8"
 dependencies = [
  "jobserver",
  "libc",
@@ -1655,16 +1635,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "cipher"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
-dependencies = [
- "generic-array 0.14.7",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1680,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1690,9 +1661,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1702,14 +1673,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1859,7 +1830,7 @@ dependencies = [
  "log",
  "regalloc2",
  "smallvec",
- "target-lexicon 0.12.14",
+ "target-lexicon 0.12.15",
 ]
 
 [[package]]
@@ -1905,7 +1876,7 @@ dependencies = [
  "cranelift-codegen",
  "log",
  "smallvec",
- "target-lexicon 0.12.14",
+ "target-lexicon 0.12.15",
 ]
 
 [[package]]
@@ -1922,7 +1893,7 @@ checksum = "f32e81605f352cf37af5463f11cd7deec7b6572741931a8d372f7fdd4a744f5d"
 dependencies = [
  "cranelift-codegen",
  "libc",
- "target-lexicon 0.12.14",
+ "target-lexicon 0.12.15",
 ]
 
 [[package]]
@@ -1958,9 +1929,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
  "rustc_version 0.4.0",
 ]
@@ -2080,16 +2051,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms",
  "rand_core 0.6.4",
  "rustc_version 0.4.0",
  "subtle",
@@ -2104,7 +2074,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2119,12 +2089,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core 0.20.9",
- "darling_macro 0.20.9",
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -2143,16 +2113,16 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2168,13 +2138,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core 0.20.9",
+ "darling_core 0.20.10",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2214,7 +2184,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2225,7 +2195,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2264,10 +2234,10 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
 dependencies = [
- "darling 0.20.9",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2287,20 +2257,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core 0.20.0",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 1.0.109",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2350,17 +2320,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -2476,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -2532,7 +2491,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
- "strum 0.26.2",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -2566,7 +2525,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2584,10 +2543,10 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
- "darling 0.20.9",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2861,12 +2820,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,16 +2857,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -2993,7 +2936,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -3041,7 +2984,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "debugid",
  "fxhash",
  "serde",
@@ -3138,7 +3081,7 @@ dependencies = [
  "indexmap 2.2.6",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
 ]
 
@@ -3198,15 +3141,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -3333,9 +3267,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.2"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3935c160d00ac752e09787e6e6bfc26494c2183cc922f1bc678a60d4733bc2"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -3345,9 +3279,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3432,124 +3366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3557,14 +3373,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
- "smallvec",
- "utf8_iter",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -3798,11 +3612,11 @@ checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3825,12 +3639,12 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3845,7 +3659,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -3932,12 +3746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
-name = "litemap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
-
-[[package]]
 name = "local-channel"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3975,9 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
@@ -4059,7 +3867,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -4080,9 +3888,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memfd"
@@ -4153,9 +3961,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
@@ -4178,9 +3986,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -4202,12 +4010,6 @@ name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
-
-[[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
@@ -4245,9 +4047,9 @@ dependencies = [
  "derive_more",
  "futures",
  "near-async-derive",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-performance-metrics",
- "near-time",
+ "near-time 2.0.0-rc.1",
  "once_cell",
  "serde",
  "serde_json",
@@ -4263,7 +4065,7 @@ source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c5
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -4299,14 +4101,14 @@ dependencies = [
  "near-epoch-manager",
  "near-mainnet-res",
  "near-network",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-parameters 2.0.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
  "near-primitives 2.0.0-rc.1",
  "near-store",
- "near-vm-runner 2.0.0-rc.1",
+ "near-vm-runner",
  "node-runtime",
  "num-rational 0.3.2",
  "once_cell",
@@ -4333,7 +4135,7 @@ dependencies = [
  "near-async",
  "near-config-utils 2.0.0-rc.1",
  "near-crypto 2.0.0-rc.1",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-parameters 2.0.0-rc.1",
  "near-primitives 2.0.0-rc.1",
  "num-rational 0.3.2",
@@ -4378,7 +4180,7 @@ dependencies = [
  "near-crypto 2.0.0-rc.1",
  "near-epoch-manager",
  "near-network",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
@@ -4429,7 +4231,7 @@ dependencies = [
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-parameters 2.0.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
@@ -4437,7 +4239,7 @@ dependencies = [
  "near-primitives 2.0.0-rc.1",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.0.0-rc.1",
+ "near-vm-runner",
  "num-rational 0.3.2",
  "once_cell",
  "percent-encoding",
@@ -4483,9 +4285,9 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1eaab1d545a9be7a55b6ef09f365c2017f93a03063547591d12c0c6d27e58"
+checksum = "43b3db4ac2d4340caef06b6363c3fd16c0be1f70267908dfa53e2e6241649b0c"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4506,24 +4308,22 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2991d2912218a80ec0733ac87f84fa803accea105611eea209d4419271957667"
+checksum = "b9807fb257f7dda41383bb33e14cfd4a8840ffa7932cb972db9eabff19ce3bf4"
 dependencies = [
- "blake2 0.9.2",
+ "blake2",
  "borsh 1.5.1",
  "bs58 0.4.0",
- "c2-chacha",
  "curve25519-dalek",
  "derive_more",
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 0.20.1",
- "near-stdx 0.20.1",
+ "near-config-utils 0.23.0",
+ "near-stdx 0.23.0",
  "once_cell",
  "primitive-types 0.10.1",
- "rand 0.7.3",
  "secp256k1",
  "serde",
  "serde_json",
@@ -4536,7 +4336,7 @@ name = "near-crypto"
 version = "2.0.0-rc.1"
 source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
- "blake2 0.10.6",
+ "blake2",
  "borsh 1.5.1",
  "bs58 0.4.0",
  "curve25519-dalek",
@@ -4564,7 +4364,7 @@ dependencies = [
  "near-async",
  "near-chain-configs",
  "near-crypto 2.0.0-rc.1",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-primitives 2.0.0-rc.1",
  "once_cell",
  "prometheus",
@@ -4586,7 +4386,7 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-crypto 2.0.0-rc.1",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-primitives 2.0.0-rc.1",
  "near-store",
  "num-rational 0.3.2",
@@ -4601,11 +4401,11 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d998dfc1e04001608899b2498ad5a782c7d036b73769d510de21964db99286"
+checksum = "00ce363e4078b870775e2a5a5189feae22f0870ca673f6409b1974922dada0c4"
 dependencies = [
- "near-primitives-core 0.20.1",
+ "near-primitives-core 0.23.0",
 ]
 
 [[package]]
@@ -4630,7 +4430,7 @@ dependencies = [
  "near-crypto 2.0.0-rc.1",
  "near-dyn-configs",
  "near-indexer-primitives 2.0.0-rc.1",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-parameters 2.0.0-rc.1",
  "near-primitives 2.0.0-rc.1",
  "near-store",
@@ -4646,11 +4446,11 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362042db6d020aba9ac03dadf32088f848cc2156c9a7976d45a2a9cf6b18548e"
+checksum = "ca85c74772338d1b8c8b8729ffa14dec44dacefa2ce367795f3de8846f2fdc06"
 dependencies = [
- "near-primitives 0.20.1",
+ "near-primitives 0.23.0",
  "serde",
  "serde_json",
 ]
@@ -4685,7 +4485,7 @@ dependencies = [
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
  "near-network",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-primitives 2.0.0-rc.1",
  "near-rpc-error-macro 2.0.0-rc.1",
  "once_cell",
@@ -4730,9 +4530,9 @@ dependencies = [
 
 [[package]]
 name = "near-lake-framework"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ba9f13f373f60bfc2016ee70a52d4c5e7ec65dd2e7ea641a97770d9faa144f"
+checksum = "0cf514c5d43ac5e0309b80545583a35c09a5cf19f77894241e755e0223a8c50c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4744,7 +4544,7 @@ dependencies = [
  "aws-types",
  "derive_builder 0.13.1",
  "futures",
- "near-indexer-primitives 0.20.1",
+ "near-indexer-primitives 0.23.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -4788,16 +4588,16 @@ dependencies = [
  "near-chain-configs",
  "near-crypto 2.0.0-rc.1",
  "near-fmt 2.0.0-rc.1",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-primitives 2.0.0-rc.1",
  "near-store",
  "once_cell",
- "opentelemetry 0.22.0",
+ "opentelemetry",
  "parking_lot 0.12.3",
  "pin-project",
- "protobuf 3.4.0",
+ "protobuf 3.5.0",
  "protobuf-codegen",
  "rand 0.8.5",
  "rayon",
@@ -4811,36 +4611,8 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "near-o11y"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20762631bc8253030013bbae9b5f0542691edc1aa6722f1e8141cc9b928ae5b"
-dependencies = [
- "actix",
- "base64 0.21.7",
- "clap",
- "near-crypto 0.20.1",
- "near-fmt 0.20.1",
- "near-primitives-core 0.20.1",
- "once_cell",
- "opentelemetry 0.17.0",
- "opentelemetry-otlp 0.10.0",
- "opentelemetry-semantic-conventions 0.9.0",
- "prometheus",
- "serde",
- "serde_json",
- "strum 0.24.1",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-appender",
- "tracing-opentelemetry 0.17.4",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -4854,9 +4626,9 @@ dependencies = [
  "near-crypto 2.0.0-rc.1",
  "near-primitives-core 2.0.0-rc.1",
  "once_cell",
- "opentelemetry 0.22.0",
- "opentelemetry-otlp 0.15.0",
- "opentelemetry-semantic-conventions 0.14.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prometheus",
  "serde",
@@ -4865,21 +4637,20 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
- "tracing-opentelemetry 0.23.0",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "near-parameters"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f16a59b6c3e69b0585be951af6fe42a0ba86c0e207cb8c63badd19efd16680"
+checksum = "fddf39f5f729976a791d86e0e30a71ec4d8e8dcf58117c8694e7b22fb3f50ee6"
 dependencies = [
- "assert_matches",
  "borsh 1.5.1",
  "enum-map",
  "near-account-id",
- "near-primitives-core 0.20.1",
+ "near-primitives-core 0.23.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -4917,7 +4688,7 @@ dependencies = [
  "libc",
  "once_cell",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
 ]
 
@@ -4927,7 +4698,7 @@ version = "2.0.0-rc.1"
 source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -4937,7 +4708,7 @@ source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c5
 dependencies = [
  "borsh 1.5.1",
  "near-crypto 2.0.0-rc.1",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-primitives 2.0.0-rc.1",
  "once_cell",
  "rand 0.8.5",
@@ -4945,13 +4716,14 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0462b067732132babcc89d5577db3bfcb0a1bcfbaaed3f2db4c11cd033666314"
+checksum = "d58c175262923db9885ed0347e96ec3bcbec57825e3b6d7de03da220f5e14ef5"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
  "borsh 1.5.1",
+ "bytes",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
@@ -4959,14 +4731,14 @@ dependencies = [
  "easy-ext",
  "enum-map",
  "hex",
- "near-crypto 0.20.1",
- "near-fmt 0.20.1",
- "near-o11y 0.20.1",
- "near-parameters 0.20.1",
- "near-primitives-core 0.20.1",
- "near-rpc-error-macro 0.20.1",
- "near-stdx 0.20.1",
- "near-vm-runner 0.20.1",
+ "itertools 0.10.5",
+ "near-crypto 0.23.0",
+ "near-fmt 0.23.0",
+ "near-parameters 0.23.0",
+ "near-primitives-core 0.23.0",
+ "near-rpc-error-macro 0.23.0",
+ "near-stdx 0.23.0",
+ "near-time 0.23.0",
  "num-rational 0.3.2",
  "once_cell",
  "primitive-types 0.10.1",
@@ -4976,13 +4748,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml",
  "sha3",
  "smart-default",
  "strum 0.24.1",
  "thiserror",
- "time",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -5007,8 +4778,8 @@ dependencies = [
  "near-primitives-core 2.0.0-rc.1",
  "near-rpc-error-macro 2.0.0-rc.1",
  "near-stdx 2.0.0-rc.1",
- "near-time",
- "near-vm-runner 2.0.0-rc.1",
+ "near-time 2.0.0-rc.1",
+ "near-vm-runner",
  "num-rational 0.3.2",
  "once_cell",
  "ordered-float",
@@ -5029,9 +4800,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8443eb718606f572c438be6321a097a8ebd69f8e48d953885b4f16601af88225"
+checksum = "45de00d413f5bb890a3912f32fcd0974b2b0a975cc7874012e2c4c4fa7f28917"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5043,9 +4814,7 @@ dependencies = [
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
- "serde_with",
  "sha2 0.10.8",
- "strum 0.24.1",
  "thiserror",
 ]
 
@@ -5087,7 +4856,7 @@ dependencies = [
  "near-client-primitives",
  "near-crypto 2.0.0-rc.1",
  "near-network",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-parameters 2.0.0-rc.1",
  "near-primitives 2.0.0-rc.1",
  "node-runtime",
@@ -5101,13 +4870,13 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fca203c51edd9595ec14db1d13359fb9ede32314990bf296b6c5c4502f6ab7"
+checksum = "cf41b149dcc1f5a35d6a96fbcd8c28c92625c05b52025a72ee7378c72bcd68ce"
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -5117,19 +4886,18 @@ source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c5
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897a445de2102f6732c8a185d922f5e3bf7fd0a41243ce40854df2197237f799"
+checksum = "73c7f0f12f426792dd2c9d83df43d73c3b15d80f6e99e8d0e16ff3e024d0f9ba"
 dependencies = [
- "fs2",
- "near-rpc-error-core 0.20.1",
+ "near-rpc-error-core 0.23.0",
  "serde",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -5139,14 +4907,14 @@ source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c5
 dependencies = [
  "near-rpc-error-core 2.0.0-rc.1",
  "serde",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "near-stdx"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855fd5540e3b4ff6fedf12aba2db1ee4b371b36f465da1363a6d022b27cb43b8"
+checksum = "29e1897481272eb144328abd51ca9f59b5b558e7a6dc6e2177c8c9bb18fbd818"
 
 [[package]]
 name = "near-stdx"
@@ -5175,11 +4943,11 @@ dependencies = [
  "near-chain-configs",
  "near-crypto 2.0.0-rc.1",
  "near-fmt 2.0.0-rc.1",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-parameters 2.0.0-rc.1",
  "near-primitives 2.0.0-rc.1",
  "near-stdx 2.0.0-rc.1",
- "near-vm-runner 2.0.0-rc.1",
+ "near-vm-runner",
  "num_cpus",
  "once_cell",
  "rand 0.8.5",
@@ -5206,7 +4974,7 @@ dependencies = [
  "awc",
  "futures",
  "near-async",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "once_cell",
@@ -5214,6 +4982,18 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+]
+
+[[package]]
+name = "near-time"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56db32f26b089441c1a7c5451f0d68637afa9d66f6d8f6a6f2d6c2f7953520a"
+dependencies = [
+ "once_cell",
+ "serde",
+ "time",
+ "tokio",
 ]
 
 [[package]]
@@ -5237,7 +5017,7 @@ dependencies = [
  "near-vm-types",
  "near-vm-vm",
  "rkyv",
- "target-lexicon 0.12.14",
+ "target-lexicon 0.12.15",
  "thiserror",
  "tracing",
  "wasmparser 0.99.0",
@@ -5282,39 +5062,9 @@ dependencies = [
  "rkyv",
  "rustc-demangle",
  "rustix",
- "target-lexicon 0.12.14",
+ "target-lexicon 0.12.15",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "near-vm-runner"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56c80bdb1954808f59bd36a9112377197b38d424991383bf05f52d0fe2e0da5"
-dependencies = [
- "base64 0.21.7",
- "borsh 1.5.1",
- "ed25519-dalek",
- "enum-map",
- "memoffset 0.8.0",
- "near-crypto 0.20.1",
- "near-parameters 0.20.1",
- "near-primitives-core 0.20.1",
- "near-stdx 0.20.1",
- "num-rational 0.3.2",
- "once_cell",
- "prefix-sum-vec",
- "ripemd",
- "serde",
- "serde_repr",
- "serde_with",
- "sha2 0.10.8",
- "sha3",
- "strum 0.24.1",
- "thiserror",
- "tracing",
- "zeropool-bn",
 ]
 
 [[package]]
@@ -5331,7 +5081,7 @@ dependencies = [
  "lru 0.7.8",
  "memoffset 0.8.0",
  "near-crypto 2.0.0-rc.1",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-parameters 2.0.0-rc.1",
  "near-primitives-core 2.0.0-rc.1",
  "near-stdx 2.0.0-rc.1",
@@ -5410,7 +5160,7 @@ source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c5
 dependencies = [
  "anyhow",
  "near-primitives-core 2.0.0-rc.1",
- "near-vm-runner 2.0.0-rc.1",
+ "near-vm-runner",
 ]
 
 [[package]]
@@ -5448,7 +5198,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-mainnet-res",
  "near-network",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-parameters 2.0.0-rc.1",
  "near-performance-metrics",
  "near-pool",
@@ -5456,7 +5206,7 @@ dependencies = [
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.0.0-rc.1",
+ "near-vm-runner",
  "node-runtime",
  "num-rational 0.3.2",
  "once_cell",
@@ -5510,12 +5260,12 @@ source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c5
 dependencies = [
  "borsh 1.5.1",
  "near-crypto 2.0.0-rc.1",
- "near-o11y 2.0.0-rc.1",
+ "near-o11y",
  "near-parameters 2.0.0-rc.1",
  "near-primitives 2.0.0-rc.1",
  "near-primitives-core 2.0.0-rc.1",
  "near-store",
- "near-vm-runner 2.0.0-rc.1",
+ "near-vm-runner",
  "near-wallet-contract",
  "num-bigint 0.3.3",
  "num-traits",
@@ -5563,7 +5313,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -5595,9 +5345,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -5657,7 +5407,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -5701,9 +5451,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -5726,7 +5476,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -5743,7 +5493,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -5776,27 +5526,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "js-sys",
- "lazy_static",
- "percent-encoding",
- "pin-project",
- "rand 0.8.5",
- "thiserror",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
@@ -5812,24 +5541,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
-dependencies = [
- "async-trait",
- "futures",
- "futures-util",
- "http 0.2.12",
- "opentelemetry 0.17.0",
- "prost 0.9.0",
- "thiserror",
- "tokio",
- "tonic 0.6.2",
- "tonic-build",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
@@ -5837,14 +5548,14 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http 0.2.12",
- "opentelemetry 0.22.0",
+ "opentelemetry",
  "opentelemetry-proto",
- "opentelemetry-semantic-conventions 0.14.0",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "prost 0.12.6",
+ "prost",
  "thiserror",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -5853,19 +5564,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
 dependencies = [
- "opentelemetry 0.22.0",
+ "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.12.6",
- "tonic 0.11.0",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
-dependencies = [
- "opentelemetry 0.17.0",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -5887,7 +5589,7 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.22.0",
+ "opentelemetry",
  "ordered-float",
  "percent-encoding",
  "rand 0.8.5",
@@ -5898,9 +5600,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
 dependencies = [
  "borsh 1.5.1",
  "num-traits",
@@ -6141,9 +5843,9 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.2",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6174,16 +5876,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.2.6",
-]
 
 [[package]]
 name = "phf"
@@ -6220,7 +5912,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -6259,12 +5951,6 @@ checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
 dependencies = [
  "crunchy",
 ]
-
-[[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "postgres"
@@ -6334,7 +6020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -6418,9 +6104,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -6442,55 +6128,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
-dependencies = [
- "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
-dependencies = [
- "bytes",
- "heck 0.3.3",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost 0.9.0",
- "prost-types",
- "regex",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "prost-derive",
 ]
 
 [[package]]
@@ -6503,17 +6146,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
-dependencies = [
- "bytes",
- "prost 0.9.0",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -6524,9 +6157,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58678a64de2fced2bdec6bca052a6716a0efe692d6e3f53d1bda6a1def64cfc0"
+checksum = "df67496db1a89596beaced1579212e9b7c53c22dca1d9745de00ead76573d514"
 dependencies = [
  "once_cell",
  "protobuf-support",
@@ -6535,13 +6168,13 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32777b0b3f6538d9d2e012b3fad85c7e4b9244b5958d04a6415f4333782b7a77"
+checksum = "eab09155fad2d39333d3796f67845d43e29b266eea74f7bc93f153f707f126dc"
 dependencies = [
  "anyhow",
  "once_cell",
- "protobuf 3.4.0",
+ "protobuf 3.5.0",
  "protobuf-parse",
  "regex",
  "tempfile",
@@ -6550,14 +6183,14 @@ dependencies = [
 
 [[package]]
 name = "protobuf-parse"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cb37955261126624a25b5e6bda40ae34cf3989d52a783087ca6091b29b5642"
+checksum = "1a16027030d4ec33e423385f73bb559821827e9ec18c50e7874e4d6de5a4e96f"
 dependencies = [
  "anyhow",
- "indexmap 1.9.3",
+ "indexmap 2.2.6",
  "log",
- "protobuf 3.4.0",
+ "protobuf 3.5.0",
  "protobuf-support",
  "tempfile",
  "thiserror",
@@ -6566,9 +6199,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ed294a835b0f30810e13616b1cd34943c6d1e84a8f3b0dcfe466d256c3e7e7"
+checksum = "70e2d30ab1878b2e72d1e2fc23ff5517799c9929e2cf81a8516f9f4dcf2b9cf3"
 dependencies = [
  "thiserror",
 ]
@@ -6771,11 +6404,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -6927,7 +6560,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -7150,7 +6783,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno 0.3.9",
  "libc",
  "linux-raw-sys",
@@ -7324,7 +6957,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -7364,9 +6997,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -7395,22 +7028,22 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -7424,9 +7057,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -7441,7 +7074,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -7467,9 +7100,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.8.1"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+checksum = "e73139bc5ec2d45e6c5fd85be5a46949c1c39a4c18e56915f5eb4c12f975e377"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7485,14 +7118,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.1"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+checksum = "b80d3d6b56b64335c0180e5ffde23b3c5e08c14c585b51a15bd0e95393f46703"
 dependencies = [
- "darling 0.20.9",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -7762,9 +7395,9 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros 0.26.4",
 ]
@@ -7792,7 +7425,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -7805,7 +7438,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -7829,9 +7462,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -7846,9 +7479,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7864,7 +7497,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -7872,17 +7505,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
 
 [[package]]
 name = "sysinfo"
@@ -7934,9 +7556,9 @@ checksum = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
 
 [[package]]
 name = "tempfile"
@@ -7967,7 +7589,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -8040,20 +7662,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -8101,7 +7713,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -8148,7 +7760,7 @@ dependencies = [
  "rand 0.8.5",
  "socket2",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "whoami",
 ]
 
@@ -8169,20 +7781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
 ]
@@ -8218,7 +7816,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.14",
+ "toml_edit 0.22.15",
 ]
 
 [[package]]
@@ -8243,46 +7841,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.14"
+version = "0.22.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow 0.6.13",
-]
-
-[[package]]
-name = "tonic"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
-dependencies = [
- "async-stream",
- "async-trait",
- "base64 0.13.1",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.9.0",
- "prost-derive 0.9.0",
- "tokio",
- "tokio-stream",
- "tokio-util 0.6.10",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -8303,25 +7870,13 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.6",
+ "prost",
  "tokio",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
-dependencies = [
- "proc-macro2",
- "prost-build",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -8338,7 +7893,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -8388,7 +7943,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -8399,27 +7954,6 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -8435,32 +7969,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
-dependencies = [
- "once_cell",
- "opentelemetry 0.17.0",
- "tracing",
- "tracing-core",
- "tracing-log 0.1.4",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.22.0",
+ "opentelemetry",
  "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
@@ -8480,7 +8000,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
 ]
 
 [[package]]
@@ -8586,12 +8106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8617,9 +8131,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -8633,18 +8147,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8652,9 +8154,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
 name = "valuable"
@@ -8755,7 +8257,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
  "wasm-bindgen-shared",
 ]
 
@@ -8789,7 +8291,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8840,7 +8342,7 @@ dependencies = [
  "enumset",
  "rkyv",
  "smallvec",
- "target-lexicon 0.12.14",
+ "target-lexicon 0.12.15",
  "thiserror",
  "wasmer-types-near",
  "wasmer-vm-near",
@@ -8878,7 +8380,7 @@ dependencies = [
  "memmap2",
  "more-asserts",
  "rustc-demangle",
- "target-lexicon 0.12.14",
+ "target-lexicon 0.12.15",
  "thiserror",
  "wasmer-compiler-near",
  "wasmer-types-near",
@@ -9072,7 +8574,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "target-lexicon 0.12.14",
+ "target-lexicon 0.12.15",
  "wasm-encoder 0.35.0",
  "wasmparser 0.115.0",
  "wasmtime-cranelift",
@@ -9108,7 +8610,7 @@ dependencies = [
  "gimli 0.28.1",
  "log",
  "object 0.32.2",
- "target-lexicon 0.12.14",
+ "target-lexicon 0.12.15",
  "thiserror",
  "wasmparser 0.115.0",
  "wasmtime-cranelift-shared",
@@ -9128,7 +8630,7 @@ dependencies = [
  "cranelift-native",
  "gimli 0.28.1",
  "object 0.32.2",
- "target-lexicon 0.12.14",
+ "target-lexicon 0.12.15",
  "wasmtime-environ",
 ]
 
@@ -9146,7 +8648,7 @@ dependencies = [
  "object 0.32.2",
  "serde",
  "serde_derive",
- "target-lexicon 0.12.14",
+ "target-lexicon 0.12.15",
  "thiserror",
  "wasmparser 0.115.0",
  "wasmtime-types",
@@ -9170,7 +8672,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_derive",
- "target-lexicon 0.12.14",
+ "target-lexicon 0.12.15",
  "wasmtime-environ",
  "wasmtime-jit-icache-coherence",
  "wasmtime-runtime",
@@ -9247,7 +8749,7 @@ checksum = "09b5575a75e711ca6c36bb9ad647c93541cdc8e34218031acba5da3f35919dd3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -9366,7 +8868,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9384,7 +8886,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9404,18 +8906,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -9426,9 +8928,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9438,9 +8940,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9450,15 +8952,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9468,9 +8970,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9480,9 +8982,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9492,9 +8994,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -9504,9 +9006,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -9535,18 +9037,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wyz"
@@ -9585,68 +9075,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
-name = "yoke"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "synstructure",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -9670,50 +9115,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "zstd"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.12+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.28.2+1.40.0"
+version = "0.28.2+2.0.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.28.2+1.40.0"
+version = "0.28.2+2.0.0-rc.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.28.2+1.40.0"
+version = "0.28.2+2.0.0-rc.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.28.2+1.40.0"
+version = "0.28.2+2.0.0-rc.1"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
@@ -675,8 +675,8 @@ dependencies = [
  "derive_builder 0.20.0",
  "fixed-hash 0.8.0",
  "impl-serde 0.4.0",
- "near-crypto 1.40.0",
- "near-primitives 1.40.0",
+ "near-crypto 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
  "serde",
  "serde_json",
  "sha3",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.28.2+1.40.0"
+version = "0.28.2+2.0.0-rc.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -1344,6 +1344,15 @@ dependencies = [
  "crypto-mac",
  "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2198,6 +2207,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,15 +2479,6 @@ name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
-
-[[package]]
-name = "elastic-array"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d63720ea2bc2e1b79f7aa044d9dc0b825f9ccb6930b32120f8fb9e873aa84bc"
-dependencies = [
- "heapsize",
-]
 
 [[package]]
 name = "elliptic-curve"
@@ -3190,15 +3201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heapsize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3686,6 +3688,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3821,6 +3832,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "windows-targets 0.52.5",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
@@ -4221,26 +4238,28 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "derive_more",
  "futures",
  "near-async-derive",
- "near-o11y 1.40.0",
+ "near-o11y 2.0.0-rc.1",
  "near-performance-metrics",
+ "near-time",
  "once_cell",
  "serde",
  "serde_json",
  "time",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "near-async-derive"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4249,16 +4268,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "lru 0.7.8",
 ]
 
 [[package]]
 name = "near-chain"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "assert_matches",
@@ -4276,18 +4295,18 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 1.40.0",
+ "near-crypto 2.0.0-rc.1",
  "near-epoch-manager",
  "near-mainnet-res",
  "near-network",
- "near-o11y 1.40.0",
- "near-parameters 1.40.0",
+ "near-o11y 2.0.0-rc.1",
+ "near-parameters 2.0.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 1.40.0",
+ "near-primitives 2.0.0-rc.1",
  "near-store",
- "near-vm-runner 1.40.0",
+ "near-vm-runner 2.0.0-rc.1",
  "node-runtime",
  "num-rational 0.3.2",
  "once_cell",
@@ -4297,25 +4316,26 @@ dependencies = [
  "strum 0.24.1",
  "tempfile",
  "thiserror",
+ "time",
  "tracing",
  "yansi",
 ]
 
 [[package]]
 name = "near-chain-configs"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more",
  "near-async",
- "near-config-utils 1.40.0",
- "near-crypto 1.40.0",
- "near-o11y 1.40.0",
- "near-parameters 1.40.0",
- "near-primitives 1.40.0",
+ "near-config-utils 2.0.0-rc.1",
+ "near-crypto 2.0.0-rc.1",
+ "near-o11y 2.0.0-rc.1",
+ "near-parameters 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
  "num-rational 0.3.2",
  "once_cell",
  "serde",
@@ -4328,12 +4348,12 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "near-async",
- "near-crypto 1.40.0",
- "near-primitives 1.40.0",
+ "near-crypto 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
  "thiserror",
  "time",
  "tracing",
@@ -4341,8 +4361,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "borsh 1.5.1",
@@ -4355,18 +4375,18 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 1.40.0",
+ "near-crypto 2.0.0-rc.1",
  "near-epoch-manager",
  "near-network",
- "near-o11y 1.40.0",
+ "near-o11y 2.0.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 1.40.0",
+ "near-primitives 2.0.0-rc.1",
  "near-store",
  "once_cell",
  "rand 0.8.5",
- "reed-solomon-erasure",
+ "reed-solomon-erasure 6.0.0",
  "strum 0.24.1",
  "time",
  "tracing",
@@ -4374,17 +4394,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 1.40.0",
+ "near-primitives 2.0.0-rc.1",
 ]
 
 [[package]]
 name = "near-client"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4405,25 +4425,25 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 1.40.0",
+ "near-crypto 2.0.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
- "near-o11y 1.40.0",
- "near-parameters 1.40.0",
+ "near-o11y 2.0.0-rc.1",
+ "near-parameters 2.0.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 1.40.0",
+ "near-primitives 2.0.0-rc.1",
  "near-store",
  "near-telemetry",
- "near-vm-runner 1.40.0",
+ "near-vm-runner 2.0.0-rc.1",
  "num-rational 0.3.2",
  "once_cell",
  "percent-encoding",
  "rand 0.8.5",
  "rayon",
- "reed-solomon-erasure",
+ "reed-solomon-erasure 6.0.0",
  "regex",
  "reqwest",
  "rust-s3",
@@ -4433,6 +4453,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "tracing",
  "yansi",
@@ -4440,8 +4461,8 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "chrono",
@@ -4449,8 +4470,8 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 1.40.0",
- "near-primitives 1.40.0",
+ "near-crypto 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
  "serde",
  "serde_json",
  "strum 0.24.1",
@@ -4474,8 +4495,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4489,7 +4510,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2991d2912218a80ec0733ac87f84fa803accea105611eea209d4419271957667"
 dependencies = [
- "blake2",
+ "blake2 0.9.2",
  "borsh 1.5.1",
  "bs58 0.4.0",
  "c2-chacha",
@@ -4512,10 +4533,10 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh 1.5.1",
  "bs58 0.4.0",
  "curve25519-dalek",
@@ -4523,8 +4544,8 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 1.40.0",
- "near-stdx 1.40.0",
+ "near-config-utils 2.0.0-rc.1",
+ "near-stdx 2.0.0-rc.1",
  "once_cell",
  "primitive-types 0.10.1",
  "secp256k1",
@@ -4536,14 +4557,15 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "anyhow",
  "near-async",
  "near-chain-configs",
- "near-o11y 1.40.0",
- "near-primitives 1.40.0",
+ "near-crypto 2.0.0-rc.1",
+ "near-o11y 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
  "once_cell",
  "prometheus",
  "serde",
@@ -4555,17 +4577,17 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "borsh 1.5.1",
  "itertools 0.10.5",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 1.40.0",
- "near-o11y 1.40.0",
- "near-primitives 1.40.0",
+ "near-crypto 2.0.0-rc.1",
+ "near-o11y 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
  "near-store",
  "num-rational 0.3.2",
  "once_cell",
@@ -4588,16 +4610,16 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
- "near-primitives-core 1.40.0",
+ "near-primitives-core 2.0.0-rc.1",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "anyhow",
@@ -4605,12 +4627,12 @@ dependencies = [
  "lazy_static",
  "near-chain-configs",
  "near-client",
- "near-crypto 1.40.0",
+ "near-crypto 2.0.0-rc.1",
  "near-dyn-configs",
- "near-indexer-primitives 1.40.0",
- "near-o11y 1.40.0",
- "near-parameters 1.40.0",
- "near-primitives 1.40.0",
+ "near-indexer-primitives 2.0.0-rc.1",
+ "near-o11y 2.0.0-rc.1",
+ "near-parameters 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4635,18 +4657,18 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
- "near-primitives 1.40.0",
+ "near-primitives 2.0.0-rc.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4663,9 +4685,9 @@ dependencies = [
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
  "near-network",
- "near-o11y 1.40.0",
- "near-primitives 1.40.0",
- "near-rpc-error-macro 1.40.0",
+ "near-o11y 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
+ "near-rpc-error-macro 2.0.0-rc.1",
  "once_cell",
  "serde",
  "serde_json",
@@ -4677,29 +4699,29 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 1.40.0",
+ "near-primitives 2.0.0-rc.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 1.40.0",
- "near-primitives 1.40.0",
- "near-rpc-error-macro 1.40.0",
+ "near-crypto 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
+ "near-rpc-error-macro 2.0.0-rc.1",
  "serde",
  "serde_json",
  "thiserror",
@@ -4733,19 +4755,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 1.40.0",
+ "near-primitives 2.0.0-rc.1",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "anyhow",
@@ -4763,12 +4785,13 @@ dependencies = [
  "itertools 0.10.5",
  "lru 0.7.8",
  "near-async",
- "near-crypto 1.40.0",
- "near-fmt 1.40.0",
- "near-o11y 1.40.0",
+ "near-chain-configs",
+ "near-crypto 2.0.0-rc.1",
+ "near-fmt 2.0.0-rc.1",
+ "near-o11y 2.0.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 1.40.0",
+ "near-primitives 2.0.0-rc.1",
  "near-store",
  "once_cell",
  "opentelemetry 0.22.0",
@@ -4778,6 +4801,7 @@ dependencies = [
  "protobuf-codegen",
  "rand 0.8.5",
  "rayon",
+ "reed-solomon-erasure 6.0.0",
  "serde",
  "sha2 0.10.8",
  "smart-default",
@@ -4821,14 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 1.40.0",
- "near-primitives-core 1.40.0",
+ "near-crypto 2.0.0-rc.1",
+ "near-primitives-core 2.0.0-rc.1",
  "once_cell",
  "opentelemetry 0.22.0",
  "opentelemetry-otlp 0.15.0",
@@ -4866,13 +4890,13 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "borsh 1.5.1",
  "enum-map",
  "near-account-id",
- "near-primitives-core 1.40.0",
+ "near-primitives-core 2.0.0-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -4883,8 +4907,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4899,8 +4923,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "quote",
  "syn 2.0.66",
@@ -4908,13 +4932,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "borsh 1.5.1",
- "near-crypto 1.40.0",
- "near-o11y 1.40.0",
- "near-primitives 1.40.0",
+ "near-crypto 2.0.0-rc.1",
+ "near-o11y 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
  "once_cell",
  "rand 0.8.5",
 ]
@@ -4948,7 +4972,7 @@ dependencies = [
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "reed-solomon-erasure",
+ "reed-solomon-erasure 4.0.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -4963,8 +4987,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4975,27 +4999,26 @@ dependencies = [
  "chrono",
  "derive_more",
  "easy-ext",
- "enum-map",
  "hex",
  "itertools 0.10.5",
- "near-async",
- "near-crypto 1.40.0",
- "near-fmt 1.40.0",
- "near-parameters 1.40.0",
- "near-primitives-core 1.40.0",
- "near-rpc-error-macro 1.40.0",
- "near-stdx 1.40.0",
- "near-vm-runner 1.40.0",
+ "near-crypto 2.0.0-rc.1",
+ "near-fmt 2.0.0-rc.1",
+ "near-parameters 2.0.0-rc.1",
+ "near-primitives-core 2.0.0-rc.1",
+ "near-rpc-error-macro 2.0.0-rc.1",
+ "near-stdx 2.0.0-rc.1",
+ "near-time",
+ "near-vm-runner 2.0.0-rc.1",
  "num-rational 0.3.2",
  "once_cell",
+ "ordered-float",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "reed-solomon-erasure",
+ "reed-solomon-erasure 6.0.0",
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml",
  "sha3",
  "smart-default",
  "strum 0.24.1",
@@ -5028,8 +5051,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5047,8 +5070,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5062,11 +5085,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 1.40.0",
+ "near-crypto 2.0.0-rc.1",
  "near-network",
- "near-o11y 1.40.0",
- "near-parameters 1.40.0",
- "near-primitives 1.40.0",
+ "near-o11y 2.0.0-rc.1",
+ "near-parameters 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5089,8 +5112,8 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "quote",
  "serde",
@@ -5111,10 +5134,10 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
- "near-rpc-error-core 1.40.0",
+ "near-rpc-error-core 2.0.0-rc.1",
  "serde",
  "syn 2.0.66",
 ]
@@ -5127,13 +5150,13 @@ checksum = "855fd5540e3b4ff6fedf12aba2db1ee4b371b36f465da1363a6d022b27cb43b8"
 
 [[package]]
 name = "near-stdx"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 
 [[package]]
 name = "near-store"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5141,8 +5164,8 @@ dependencies = [
  "borsh 1.5.1",
  "bytesize",
  "crossbeam",
+ "derive-where",
  "derive_more",
- "elastic-array",
  "enum-map",
  "hex",
  "itertools 0.10.5",
@@ -5150,21 +5173,23 @@ dependencies = [
  "lru 0.7.8",
  "near-async",
  "near-chain-configs",
- "near-crypto 1.40.0",
- "near-fmt 1.40.0",
- "near-o11y 1.40.0",
- "near-parameters 1.40.0",
- "near-primitives 1.40.0",
- "near-stdx 1.40.0",
- "near-vm-runner 1.40.0",
+ "near-crypto 2.0.0-rc.1",
+ "near-fmt 2.0.0-rc.1",
+ "near-o11y 2.0.0-rc.1",
+ "near-parameters 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
+ "near-stdx 2.0.0-rc.1",
+ "near-vm-runner 2.0.0-rc.1",
  "num_cpus",
  "once_cell",
  "rand 0.8.5",
  "rayon",
+ "reed-solomon-erasure 6.0.0",
  "rlimit",
  "rocksdb",
  "serde",
  "serde_json",
+ "smallvec",
  "strum 0.24.1",
  "tempfile",
  "thiserror",
@@ -5174,14 +5199,14 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "awc",
  "futures",
  "near-async",
- "near-o11y 1.40.0",
+ "near-o11y 2.0.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "once_cell",
@@ -5192,9 +5217,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-time"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
+dependencies = [
+ "once_cell",
+ "serde",
+ "time",
+ "tokio",
+]
+
+[[package]]
 name = "near-vm-compiler"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5209,8 +5245,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5230,8 +5266,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5283,21 +5319,22 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
  "borsh 1.5.1",
+ "bytesize",
  "ed25519-dalek",
  "enum-map",
  "finite-wasm",
- "lru 0.12.3",
+ "lru 0.7.8",
  "memoffset 0.8.0",
- "near-crypto 1.40.0",
- "near-parameters 1.40.0",
- "near-primitives-core 1.40.0",
- "near-stdx 1.40.0",
+ "near-crypto 2.0.0-rc.1",
+ "near-o11y 2.0.0-rc.1",
+ "near-parameters 2.0.0-rc.1",
+ "near-primitives-core 2.0.0-rc.1",
+ "near-stdx 2.0.0-rc.1",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5308,6 +5345,7 @@ dependencies = [
  "parity-wasm 0.41.0",
  "parity-wasm 0.42.2",
  "prefix-sum-vec",
+ "prometheus",
  "pwasm-utils",
  "ripemd",
  "rustix",
@@ -5335,8 +5373,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "indexmap 1.9.3",
  "num-traits",
@@ -5346,8 +5384,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "backtrace",
  "cc",
@@ -5367,18 +5405,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "anyhow",
- "near-primitives-core 1.40.0",
- "near-vm-runner 1.40.0",
+ "near-primitives-core 2.0.0-rc.1",
+ "near-vm-runner 2.0.0-rc.1",
 ]
 
 [[package]]
 name = "nearcore"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5402,23 +5440,23 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 1.40.0",
- "near-crypto 1.40.0",
+ "near-config-utils 2.0.0-rc.1",
+ "near-crypto 2.0.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
  "near-jsonrpc-primitives",
  "near-mainnet-res",
  "near-network",
- "near-o11y 1.40.0",
- "near-parameters 1.40.0",
+ "near-o11y 2.0.0-rc.1",
+ "near-parameters 2.0.0-rc.1",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 1.40.0",
+ "near-primitives 2.0.0-rc.1",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
- "near-vm-runner 1.40.0",
+ "near-vm-runner 2.0.0-rc.1",
  "node-runtime",
  "num-rational 0.3.2",
  "once_cell",
@@ -5467,27 +5505,23 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.40.0"
-source = "git+https://github.com/near/nearcore?tag=1.40.0#7dd0b5993577f592be15eb102e5a3da37be66271"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.0.0-rc.1#053726e31bb4eb73c572e07292943e59dbb11c4a"
 dependencies = [
  "borsh 1.5.1",
- "hex",
- "near-chain-configs",
- "near-crypto 1.40.0",
- "near-o11y 1.40.0",
- "near-parameters 1.40.0",
- "near-primitives 1.40.0",
- "near-primitives-core 1.40.0",
+ "near-crypto 2.0.0-rc.1",
+ "near-o11y 2.0.0-rc.1",
+ "near-parameters 2.0.0-rc.1",
+ "near-primitives 2.0.0-rc.1",
+ "near-primitives-core 2.0.0-rc.1",
  "near-store",
- "near-vm-runner 1.40.0",
+ "near-vm-runner 2.0.0-rc.1",
  "near-wallet-contract",
  "num-bigint 0.3.3",
- "num-rational 0.3.2",
  "num-traits",
  "once_cell",
  "rand 0.8.5",
  "rayon",
- "serde",
  "serde_json",
  "sha2 0.10.8",
  "thiserror",
@@ -5868,7 +5902,10 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
+ "borsh 1.5.1",
  "num-traits",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]
@@ -6049,6 +6086,17 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api 0.4.12",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
@@ -6067,6 +6115,20 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall 0.1.57",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
@@ -6594,6 +6656,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -6632,6 +6695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+ "serde",
 ]
 
 [[package]]
@@ -6689,6 +6753,15 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -6723,6 +6796,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "reed-solomon-erasure"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
+dependencies = [
+ "libm",
+ "lru 0.7.8",
+ "parking_lot 0.11.2",
+ "smallvec",
+ "spin 0.9.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.28.2+1.40.0"
+version = "0.28.2+2.0.0-rc.1"
 edition = "2021"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -37,9 +37,9 @@ hex = "0.4"
 impl-serde = "0.4"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "1.40.0" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "1.40.0" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "1.40.0" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.0.0-rc.1" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.0.0-rc.1" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.0.0-rc.1" }
 near-lake-framework = "0.7"
 prometheus = "0.13"
 rlp = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.28.2+2.0.0-rc.1"
+version = "0.28.2-2.0.0-rc.1"
 edition = "2021"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"

--- a/engine/src/tracing/alchemy/serialization.rs
+++ b/engine/src/tracing/alchemy/serialization.rs
@@ -4,7 +4,7 @@ use crate::tracing::alchemy::{
     AlchemySuicideType, AlchemyTraceTemplate,
 };
 use aurora_engine_types::{types::Address, H256, U256};
-use std::{borrow::Cow, str::FromStr, string::ToString};
+use std::{borrow::Cow, fmt, str::FromStr, string::ToString};
 
 pub const ALCHEMY_CREATE_TYPE_TAG: &str = "create";
 pub const ALCHEMY_SUICIDE_TYPE_TAG: &str = "suicide";
@@ -374,16 +374,18 @@ impl TryFrom<&Option<SerializableAlchemyTraceResult>> for AlchemyCallResult {
     }
 }
 
-impl ToString for AlchemyCallKind {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Call => ALCHEMY_CALL_KIND_CALL_TAG.into(),
-            Self::DelegateCall => ALCHEMY_CALL_KIND_DELEGATE_CALL_TAG.into(),
-            Self::CallCode => ALCHEMY_CALL_KIND_CALL_CODE_TAG.into(),
-            Self::StaticCall => ALCHEMY_CALL_KIND_STATIC_CALL_TAG.into(),
-        }
+impl fmt::Display for AlchemyCallKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Call => ALCHEMY_CALL_KIND_CALL_TAG,
+            Self::DelegateCall => ALCHEMY_CALL_KIND_DELEGATE_CALL_TAG,
+            Self::CallCode => ALCHEMY_CALL_KIND_CALL_CODE_TAG,
+            Self::StaticCall => ALCHEMY_CALL_KIND_STATIC_CALL_TAG,
+        };
+        write!(f, "{}", s)
     }
 }
+
 impl FromStr for AlchemyCallKind {
     type Err = anyhow::Error;
 
@@ -398,11 +400,12 @@ impl FromStr for AlchemyCallKind {
     }
 }
 
-impl ToString for AlchemyCreateType {
-    fn to_string(&self) -> String {
-        ALCHEMY_CREATE_TYPE_TAG.into()
+impl fmt::Display for AlchemyCreateType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", ALCHEMY_CREATE_TYPE_TAG)
     }
 }
+
 impl FromStr for AlchemyCreateType {
     type Err = anyhow::Error;
 
@@ -418,11 +421,12 @@ impl FromStr for AlchemyCreateType {
     }
 }
 
-impl ToString for AlchemyCallType {
-    fn to_string(&self) -> String {
-        ALCHEMY_CALL_TYPE_TAG.into()
+impl fmt::Display for AlchemyCallType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", ALCHEMY_CALL_TYPE_TAG)
     }
 }
+
 impl FromStr for AlchemyCallType {
     type Err = anyhow::Error;
 
@@ -438,11 +442,12 @@ impl FromStr for AlchemyCallType {
     }
 }
 
-impl ToString for AlchemySuicideType {
-    fn to_string(&self) -> String {
-        ALCHEMY_SUICIDE_TYPE_TAG.into()
+impl fmt::Display for AlchemySuicideType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", ALCHEMY_SUICIDE_TYPE_TAG)
     }
 }
+
 impl FromStr for AlchemySuicideType {
     type Err = anyhow::Error;
 

--- a/refiner-lib/src/near_stream.rs
+++ b/refiner-lib/src/near_stream.rs
@@ -352,7 +352,9 @@ pub mod tests {
 
     pub fn read_block(path: &str) -> NEARBlock {
         let data = std::fs::read_to_string(path).unwrap();
-        serde_json::from_str(&data).unwrap()
+        serde_json::from_str(&data).unwrap_or_else(|e| {
+            panic!("Failed to parse block from {}: {}", path, e);
+        })
     }
 
     pub struct TestContext {

--- a/refiner-lib/src/refiner_inner.rs
+++ b/refiner-lib/src/refiner_inner.rs
@@ -95,12 +95,6 @@ struct PartialState {
     seen_receipts: HashSet<CryptoHash>,
 }
 
-/// Data computed by the refiner and passed to the callback
-#[derive(Debug)]
-pub struct RefinerItem {
-    pub block: AuroraBlock,
-}
-
 impl Refiner {
     pub fn new(chain_id: u64, engine_account_id: AccountId) -> Self {
         Self {

--- a/refiner-types/Cargo.toml
+++ b/refiner-types/Cargo.toml
@@ -17,6 +17,7 @@ aurora-engine.workspace = true
 aurora-engine-sdk.workspace = true
 aurora-engine-transactions.workspace = true
 aurora-engine-types.workspace = true
+borsh.workspace = true
 derive_builder.workspace = true
 fixed-hash.workspace = true
 impl-serde.workspace = true

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77.0"
+channel = "1.78.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
[x] Update nearcore version
[x] Updates Rust to 1.78 (new clippy lints)
[x] Support `priority_fee` from https://github.com/near/nearcore/commit/a9a6eff1121dc48c4aa6a0e4891ef29542e41b84 (SUPPORT FOR BLOCKS WITHOUT `priority` HAS BEEN DROPPED)
