### PR TITLE
fix: use engine account id from storage

### DIFF
--- a/refiner-app/src/input/nearcore.rs
+++ b/refiner-app/src/input/nearcore.rs
@@ -27,7 +27,7 @@ pub fn get_nearcore_stream(
 
     tokio::spawn(async move {
         while let Some(block) = stream.recv().await {
-            // TODO: Slow converstion between types. Fix
+            // TODO: Slow conversion between types. Fix
             sender
                 .send(BlockWithMetadata::new(convert(ch_json(block)), ()))
                 .await

--- a/refiner-lib/src/tx_hash_tracker.rs
+++ b/refiner-lib/src/tx_hash_tracker.rs
@@ -106,8 +106,8 @@ const CACHE_SIZE: usize = 1_000_000;
 const PERSISTENT_HISTORY_SIZE: u64 = 432_000;
 
 /// Range delete operations are cheap to write (they are essentially one tombstone key in the DB),
-/// however they are expsensive to resolve during compaction. We cannot write one pruning
-/// operation per block and keep reasonable performance of the DB when compation happens.
+/// however they are expensive to resolve during compaction. We cannot write one pruning
+/// operation per block and keep reasonable performance of the DB when compaction happens.
 /// Therefore, we will only prune old data once every `PRUNE_FREQUENCY` blocks. This means the
 /// DB may grow a little larger than `PERSISTENT_HISTORY_SIZE` sometimes.
 const PRUNE_FREQUENCY: u64 = 50_000;

--- a/refiner-types/src/aurora_block.rs
+++ b/refiner-types/src/aurora_block.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::bloom::Bloom;
 
-/// Similar to Ethereum blocks, but only contains information relevant for Aurora. In addition
+/// Similar to Ethereum blocks, but only contains information relevant for Aurora. In addition,
 /// it contains extra metadata to map it into a NEAR block.
 ///
 /// ## Fields from Ethereum blocks not included:


### PR DESCRIPTION
The PR removes hardcoded engine account id: `aurora` from the codebase, and changes the value to the value that is stored in the storage.