### PR TITLE
chore: bump nearcore to 2.4.0 rc.1, Rust toolchain to 1.82.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
 dependencies = [
  "actix-utils",
  "actix-web",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-util",
  "log",
  "once_cell",
@@ -75,11 +75,11 @@ dependencies = [
  "brotli",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 0.99.18",
  "encoding_rs",
  "flate2",
  "futures-core",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -105,7 +105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -213,7 +213,7 @@ dependencies = [
  "bytestring",
  "cfg-if 1.0.0",
  "cookie",
- "derive_more",
+ "derive_more 0.99.18",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -244,7 +244,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -255,7 +255,7 @@ checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "android-tzdata"
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -368,49 +368,49 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -464,7 +464,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -475,8 +475,14 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attohttpc"
@@ -585,7 +591,7 @@ version = "1.0.0"
 source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.7.0#338dd61b2ccf60cf2438bac1979d19dd4f0dca59"
 dependencies = [
  "base64 0.22.1",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bs58 0.5.1",
  "hex",
  "primitive-types 0.12.2",
@@ -596,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.29.0-2.3.1"
+version = "0.29.0-2.4.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -622,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.29.0-2.3.1"
+version = "0.29.0-2.4.0-rc.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -633,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.29.0-2.3.1"
+version = "0.29.0-2.4.0-rc.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -644,7 +650,7 @@ dependencies = [
  "aurora-engine-types",
  "aurora-refiner-types",
  "aurora-standalone-engine",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "byteorder",
  "derive_builder 0.20.2",
  "engine-standalone-storage",
@@ -667,18 +673,18 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.29.0-2.3.1"
+version = "0.29.0-2.4.0-rc.1"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
  "aurora-engine-transactions",
  "aurora-engine-types",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "derive_builder 0.20.2",
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
- "near-crypto 2.3.1",
- "near-primitives 2.3.1",
+ "near-crypto 2.4.0-rc.1",
+ "near-primitives 2.4.0-rc.1",
  "serde",
  "serde_json",
  "sha3",
@@ -686,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.29.0-2.3.1"
+version = "0.29.0-2.4.0-rc.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -695,7 +701,7 @@ dependencies = [
  "aurora-engine-transactions",
  "aurora-engine-types",
  "aurora-refiner-types",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "engine-standalone-storage",
  "engine-standalone-tracing",
  "hex",
@@ -716,7 +722,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -741,10 +747,10 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "cookie",
- "derive_more",
+ "derive_more 0.99.18",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "itoa",
  "log",
@@ -761,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.5.8"
+version = "1.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7198e6f03240fdceba36656d8be440297b6b82270325908c7381f37d826a74f6"
+checksum = "9b49afaa341e8dd8577e1a2200468f98956d6eda50bcf4a53246cc00174ba924"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -812,7 +818,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde-xml-rs",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "url",
 ]
@@ -823,7 +829,7 @@ version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -854,11 +860,10 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.54.0"
+version = "1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f2a62020f3e06f9b352b2a23547f6e1d110b6bf1e18a6b588ae36114eaf6e2"
+checksum = "0e531658a0397d22365dfe26c3e1c0c8448bf6a3a2d8a098ded802f2b1261615"
 dependencies = [
- "ahash 0.8.11",
  "aws-credential-types",
  "aws-runtime",
  "aws-sigv4",
@@ -889,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.45.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33ae899566f3d395cbf42858e433930682cc9c1889fa89318896082fef45efb"
+checksum = "09677244a9da92172c8dc60109b4a9658597d4d298b188dd0018b6a66b410ca4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -911,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.46.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39c09e199ebd96b9f860b0fce4b6625f211e064ad7c8693b72ecf7ef03881e0"
+checksum = "81fea2f3a8bb3bd10932ae7ad59cc59f65f270fc9183a7e91f501dc5efbef7ee"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -933,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.45.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d95f93a98130389eb6233b9d615249e543f6c24a68ca1f109af9ca5164a8765"
+checksum = "6ada54e5f26ac246dc79727def52f7f8ed38915cb47781e2a72213957dc3a7d5"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -956,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8db6904450bafe7473c6ca9123f88cc11089e41a025408f992db4e22d3be68"
+checksum = "5619742a0d8f253be760bfbb8e8e8368c69e3587e4637af5754e488a611499b1"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -996,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.12"
+version = "0.60.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598b1689d001c4d4dc3cb386adb07d37786783aee3ac4b324bcadac116bf3d23"
+checksum = "ba1a71073fca26775c8b5189175ea8863afb1c9ea2cceb02a5de5ad9dfbaa795"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -1068,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db"
+checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1078,26 +1083,26 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "httparse",
- "hyper",
- "hyper-rustls",
+ "hyper 0.14.31",
+ "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls",
+ "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
+checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -1112,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.7"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b"
+checksum = "4fbd94a32b3a7d55d3806fe27d98d3ad393050439dd05eb53ece36ec5e3d3510"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1172,7 +1177,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper",
+ "hyper 0.14.31",
  "itoa",
  "matchit",
  "memchr",
@@ -1181,7 +1186,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1292,7 +1297,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1349,17 +1354,15 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "0.3.8"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec 0.7.6",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "constant_time_eq",
- "crypto-mac",
- "digest 0.9.0",
 ]
 
 [[package]]
@@ -1414,11 +1417,11 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+checksum = "2506947f73ad44e344215ccd6403ac2ae18cd8e046e581a441bf8d199f257f03"
 dependencies = [
- "borsh-derive 1.5.1",
+ "borsh-derive 1.5.3",
  "cfg_aliases",
 ]
 
@@ -1437,16 +1440,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+checksum = "c2593a3b8b938bd68373196c9832f516be11fa487ef4ae745eb282e6a56a7244"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
- "syn_derive",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1556,9 +1558,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "bytes-utils"
@@ -1601,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.28"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "jobserver",
  "libc",
@@ -1665,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1675,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1694,14 +1696,14 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "cloud-storage"
@@ -1720,7 +1722,7 @@ dependencies = [
  "lazy_static",
  "openssl",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "tokio",
@@ -1737,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console"
@@ -1762,9 +1764,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -1810,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -2074,7 +2076,6 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "rand_core 0.6.4",
  "rustc_version 0.4.1",
  "subtle",
  "zeroize",
@@ -2088,7 +2089,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2136,7 +2137,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2158,7 +2159,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2198,18 +2199,18 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2251,7 +2252,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2271,7 +2272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core 0.20.2",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2284,7 +2285,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.79",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2334,6 +2355,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2481,9 +2513,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -2539,7 +2571,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2560,7 +2592,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2616,7 +2648,7 @@ dependencies = [
  "hex",
  "serde",
  "sha3",
- "thiserror",
+ "thiserror 1.0.69",
  "uint 0.9.5",
 ]
 
@@ -2658,7 +2690,7 @@ dependencies = [
  "ethereum-types 0.14.1",
  "hash-db 0.16.0",
  "hash256-std-hasher",
- "parity-scale-codec 3.6.12",
+ "parity-scale-codec 3.7.0",
  "rlp 0.5.2",
  "scale-info",
  "serde",
@@ -2708,7 +2740,7 @@ dependencies = [
  "evm-gasometer",
  "evm-runtime",
  "log",
- "parity-scale-codec 3.6.12",
+ "parity-scale-codec 3.7.0",
  "primitive-types 0.12.2",
  "rlp 0.5.2",
  "scale-info",
@@ -2721,7 +2753,7 @@ name = "evm-core"
 version = "0.45.2"
 source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.45.4-aurora#1d9d1dc299fe379913347a71ca00f06344a07262"
 dependencies = [
- "parity-scale-codec 3.6.12",
+ "parity-scale-codec 3.7.0",
  "primitive-types 0.12.2",
  "scale-info",
  "serde",
@@ -2764,9 +2796,9 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "ff"
@@ -2794,7 +2826,7 @@ dependencies = [
  "dissimilar",
  "num-traits",
  "prefix-sum-vec",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-encoder 0.27.0",
  "wasmparser 0.105.0",
  "wasmprinter",
@@ -2835,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2956,7 +2988,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3106,6 +3138,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.6.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hash-db"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,9 +3215,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3309,15 +3360,15 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -3332,6 +3383,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.7",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,12 +3410,29 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.31",
  "log",
- "rustls",
+ "rustls 0.21.12",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.5.1",
+ "hyper-util",
+ "rustls 0.23.17",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -3353,7 +3441,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.31",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -3366,10 +3454,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.31",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.5.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3396,6 +3519,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3403,12 +3644,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -3440,14 +3692,14 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec 3.6.12",
+ "parity-scale-codec 3.7.0",
 ]
 
 [[package]]
 name = "impl-more"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
+checksum = "aae21c3177a27788957044151cc2800043d127acaa460a47ebb9b84dfa2c6aa0"
 
 [[package]]
 name = "impl-rlp"
@@ -3523,7 +3775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -3581,9 +3833,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
 
 [[package]]
 name = "jobserver"
@@ -3596,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb94a0ffd3f3ee755c20f7d8752f45cac88605a4dcf808abcff72873296ec7b"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3672,9 +3924,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "libloading"
@@ -3688,9 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libredox"
@@ -3785,6 +4037,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
 name = "local-channel"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3841,7 +4099,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
 ]
 
 [[package]]
@@ -3906,7 +4164,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4074,22 +4332,22 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35cbb989542587b47205e608324ddd391f0cee1c22b4b64ae49f458334b95907"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "serde",
 ]
 
 [[package]]
 name = "near-async"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
- "derive_more",
+ "derive_more 0.99.18",
  "futures",
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.3.1",
+ "near-time 2.4.0-rc.1",
  "once_cell",
  "serde",
  "serde_json",
@@ -4100,30 +4358,30 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "near-cache"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "lru 0.12.5",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
  "assert_matches",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bytesize",
  "chrono",
  "crossbeam-channel",
@@ -4132,22 +4390,23 @@ dependencies = [
  "itertools 0.10.5",
  "itoa",
  "lru 0.12.5",
+ "more-asserts",
  "near-async",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.3.1",
+ "near-crypto 2.4.0-rc.1",
  "near-epoch-manager",
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.3.1",
+ "near-parameters 2.4.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.3.1",
- "near-schema-checker-lib",
+ "near-primitives 2.4.0-rc.1",
+ "near-schema-checker-lib 2.4.0-rc.1",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4159,27 +4418,27 @@ dependencies = [
  "serde",
  "strum 0.24.1",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
  "time",
+ "tokio",
  "tracing",
- "yansi",
 ]
 
 [[package]]
 name = "near-chain-configs"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
- "derive_more",
- "near-config-utils 2.3.1",
- "near-crypto 2.3.1",
+ "derive_more 0.99.18",
+ "near-config-utils 2.4.0-rc.1",
+ "near-crypto 2.4.0-rc.1",
  "near-o11y",
- "near-parameters 2.3.1",
- "near-primitives 2.3.1",
- "near-time 2.3.1",
+ "near-parameters 2.4.0-rc.1",
+ "near-primitives 2.4.0-rc.1",
+ "near-time 2.4.0-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_json",
@@ -4191,26 +4450,26 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
- "near-crypto 2.3.1",
- "near-primitives 2.3.1",
- "near-time 2.3.1",
- "thiserror",
+ "near-crypto 2.4.0-rc.1",
+ "near-primitives 2.4.0-rc.1",
+ "near-time 2.4.0-rc.1",
+ "thiserror 2.0.3",
  "time",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "chrono",
- "derive_more",
+ "derive_more 0.99.18",
  "futures",
  "itertools 0.10.5",
  "lru 0.12.5",
@@ -4218,17 +4477,17 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.3.1",
+ "near-crypto 2.4.0-rc.1",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.3.1",
+ "near-primitives 2.4.0-rc.1",
  "near-store",
  "rand 0.8.5",
- "reed-solomon-erasure 6.0.0",
+ "reed-solomon-erasure",
  "strum 0.24.1",
  "time",
  "tracing",
@@ -4236,27 +4495,27 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.3.1",
+ "near-primitives 2.4.0-rc.1",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
  "async-trait",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bytesize",
  "chrono",
  "cloud-storage",
- "derive_more",
+ "derive_more 0.99.18",
  "futures",
  "itertools 0.10.5",
  "lru 0.12.5",
@@ -4267,16 +4526,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.3.1",
+ "near-crypto 2.4.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.3.1",
+ "near-parameters 2.4.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.3.1",
+ "near-primitives 2.4.0-rc.1",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4285,150 +4544,151 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "rayon",
- "reed-solomon-erasure 6.0.0",
+ "reed-solomon-erasure",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "rust-s3",
  "serde",
  "serde_json",
  "strum 0.24.1",
  "sysinfo",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
  "time",
  "tokio",
+ "tokio-stream",
+ "tokio-util",
  "tracing",
  "yansi",
 ]
 
 [[package]]
 name = "near-client-primitives"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.3.1",
- "near-primitives 2.3.1",
- "near-time 2.3.1",
+ "near-crypto 2.4.0-rc.1",
+ "near-primitives 2.4.0-rc.1",
+ "near-time 2.4.0-rc.1",
  "serde",
  "serde_json",
  "strum 0.24.1",
- "thiserror",
+ "thiserror 2.0.3",
  "time",
  "tracing",
- "yansi",
 ]
 
 [[package]]
 name = "near-config-utils"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b3db4ac2d4340caef06b6363c3fd16c0be1f70267908dfa53e2e6241649b0c"
+checksum = "4e7b41110a20f1d82bb06f06e4800068c5ade6d8ff844787f8753bc2ce7b16f7"
 dependencies = [
  "anyhow",
  "json_comments",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
 [[package]]
 name = "near-config-utils"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "anyhow",
  "json_comments",
- "thiserror",
+ "thiserror 2.0.3",
  "tracing",
 ]
 
 [[package]]
 name = "near-crypto"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9807fb257f7dda41383bb33e14cfd4a8840ffa7932cb972db9eabff19ce3bf4"
+checksum = "43b17944c8d0f274c684227d79fcd46d583b1e36064b597c53a9ebec187a86f3"
 dependencies = [
  "blake2",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bs58 0.4.0",
  "curve25519-dalek",
- "derive_more",
+ "derive_more 0.99.18",
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 0.23.0",
- "near-stdx 0.23.0",
- "once_cell",
+ "near-config-utils 0.27.0",
+ "near-schema-checker-lib 0.27.0",
+ "near-stdx 0.27.0",
  "primitive-types 0.10.1",
  "secp256k1",
  "serde",
  "serde_json",
  "subtle",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "near-crypto"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "blake2",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bs58 0.4.0",
  "curve25519-dalek",
- "derive_more",
+ "derive_more 0.99.18",
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.3.1",
- "near-schema-checker-lib",
- "near-stdx 2.3.1",
+ "near-config-utils 2.4.0-rc.1",
+ "near-schema-checker-lib 2.4.0-rc.1",
+ "near-stdx 2.4.0-rc.1",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
  "serde",
  "serde_json",
  "subtle",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "anyhow",
  "near-chain-configs",
- "near-crypto 2.3.1",
+ "near-crypto 2.4.0-rc.1",
  "near-o11y",
- "near-primitives 2.3.1",
- "near-time 2.3.1",
+ "near-primitives 2.4.0-rc.1",
+ "near-time 2.4.0-rc.1",
  "prometheus",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "itertools 0.10.5",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.3.1",
+ "near-crypto 2.4.0-rc.1",
  "near-o11y",
- "near-primitives 2.3.1",
- "near-schema-checker-lib",
+ "near-primitives 2.4.0-rc.1",
+ "near-schema-checker-lib 2.4.0-rc.1",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4443,38 +4703,38 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ce363e4078b870775e2a5a5189feae22f0870ca673f6409b1974922dada0c4"
+checksum = "b1eff0731995774d1498f017c968a3ebbfdadad84f556afea4b83679f6706ac9"
 dependencies = [
- "near-primitives-core 0.23.0",
+ "near-primitives-core 0.27.0",
 ]
 
 [[package]]
 name = "near-fmt"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
- "near-primitives-core 2.3.1",
+ "near-primitives-core 2.4.0-rc.1",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.3.1",
- "near-crypto 2.3.1",
+ "near-config-utils 2.4.0-rc.1",
+ "near-crypto 2.4.0-rc.1",
  "near-dyn-configs",
- "near-indexer-primitives 2.3.1",
+ "near-indexer-primitives 2.4.0-rc.1",
  "near-o11y",
- "near-parameters 2.3.1",
- "near-primitives 2.3.1",
+ "near-parameters 2.4.0-rc.1",
+ "near-primitives 2.4.0-rc.1",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4487,35 +4747,35 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca85c74772338d1b8c8b8729ffa14dec44dacefa2ce367795f3de8846f2fdc06"
+checksum = "ce9644d23252a0af5c5151b40d440d64339618f356d7ec19ddfd1ce004863a1d"
 dependencies = [
- "near-primitives 0.23.0",
+ "near-primitives 0.27.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
- "near-primitives 2.3.1",
+ "near-primitives 2.4.0-rc.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
  "actix-cors",
  "actix-web",
  "bs58 0.4.0",
- "derive_more",
+ "derive_more 0.99.18",
  "easy-ext",
  "futures",
  "hex",
@@ -4527,7 +4787,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.3.1",
+ "near-primitives 2.4.0-rc.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -4538,40 +4798,40 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.3.1",
+ "near-primitives 2.4.0-rc.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.3.1",
- "near-primitives 2.3.1",
- "near-schema-checker-lib",
+ "near-crypto 2.4.0-rc.1",
+ "near-primitives 2.4.0-rc.1",
+ "near-schema-checker-lib 2.4.0-rc.1",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.3",
  "time",
 ]
 
 [[package]]
 name = "near-lake-framework"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf514c5d43ac5e0309b80545583a35c09a5cf19f77894241e755e0223a8c50c"
+checksum = "b784d25c9eae449a09f432c85bfc98ab4ea30af0242ec81b37acf357652641d7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4583,10 +4843,11 @@ dependencies = [
  "aws-types",
  "derive_builder 0.13.1",
  "futures",
- "near-indexer-primitives 0.23.0",
+ "near-indexer-primitives 0.27.0",
+ "reqwest 0.12.9",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4594,30 +4855,30 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.3.1",
+ "near-primitives 2.4.0-rc.1",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
  "anyhow",
  "arc-swap",
  "async-trait",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bytes",
  "bytesize",
  "chrono",
  "crossbeam-channel",
- "derive_more",
+ "derive_more 0.99.18",
  "enum-map",
  "futures",
  "futures-util",
@@ -4626,28 +4887,28 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.3.1",
- "near-fmt 2.3.1",
+ "near-crypto 2.4.0-rc.1",
+ "near-fmt 2.4.0-rc.1",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.3.1",
- "near-schema-checker-lib",
+ "near-primitives 2.4.0-rc.1",
+ "near-schema-checker-lib 2.4.0-rc.1",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.3",
  "pin-project",
- "protobuf 3.6.0",
+ "protobuf 3.7.1",
  "protobuf-codegen",
  "rand 0.8.5",
  "rayon",
- "reed-solomon-erasure 6.0.0",
+ "reed-solomon-erasure",
  "serde",
  "sha2 0.10.8",
  "smart-default",
  "strum 0.24.1",
  "stun",
- "thiserror",
+ "thiserror 2.0.3",
  "time",
  "tokio",
  "tokio-stream",
@@ -4657,14 +4918,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.3.1",
- "near-primitives-core 2.3.1",
+ "near-crypto 2.4.0-rc.1",
+ "near-primitives-core 2.4.0-rc.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -4672,7 +4933,7 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -4682,44 +4943,45 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddf39f5f729976a791d86e0e30a71ec4d8e8dcf58117c8694e7b22fb3f50ee6"
+checksum = "0d4b4d014ac9f46baf0eeac7214567a08db97d5fd26157ea13edfbb8ffc5fd8c"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "enum-map",
  "near-account-id",
- "near-primitives-core 0.23.0",
+ "near-primitives-core 0.27.0",
+ "near-schema-checker-lib 0.27.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
  "serde_yaml",
  "strum 0.24.1",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "near-parameters"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.3.1",
- "near-schema-checker-lib",
+ "near-primitives-core 2.4.0-rc.1",
+ "near-schema-checker-lib 2.4.0-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
  "serde_yaml",
  "strum 0.24.1",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4733,264 +4995,262 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "near-pool"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
- "borsh 1.5.1",
- "near-crypto 2.3.1",
+ "borsh 1.5.3",
+ "near-crypto 2.4.0-rc.1",
  "near-o11y",
- "near-primitives 2.3.1",
+ "near-primitives 2.4.0-rc.1",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "near-primitives"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c175262923db9885ed0347e96ec3bcbec57825e3b6d7de03da220f5e14ef5"
+checksum = "b45b4742a1817ff7d80dcf51c6facb8134478f8c4a6d717825cca2e4b834b17f"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.5.1",
+ "bitvec 1.0.1",
+ "borsh 1.5.3",
  "bytes",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
- "derive_more",
+ "derive_more 0.99.18",
  "easy-ext",
  "enum-map",
  "hex",
- "itertools 0.10.5",
- "near-crypto 0.23.0",
- "near-fmt 0.23.0",
- "near-parameters 0.23.0",
- "near-primitives-core 0.23.0",
- "near-rpc-error-macro",
- "near-stdx 0.23.0",
- "near-time 0.23.0",
+ "near-crypto 0.27.0",
+ "near-fmt 0.27.0",
+ "near-parameters 0.27.0",
+ "near-primitives-core 0.27.0",
+ "near-schema-checker-lib 0.27.0",
+ "near-stdx 0.27.0",
+ "near-time 0.27.0",
  "num-rational 0.3.2",
- "once_cell",
+ "ordered-float",
  "primitive-types 0.10.1",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "reed-solomon-erasure 4.0.2",
  "serde",
  "serde_json",
  "serde_with",
  "sha3",
  "smart-default",
  "strum 0.24.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "zstd",
 ]
 
 [[package]]
 name = "near-primitives"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
  "bitvec 1.0.1",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bytes",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
- "derive_more",
+ "derive_more 0.99.18",
  "easy-ext",
  "enum-map",
  "hex",
  "itertools 0.10.5",
- "near-crypto 2.3.1",
- "near-fmt 2.3.1",
- "near-parameters 2.3.1",
- "near-primitives-core 2.3.1",
- "near-schema-checker-lib",
- "near-stdx 2.3.1",
- "near-time 2.3.1",
+ "near-crypto 2.4.0-rc.1",
+ "near-fmt 2.4.0-rc.1",
+ "near-parameters 2.4.0-rc.1",
+ "near-primitives-core 2.4.0-rc.1",
+ "near-schema-checker-lib 2.4.0-rc.1",
+ "near-stdx 2.4.0-rc.1",
+ "near-time 2.4.0-rc.1",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "reed-solomon-erasure 6.0.0",
+ "reed-solomon-erasure",
  "serde",
  "serde_json",
  "serde_with",
  "sha3",
  "smart-default",
  "strum 0.24.1",
- "thiserror",
+ "thiserror 2.0.3",
  "tracing",
  "zstd",
 ]
 
 [[package]]
 name = "near-primitives-core"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45de00d413f5bb890a3912f32fcd0974b2b0a975cc7874012e2c4c4fa7f28917"
+checksum = "0de2c9da5de096b5cd4786a270900ff32a49d267e442a2e7f271fb23eb925c87"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bs58 0.4.0",
- "derive_more",
+ "derive_more 0.99.18",
  "enum-map",
  "near-account-id",
+ "near-schema-checker-lib 0.27.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "near-primitives-core"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bs58 0.4.0",
- "derive_more",
+ "derive_more 0.99.18",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib",
+ "near-schema-checker-lib 2.4.0-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
  "actix-cors",
  "actix-http",
  "actix-web",
  "awc",
- "derive_more",
+ "derive_more 0.99.18",
  "futures",
  "hex",
  "near-account-id",
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.3.1",
+ "near-crypto 2.4.0-rc.1",
  "near-network",
  "near-o11y",
- "near-parameters 2.3.1",
- "near-primitives 2.3.1",
+ "near-parameters 2.4.0-rc.1",
+ "near-primitives 2.4.0-rc.1",
  "node-runtime",
  "paperclip",
  "serde",
  "serde_json",
  "strum 0.24.1",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
 ]
 
 [[package]]
-name = "near-rpc-error-core"
-version = "0.23.0"
+name = "near-schema-checker-core"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf41b149dcc1f5a35d6a96fbcd8c28c92625c05b52025a72ee7378c72bcd68ce"
-dependencies = [
- "quote",
- "serde",
- "syn 2.0.79",
-]
-
-[[package]]
-name = "near-rpc-error-macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c7f0f12f426792dd2c9d83df43d73c3b15d80f6e99e8d0e16ff3e024d0f9ba"
-dependencies = [
- "near-rpc-error-core",
- "serde",
- "syn 2.0.79",
-]
+checksum = "03541d1dadd0b5dd0a2e1ae1fbe5735fdab79332ed556af36cdcbe50d4b8cf04"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9050b0822d2c0dbd90d8c523fd74634f77c5be4ed3337e7010c0d986121982"
 dependencies = [
- "near-schema-checker-core",
- "near-schema-checker-macro",
+ "near-schema-checker-core 0.27.0",
+ "near-schema-checker-macro 0.27.0",
+]
+
+[[package]]
+name = "near-schema-checker-lib"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
+dependencies = [
+ "near-schema-checker-core 2.4.0-rc.1",
+ "near-schema-checker-macro 2.4.0-rc.1",
 ]
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
-
-[[package]]
-name = "near-stdx"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e1897481272eb144328abd51ca9f59b5b558e7a6dc6e2177c8c9bb18fbd818"
+checksum = "a1bca8c93ff0ad17138c147323a07f036d11c9e1602e3bc2ac9d29c3cf78b89d"
+
+[[package]]
+name = "near-schema-checker-macro"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 
 [[package]]
 name = "near-stdx"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427b4e4af5e32f682064772da8b1a7558b3f090e6151c8804cff24ee6c5c4966"
+
+[[package]]
+name = "near-stdx"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 
 [[package]]
 name = "near-store"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bytesize",
  "crossbeam",
  "derive-where",
- "derive_more",
+ "derive_more 0.99.18",
  "enum-map",
  "hex",
  "itertools 0.10.5",
  "itoa",
  "lru 0.12.5",
  "near-chain-configs",
- "near-crypto 2.3.1",
- "near-fmt 2.3.1",
+ "near-crypto 2.4.0-rc.1",
+ "near-fmt 2.4.0-rc.1",
  "near-o11y",
- "near-parameters 2.3.1",
- "near-primitives 2.3.1",
- "near-schema-checker-lib",
- "near-stdx 2.3.1",
- "near-time 2.3.1",
+ "near-parameters 2.4.0-rc.1",
+ "near-primitives 2.4.0-rc.1",
+ "near-schema-checker-lib 2.4.0-rc.1",
+ "near-stdx 2.4.0-rc.1",
+ "near-time 2.4.0-rc.1",
  "near-vm-runner",
  "num_cpus",
  "rand 0.8.5",
  "rayon",
- "reed-solomon-erasure 6.0.0",
+ "reed-solomon-erasure",
  "rlimit",
  "rocksdb",
  "serde",
@@ -4998,15 +5258,15 @@ dependencies = [
  "smallvec",
  "strum 0.24.1",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "near-telemetry"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
  "awc",
@@ -5015,7 +5275,7 @@ dependencies = [
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-time 2.3.1",
+ "near-time 2.4.0-rc.1",
  "openssl",
  "serde",
  "serde_json",
@@ -5024,20 +5284,18 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56db32f26b089441c1a7c5451f0d68637afa9d66f6d8f6a6f2d6c2f7953520a"
+checksum = "66ade805f0ca8211f0ca2e6ea130f8ddd03bf70c9c93ebeabdddf37314e3f30b"
 dependencies = [
- "once_cell",
  "serde",
  "time",
- "tokio",
 ]
 
 [[package]]
 name = "near-time"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "serde",
  "time",
@@ -5046,8 +5304,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5055,15 +5313,15 @@ dependencies = [
  "near-vm-vm",
  "rkyv",
  "target-lexicon 0.12.16",
- "thiserror",
+ "thiserror 2.0.3",
  "tracing",
  "wasmparser 0.99.0",
 ]
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5082,8 +5340,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5098,30 +5356,30 @@ dependencies = [
  "rustc-demangle",
  "rustix",
  "target-lexicon 0.12.16",
- "thiserror",
+ "thiserror 2.0.3",
  "tracing",
 ]
 
 [[package]]
 name = "near-vm-runner"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "anyhow",
  "blst",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bytesize",
  "ed25519-dalek",
  "enum-map",
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.3.1",
+ "near-crypto 2.4.0-rc.1",
  "near-o11y",
- "near-parameters 2.3.1",
- "near-primitives-core 2.3.1",
- "near-schema-checker-lib",
- "near-stdx 2.3.1",
+ "near-parameters 2.4.0-rc.1",
+ "near-primitives-core 2.4.0-rc.1",
+ "near-schema-checker-lib 2.4.0-rc.1",
+ "near-stdx 2.4.0-rc.1",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5142,7 +5400,7 @@ dependencies = [
  "sha3",
  "strum 0.24.1",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
  "tracing",
  "wasm-encoder 0.27.0",
  "wasmer-compiler-near",
@@ -5160,19 +5418,19 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "indexmap 1.9.3",
  "num-traits",
  "rkyv",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "near-vm-vm"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "backtrace",
  "cc",
@@ -5185,32 +5443,32 @@ dependencies = [
  "near-vm-types",
  "region",
  "rkyv",
- "thiserror",
+ "thiserror 2.0.3",
  "tracing",
  "winapi",
 ]
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.3.1",
+ "near-primitives-core 2.4.0-rc.1",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
  "actix",
  "actix-rt",
  "actix-web",
  "anyhow",
  "awc",
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "bytesize",
  "chrono",
  "cloud-storage",
@@ -5218,17 +5476,18 @@ dependencies = [
  "easy-ext",
  "futures",
  "hex",
- "hyper",
- "hyper-tls",
+ "hyper 0.14.31",
+ "hyper-tls 0.5.0",
  "indicatif",
+ "itertools 0.10.5",
  "near-async",
  "near-chain",
  "near-chain-configs",
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.3.1",
- "near-crypto 2.3.1",
+ "near-config-utils 2.4.0-rc.1",
+ "near-crypto 2.4.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5236,10 +5495,10 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.3.1",
+ "near-parameters 2.4.0-rc.1",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.3.1",
+ "near-primitives 2.4.0-rc.1",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5249,7 +5508,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "rlimit",
  "rust-s3",
  "serde",
@@ -5258,7 +5517,7 @@ dependencies = [
  "smart-default",
  "strum 0.24.1",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
  "xz2",
@@ -5291,15 +5550,15 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.3.1"
-source = "git+https://github.com/near/nearcore?tag=2.3.1#2bce389e4fd9273b78e4efbb16fb3317a7389b5b"
+version = "2.4.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c18490cf4dafaedca01458f365dc5871bd293"
 dependencies = [
- "borsh 1.5.1",
- "near-crypto 2.3.1",
+ "borsh 1.5.3",
+ "near-crypto 2.4.0-rc.1",
  "near-o11y",
- "near-parameters 2.3.1",
- "near-primitives 2.3.1",
- "near-primitives-core 2.3.1",
+ "near-parameters 2.4.0-rc.1",
+ "near-primitives 2.4.0-rc.1",
+ "near-primitives-core 2.4.0-rc.1",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",
@@ -5309,7 +5568,7 @@ dependencies = [
  "rayon",
  "serde_json",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 2.0.3",
  "tracing",
 ]
 
@@ -5507,9 +5766,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if 1.0.0",
@@ -5528,7 +5787,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5539,18 +5798,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.2+3.3.2"
+version = "300.4.1+3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -5570,7 +5829,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror",
+ "thiserror 1.0.69",
  "urlencoding",
 ]
 
@@ -5588,7 +5847,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prost",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
 ]
@@ -5628,18 +5887,18 @@ dependencies = [
  "ordered-float",
  "percent-encoding",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
 ]
 
 [[package]]
 name = "ordered-float"
-version = "4.3.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
+checksum = "c65ee1f9701bf938026630b455d5315f490640234259037edb259798b3bcf85e"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.3",
  "num-traits",
  "rand 0.8.5",
  "serde",
@@ -5705,7 +5964,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -5740,14 +5999,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "paperclip-macros"
-version = "0.6.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0385be5ae9c886c46688290534363a229f2531aa2c5c2bfc3b3ddafed5143aaa"
+checksum = "ce6e25ce2c5362c8d48dc89e0f9ca076d507f7c1eabd04f0d593cdf5addff90c"
 dependencies = [
  "heck 0.4.1",
  "http 0.2.12",
@@ -5775,28 +6034,29 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "8be4817d39f3272f69c59fe05d0535ae6456c2dc2fa1ba02910296c7e0a5c590"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec 1.0.1",
  "byte-slice-cast 1.2.2",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.12"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+checksum = "8781a75c6205af67215f382092b6e0a4ff3734798523e69073d4bcd294ec767b"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5932,29 +6192,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -6053,12 +6313,12 @@ checksum = "aa06bd51638b6e76ac9ba9b6afb4164fa647bd2916d722f2623fbb6d1ed8bdba"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6142,9 +6402,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -6161,7 +6421,7 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.3",
  "protobuf 2.28.0",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6184,7 +6444,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6195,60 +6455,60 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf"
-version = "3.6.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3018844a02746180074f621e847703737d27d89d7f0721a7a4da317f88b16385"
+checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
 dependencies = [
  "once_cell",
  "protobuf-support",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.6.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c15a212b4de05eb8bc989fd066a74c86bd3c04e27d6e86bd7703b806d7734"
+checksum = "e26b833f144769a30e04b1db0146b2aaa53fd2fd83acf10a6b5f996606c18144"
 dependencies = [
  "anyhow",
  "once_cell",
- "protobuf 3.6.0",
+ "protobuf 3.7.1",
  "protobuf-parse",
  "regex",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "protobuf-parse"
-version = "3.6.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06f45f16b522d92336e839b5e40680095a045e36a1e7f742ba682ddc85236772"
+checksum = "322330e133eab455718444b4e033ebfac7c6528972c784fcde28d2cc783c6257"
 dependencies = [
  "anyhow",
  "indexmap 2.6.0",
  "log",
- "protobuf 3.6.0",
+ "protobuf 3.7.1",
  "protobuf-support",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "which",
 ]
 
 [[package]]
 name = "protobuf-support"
-version = "3.6.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf96d872914fcda2b66d66ea3fff2be7c66865d31c7bb2790cff32c0e714880"
+checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa37f80ca58604976033fae9515a8a2989fc13797d953f7c04fb8fa36a11f205"
+checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
 dependencies = [
  "cc",
 ]
@@ -6448,16 +6708,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
-]
-
-[[package]]
-name = "reed-solomon-erasure"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
-dependencies = [
- "smallvec",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6488,13 +6739,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
+ "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
 
@@ -6509,9 +6760,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6568,11 +6819,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper",
- "hyper-tls",
+ "hyper 0.14.31",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -6581,12 +6832,12 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -6597,6 +6848,49 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.7",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-rustls 0.27.3",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "system-configuration 0.6.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
 ]
 
 [[package]]
@@ -6758,12 +7052,12 @@ dependencies = [
  "md5",
  "minidom",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde-xml-rs",
  "serde_derive",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tokio-stream",
@@ -6808,9 +7102,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.6.0",
  "errno 0.3.9",
@@ -6827,8 +7121,21 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -6838,7 +7145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework",
 ]
@@ -6853,6 +7160,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6863,10 +7185,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.17"
+name = "rustls-webpki"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "rxml"
@@ -6893,34 +7226,34 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scale-info"
-version = "2.11.3"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "bitvec 1.0.1",
  "cfg-if 1.0.0",
- "derive_more",
- "parity-scale-codec 3.6.12",
+ "derive_more 1.0.0",
+ "parity-scale-codec 3.7.0",
  "scale-info-derive",
 ]
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.3"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "schannel"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -6995,9 +7328,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7026,9 +7359,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
@@ -7051,7 +7384,7 @@ checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
 dependencies = [
  "log",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "xml-rs",
 ]
 
@@ -7066,13 +7399,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7086,9 +7419,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -7104,7 +7437,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7155,7 +7488,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7455,7 +7788,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7468,7 +7801,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7484,7 +7817,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.16.20",
  "subtle",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "url",
  "webrtc-util",
@@ -7509,9 +7842,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7519,22 +7852,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "sysinfo"
@@ -7559,7 +7900,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -7567,6 +7919,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7592,9 +7954,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
@@ -7605,22 +7967,42 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7702,6 +8084,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7718,9 +8110,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7752,7 +8144,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7808,7 +8200,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.17",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -7890,10 +8293,10 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper",
+ "hyper 0.14.31",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -7957,7 +8360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tracing-subscriber",
 ]
@@ -7970,7 +8373,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8097,12 +8500,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
@@ -8112,9 +8512,9 @@ checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-normalization"
@@ -8157,9 +8557,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -8173,6 +8573,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8180,9 +8592,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 
 [[package]]
 name = "valuable"
@@ -8264,9 +8676,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef073ced962d62984fb38a36e5fdc1a2b23c9e0e1fa0689bb97afa4202ef6887"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
@@ -8275,24 +8687,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4bfab14ef75323f4eb75fa52ee0a3fb59611977fd3240da19b2cf36ff85030e"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65471f79c1022ffa5291d33520cbbb53b7687b01c2f8e83b57d102eed7ed479d"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -8302,9 +8714,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bec9830f60924d9ceb3ef99d55c155be8afa76954edffbb5936ff4509474e7"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8312,22 +8724,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42f6c679374623f295a8623adfe63d9284091245c3504bde47c17a3ce2777d9"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-encoder"
@@ -8349,9 +8761,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -8370,7 +8782,7 @@ dependencies = [
  "rkyv",
  "smallvec",
  "target-lexicon 0.12.16",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmer-types-near",
  "wasmer-vm-near",
  "wasmparser 0.78.2",
@@ -8408,7 +8820,7 @@ dependencies = [
  "more-asserts",
  "rustc-demangle",
  "target-lexicon 0.12.16",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmer-compiler-near",
  "wasmer-types-near",
  "wasmer-vm-near",
@@ -8425,7 +8837,7 @@ dependencies = [
  "leb128",
  "region",
  "rkyv",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmer-compiler-near",
  "wasmer-engine-near",
  "wasmer-types-near",
@@ -8435,18 +8847,18 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-core-near"
-version = "0.18.3"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3fac37da3c625e98708c5dd92d3f642aaf700fd077168d3d0fff277ec6a165"
+checksum = "af9c54899b847f8bab6d47295487c9827f14cc411bd70b168e87a4ea017ccd7e"
 dependencies = [
  "bincode",
  "blake3",
- "borsh 0.9.3",
+ "borsh 1.5.3",
  "cc",
  "digest 0.8.1",
  "errno 0.2.8",
  "hex",
- "indexmap 1.9.3",
+ "indexmap 2.6.0",
  "lazy_static",
  "libc",
  "nix 0.15.0",
@@ -8479,12 +8891,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-singlepass-backend-near"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6edd0ba6c0bcf9b279186d4dbe81649dda3e5ef38f586865943de4dcd653f8"
+checksum = "9358673d39c3b4a15374fba0536bfe5e50485e7c826de50d2dbef8c96df07674"
 dependencies = [
  "bincode",
- "borsh 0.9.3",
+ "borsh 1.5.3",
  "byteorder",
  "dynasm 1.2.3",
  "dynasmrt 1.2.3",
@@ -8505,7 +8917,7 @@ checksum = "1ba154adffb0fbd33f5dabd3788a1744d846b43e6e090d44269c7ee8fa5743e4"
 dependencies = [
  "indexmap 1.9.3",
  "rkyv",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8523,7 +8935,7 @@ dependencies = [
  "more-asserts",
  "region",
  "rkyv",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmer-types-near",
  "winapi",
 ]
@@ -8638,7 +9050,7 @@ dependencies = [
  "log",
  "object 0.32.2",
  "target-lexicon 0.12.16",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmparser 0.115.0",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
@@ -8676,7 +9088,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon 0.12.16",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmparser 0.115.0",
  "wasmtime-types",
 ]
@@ -8764,7 +9176,7 @@ dependencies = [
  "cranelift-entity",
  "serde",
  "serde_derive",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmparser 0.115.0",
 ]
 
@@ -8776,7 +9188,7 @@ checksum = "09b5575a75e711ca6c36bb9ad647c93541cdc8e34218031acba5da3f35919dd3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8787,9 +9199,9 @@ checksum = "9dafab2db172a53e23940e0fa3078c202f567ee5f13f4b42f66b694fab43c658"
 
 [[package]]
 name = "web-sys"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44188d185b5bdcae1052d08bcbcf9091a5524038d4572cc4f4f2bb9d5554ddd9"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8821,7 +9233,7 @@ dependencies = [
  "log",
  "nix 0.24.3",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "winapi",
 ]
@@ -8895,6 +9307,36 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -9066,6 +9508,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9076,9 +9530,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
+checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
 
 [[package]]
 name = "xmlparser"
@@ -9102,6 +9556,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9119,7 +9597,28 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure",
 ]
 
 [[package]]
@@ -9139,7 +9638,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9154,6 +9653,28 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "rustc-hex",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.29.0-2.3.1"
+version = "0.29.0-2.4.0-rc.1"
 edition = "2021"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -37,9 +37,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.3.1" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.3.1" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.3.1" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.4.0-rc.1" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.4.0-rc.1" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.4.0-rc.1" }
 near-lake-framework = "0.7"
 prometheus = "0.13"
 rlp = "0.5"

--- a/refiner-app/src/conversion/mod.rs
+++ b/refiner-app/src/conversion/mod.rs
@@ -9,7 +9,7 @@ pub fn convert(block: StreamerMessage) -> NEARBlock {
             .shards
             .into_iter()
             .map(|shard| Shard {
-                shard_id: shard.shard_id,
+                shard_id: shard.shard_id.into(),
                 chunk: shard.chunk.map(|chunk| ChunkView {
                     author: ch_json(chunk.author),
                     header: ChunkHeaderView {

--- a/refiner-app/src/socket.rs
+++ b/refiner-app/src/socket.rs
@@ -114,7 +114,7 @@ async fn handle_msg(
 ) -> Result<serde_json::Value, JsonRpcError<String>> {
     match msg
         .get("method")
-        .ok_or(JsonRpcError {
+        .ok_or_else(|| JsonRpcError {
             code: -32600,
             message: "Invalid Request".into(),
             data: Some("no method defined".into()),

--- a/refiner-lib/src/tx_hash_tracker.rs
+++ b/refiner-lib/src/tx_hash_tracker.rs
@@ -4,8 +4,7 @@ use std::path::Path;
 /// A helper object for tracking the NEAR transaction hash that caused each NEAR receipt
 /// to be produced (potentially indirectly via a number of other receipts).
 ///
-/// The main interface
-/// includes the `get_tx_hash` function to query the helper for the transaction hash associated
+/// The main interface includes the `get_tx_hash` function to query the helper for the transaction hash associated
 /// with a given receipt hash, and two functions to mutate the tracker's state:
 /// `consume_near_block` and `on_block_end`. The purpose of `consume_near_block` is to update
 /// the tracker's state with the new receipts that are created in that block. The purpose of

--- a/refiner-lib/src/tx_hash_tracker.rs
+++ b/refiner-lib/src/tx_hash_tracker.rs
@@ -2,7 +2,9 @@ use aurora_refiner_types::{near_block::NEARBlock, near_primitives::hash::CryptoH
 use std::path::Path;
 
 /// A helper object for tracking the NEAR transaction hash that caused each NEAR receipt
-/// to be produced (potentially indirectly via a number of other receipts). The main interface
+/// to be produced (potentially indirectly via a number of other receipts).
+///
+/// The main interface
 /// includes the `get_tx_hash` function to query the helper for the transaction hash associated
 /// with a given receipt hash, and two functions to mutate the tracker's state:
 /// `consume_near_block` and `on_block_end`. The purpose of `consume_near_block` is to update

--- a/refiner-types/src/aurora_block.rs
+++ b/refiner-types/src/aurora_block.rs
@@ -89,8 +89,7 @@ pub struct NearBlockHeader {
 
 /// Similar to Ethereum transaction but only contains information relevant for Aurora.
 ///
-/// It includes
-/// the information of the receipt after executing the transaction as well. In addition it contains
+/// It includes the information of the receipt after executing the transaction as well. In addition it contains
 /// extra metadata to map it into a NEAR transaction.
 ///
 /// ## Fields from Ethereum transactions and receipts not included:

--- a/refiner-types/src/aurora_block.rs
+++ b/refiner-types/src/aurora_block.rs
@@ -87,7 +87,9 @@ pub struct NearBlockHeader {
     pub author: AccountId,
 }
 
-/// Similar to Ethereum transaction but only contains information relevant for Aurora. It includes
+/// Similar to Ethereum transaction but only contains information relevant for Aurora.
+///
+/// It includes
 /// the information of the receipt after executing the transaction as well. In addition it contains
 /// extra metadata to map it into a NEAR transaction.
 ///

--- a/refiner-types/src/near_block.rs
+++ b/refiner-types/src/near_block.rs
@@ -263,7 +263,9 @@ impl Clone for Shard {
                         }
                         StateChangeCauseView::Migration => StateChangeCauseView::Migration,
                         StateChangeCauseView::ReshardingV2 => StateChangeCauseView::ReshardingV2,
-                        StateChangeCauseView::BandwidthSchedulerStateUpdate => StateChangeCauseView::BandwidthSchedulerStateUpdate
+                        StateChangeCauseView::BandwidthSchedulerStateUpdate => {
+                            StateChangeCauseView::BandwidthSchedulerStateUpdate
+                        }
                     },
                     value: match &v.value {
                         StateChangeValueView::AccountUpdate {

--- a/refiner-types/src/near_block.rs
+++ b/refiner-types/src/near_block.rs
@@ -263,6 +263,7 @@ impl Clone for Shard {
                         }
                         StateChangeCauseView::Migration => StateChangeCauseView::Migration,
                         StateChangeCauseView::ReshardingV2 => StateChangeCauseView::ReshardingV2,
+                        StateChangeCauseView::BandwidthSchedulerStateUpdate => StateChangeCauseView::BandwidthSchedulerStateUpdate
                     },
                     value: match &v.value {
                         StateChangeValueView::AccountUpdate {

--- a/refiner-types/src/utils.rs
+++ b/refiner-types/src/utils.rs
@@ -5,6 +5,7 @@ const U64_MAX: U256 = U256([u64::MAX, 0, 0, 0]);
 
 pub mod u64_hex_serde {
     //! This module provides serde serialization for u64 numbers with hexadecimal encoding.
+    //!
     //! It can be used with the field attribute `#[serde(with = "u64_hex_serde")]` on u64
     //! inside structs deriving serde Serialize and Deserialize traits.
     //! Note: if a number is larger than U256::MAX then the deserializing will fail with an error.
@@ -38,6 +39,7 @@ pub mod u64_hex_serde {
 
 pub mod u128_dec_serde {
     //! This module provides serde serialization for optional u128 numbers with base-10 strings.
+    //!
     //! It can be used with the field attribute `#[serde(with = "u128_dec_serde")]` on u128 fields
     //! inside structs deriving serde Serialize and Deserialize traits.
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Reason for updating the Rust toolchain to 1.82.0

A `borealis-engine-lib` build pointing to `nearcore` [2.4.0-rc.1](https://github.com/near/nearcore/releases/tag/2.4.0-rc.1) has failed due to a version conflict between the `syn` crate versions required by different dependencies:

1. `thiserror-impl` v2.0.0 requires syn ^2.0.87.
2. `actix-macros` v0.2.4 requires syn ^2.0.79.

```
borealis-engine-lib % cargo check
    Updating git repository `https://github.com/near/nearcore`
    Updating crates.io index
error: failed to select a version for `syn`.
    ... required by package `thiserror-impl v2.0.0`
    ... which satisfies dependency `thiserror-impl = "=2.0.0"` of package `thiserror v2.0.0`
    ... which satisfies dependency `thiserror = "^2.0"` of package `near-crypto v2.4.0-rc.1 (https://github.com/near/nearcore?tag=2.4.0-rc.1#a83c1849)`
    ... which satisfies git dependency `near-crypto` of package `aurora-refiner-types v0.29.0-2.4.0-rc.1 (/Path/to/borealis-engine-lib/refiner-types)`
    ... which satisfies path dependency `aurora-refiner-types` of package `aurora-refiner v0.29.0-2.4.0-rc.1 (/Path/to/borealis-engine-lib/refiner-app)`
versions that meet the requirements `^2.0.87` are: 2.0.87

all possible versions conflict with previously selected packages.

  previously selected package `syn v2.0.79`
    ... which satisfies dependency `syn = "^2"` (locked to 2.0.79) of package `actix-macros v0.2.4`
    ... which satisfies dependency `actix-macros = "^0.2"` (locked to 0.2.4) of package `actix v0.13.5`
    ... which satisfies dependency `actix = "=0.13.5"` (locked to 0.13.5) of package `aurora-refiner v0.29.0-2.4.0-rc.1 (/Path/to/borealis-engine-lib/refiner-app)`

failed to select a version for `syn` which could resolve this conflict
```

**Updating deps to the latest compatible versions and running `cargo check` again shows:**
```
borealis-engine-lib % cargo update
    Updating crates.io index
    ...
borealis-engine-lib % cargo check
error: rustc 1.81.0 is not supported by the following packages:
  near-chunks@2.4.0-rc.1 requires rustc 1.82.0
  near-client@2.4.0-rc.1 requires rustc 1.82.0
  near-epoch-manager@2.4.0-rc.1 requires rustc 1.82.0
  near-indexer@2.4.0-rc.1 requires rustc 1.82.0
  near-jsonrpc@2.4.0-rc.1 requires rustc 1.82.0
  near-jsonrpc-client@2.4.0-rc.1 requires rustc 1.82.0
  near-mainnet-res@2.4.0-rc.1 requires rustc 1.82.0
  near-network@2.4.0-rc.1 requires rustc 1.82.0
  near-network@2.4.0-rc.1 requires rustc 1.82.0
  near-network@2.4.0-rc.1 requires rustc 1.82.0
  near-performance-metrics-macros@2.4.0-rc.1 requires rustc 1.82.0
  near-pool@2.4.0-rc.1 requires rustc 1.82.0
  near-rosetta-rpc@2.4.0-rc.1 requires rustc 1.82.0
  near-store@2.4.0-rc.1 requires rustc 1.82.0
  near-telemetry@2.4.0-rc.1 requires rustc 1.82.0
  near-wallet-contract@2.4.0-rc.1 requires rustc 1.82.0
  near-wallet-contract@2.4.0-rc.1 requires rustc 1.82.0
  near-wallet-contract@2.4.0-rc.1 requires rustc 1.82.0
  nearcore@2.4.0-rc.1 requires rustc 1.82.0
  node-runtime@2.4.0-rc.1 requires rustc 1.82.0
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.81.0
```