### PR TITLE
Read proper package version as a source of the service version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,7 @@ dependencies = [
  "tokio",
  "tracing",
  "triehash-ethereum",
+ "vergen-git2",
 ]
 
 [[package]]
@@ -3108,6 +3109,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
+dependencies = [
+ "bitflags 2.8.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3920,6 +3934,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.0+1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4017,6 +4043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -5720,6 +5747,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -8203,7 +8239,9 @@ checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -8791,6 +8829,45 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "9.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d2f179f8075b805a43a2a21728a46f0cc2921b3c58695b28fa8817e103cd9a"
+dependencies = [
+ "anyhow",
+ "derive_builder 0.20.2",
+ "rustversion",
+ "time",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-git2"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86bae87104cb2790cdee615c2bb54729804d307191732ab27b1c5357ea6ddc5"
+dependencies = [
+ "anyhow",
+ "derive_builder 0.20.2",
+ "git2",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder 0.20.2",
+ "rustversion",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,7 @@ dependencies = [
  "prometheus",
  "rlp 0.6.1",
  "rocksdb",
+ "semver 1.0.25",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ rlp = "0.6"
 rocksdb = { version = "0.21", default-features = false, features = ["snappy", "zstd", "zlib", "bzip2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+semver = "1.0.25"
 sha3 = "0.10"
 tempfile = "3"
 tokio = "1"
@@ -52,4 +53,4 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 triehash-ethereum = { git = "https://github.com/openethereum/openethereum" }
-vergen-git2 = "1"
+vergen-git2 = "1.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,4 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 triehash-ethereum = { git = "https://github.com/openethereum/openethereum" }
+vergen-git2 = "1"

--- a/refiner-lib/Cargo.toml
+++ b/refiner-lib/Cargo.toml
@@ -43,6 +43,7 @@ vergen-git2 = { workspace = true, features = ["build"] }
 [dev-dependencies]
 serde_json.workspace = true
 tempfile.workspace = true
+semver.workspace = true
 
 [features]
 ext-connector = ["aurora-engine/ext-connector", "engine-standalone-storage/ext-connector", "aurora-refiner-types/ext-connector", "aurora-standalone-engine/ext-connector"]

--- a/refiner-lib/Cargo.toml
+++ b/refiner-lib/Cargo.toml
@@ -36,6 +36,10 @@ tracing.workspace = true
 tokio = { workspace = true, features = ["sync", "macros"] }
 rocksdb.workspace = true
 
+[build-dependencies]
+anyhow.workspace = true
+vergen-git2 = { workspace = true, features = ["build"] }
+
 [dev-dependencies]
 serde_json.workspace = true
 tempfile.workspace = true

--- a/refiner-lib/build.rs
+++ b/refiner-lib/build.rs
@@ -1,0 +1,7 @@
+use vergen_git2::{Emitter, Git2Builder};
+
+fn main() -> anyhow::Result<()> {
+    let git2 = Git2Builder::all_git()?;
+    Emitter::default().add_instructions(&git2)?.emit()?;
+    Ok(())
+}

--- a/refiner-lib/src/metrics.rs
+++ b/refiner-lib/src/metrics.rs
@@ -461,9 +461,7 @@ mod tests {
         let comparator = &version_req.comparators[0];
 
         // If the version string includes a hyphen, we expect a pre-release segment that holds our build hash.
-        if version_str.contains('-') {
-            let parts: Vec<&str> = version_str.splitn(2, '-').collect();
-            let expected_pre = parts[1];
+        if let Some((_, expected_pre)) = version_str.split_once('-') {
             assert!(
                 !expected_pre.is_empty(),
                 "Expected non-empty pre-release (build hash) from the version string"

--- a/refiner-lib/src/metrics.rs
+++ b/refiner-lib/src/metrics.rs
@@ -416,3 +416,69 @@ fn version() -> String {
         pkg_ver
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use prometheus::{Encoder, TextEncoder};
+    use semver::VersionReq;
+
+    use super::*;
+
+    #[test]
+    fn test_version_in_metrics() {
+        let version = version();
+        let _counter_metric = counter("counter_metric_with_network", "Counter Metric With Network");
+        let _gauge_metric = gauge("gauge_metric_with_network", "Gauge Metric With Network");
+        let registry = prometheus::default_registry();
+        let metrics = registry.gather();
+        let mut buffer = Vec::new();
+        let encoder = TextEncoder::new();
+
+        encoder.encode(&metrics, &mut buffer).unwrap();
+        let output = String::from_utf8(buffer).unwrap();
+
+        assert!(output.contains(&format!(
+            "counter_metric_with_network{{version=\"{version}\"}} 0",
+        )));
+        assert!(output.contains(&format!(
+            "gauge_metric_with_network{{version=\"{version}\"}} 0",
+        )));
+    }
+
+    #[test]
+    fn test_version_in_semver_format() {
+        let version_str = version();
+        println!("Parsed version string: {}", version_str);
+
+        let version_req = VersionReq::parse(&version_str).unwrap();
+
+        // There should be exactly one comparator in an exact version requirement.
+        assert_eq!(
+            version_req.comparators.len(),
+            1,
+            "Expected one comparator in the version requirement"
+        );
+        let comparator = &version_req.comparators[0];
+
+        // If the version string includes a hyphen, we expect a pre-release segment that holds our build hash.
+        if version_str.contains('-') {
+            let parts: Vec<&str> = version_str.splitn(2, '-').collect();
+            let expected_pre = parts[1];
+            assert!(
+                !expected_pre.is_empty(),
+                "Expected non-empty pre-release (build hash) from the version string"
+            );
+            assert_eq!(
+                comparator.pre.as_str(),
+                expected_pre,
+                "Pre-release part does not match the expected build hash"
+            );
+        } else {
+            // Otherwise, no pre-release should be present.
+            assert!(
+                comparator.pre.is_empty(),
+                "Expected an empty pre-release part when no build hash is present"
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes a version value assigned to the metrics labels.

The version function outputs `{CARGO_PKG_VERSION}-{VERGEN_GIT_SHA}`

If `CARGO_PKG_VERSION` is not set at runtime, it returns to the `CARGO_PKG_VERSION` available at compile time.
If `VERGEN_GIT_SHA` is not set, use `CARGO_PKG_VERSION` as is.
