### PR TITLE
chore: Bump nearcore to 2.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.2-2.5.0-rc.3"
+version = "0.30.2-2.5.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.2-2.5.0-rc.3"
+version = "0.30.2-2.5.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.2-2.5.0-rc.3"
+version = "0.30.2-2.5.0"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.2-2.5.0-rc.3"
+version = "0.30.2-2.5.0"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
@@ -665,8 +665,8 @@ dependencies = [
  "derive_builder 0.20.2",
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
- "near-crypto 2.5.0-rc.3",
- "near-primitives 2.5.0-rc.3",
+ "near-crypto 2.5.0",
+ "near-primitives 2.5.0",
  "serde",
  "serde_json",
  "sha3",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.2-2.5.0-rc.3"
+version = "0.30.2-2.5.0"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -4358,8 +4358,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "derive_more 1.0.0",
@@ -4367,7 +4367,7 @@ dependencies = [
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.5.0-rc.3",
+ "near-time 2.5.0",
  "once_cell",
  "serde",
  "serde_json",
@@ -4378,8 +4378,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4388,16 +4388,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "lru 0.12.5",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "anyhow",
@@ -4416,17 +4416,17 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.5.0-rc.3",
+ "near-crypto 2.5.0",
  "near-epoch-manager",
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.5.0-rc.3",
+ "near-parameters 2.5.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.5.0-rc.3",
- "near-schema-checker-lib 2.5.0-rc.3",
+ "near-primitives 2.5.0",
+ "near-schema-checker-lib 2.5.0",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4446,19 +4446,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 1.0.0",
- "near-config-utils 2.5.0-rc.3",
- "near-crypto 2.5.0-rc.3",
+ "near-config-utils 2.5.0",
+ "near-crypto 2.5.0",
  "near-o11y",
- "near-parameters 2.5.0-rc.3",
- "near-primitives 2.5.0-rc.3",
- "near-time 2.5.0-rc.3",
+ "near-parameters 2.5.0",
+ "near-primitives 2.5.0",
+ "near-time 2.5.0",
  "num-rational 0.3.2",
  "serde",
  "serde_json",
@@ -4470,12 +4470,12 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
- "near-crypto 2.5.0-rc.3",
- "near-primitives 2.5.0-rc.3",
- "near-time 2.5.0-rc.3",
+ "near-crypto 2.5.0",
+ "near-primitives 2.5.0",
+ "near-time 2.5.0",
  "thiserror 2.0.11",
  "time",
  "tracing",
@@ -4483,8 +4483,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "borsh 1.5.5",
@@ -4497,14 +4497,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.5.0-rc.3",
+ "near-crypto 2.5.0",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.5.0-rc.3",
+ "near-primitives 2.5.0",
  "near-store",
  "rand 0.8.5",
  "reed-solomon-erasure",
@@ -4515,17 +4515,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.5.0-rc.3",
+ "near-primitives 2.5.0",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4546,16 +4546,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.5.0-rc.3",
+ "near-crypto 2.5.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.5.0-rc.3",
+ "near-parameters 2.5.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.5.0-rc.3",
+ "near-primitives 2.5.0",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4584,17 +4584,17 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.5.0-rc.3",
- "near-primitives 2.5.0-rc.3",
- "near-time 2.5.0-rc.3",
+ "near-crypto 2.5.0",
+ "near-primitives 2.5.0",
+ "near-time 2.5.0",
  "serde",
  "serde_json",
  "strum 0.24.1",
@@ -4617,8 +4617,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4653,8 +4653,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "blake2",
  "borsh 1.5.5",
@@ -4664,9 +4664,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.5.0-rc.3",
- "near-schema-checker-lib 2.5.0-rc.3",
- "near-stdx 2.5.0-rc.3",
+ "near-config-utils 2.5.0",
+ "near-schema-checker-lib 2.5.0",
+ "near-stdx 2.5.0",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4678,15 +4678,15 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "anyhow",
  "near-chain-configs",
- "near-crypto 2.5.0-rc.3",
+ "near-crypto 2.5.0",
  "near-o11y",
- "near-primitives 2.5.0-rc.3",
- "near-time 2.5.0-rc.3",
+ "near-primitives 2.5.0",
+ "near-time 2.5.0",
  "prometheus",
  "serde",
  "serde_json",
@@ -4697,18 +4697,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "borsh 1.5.5",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.5.0-rc.3",
+ "near-crypto 2.5.0",
  "near-o11y",
- "near-primitives 2.5.0-rc.3",
- "near-schema-checker-lib 2.5.0-rc.3",
+ "near-primitives 2.5.0",
+ "near-schema-checker-lib 2.5.0",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4732,30 +4732,30 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
- "near-primitives-core 2.5.0-rc.3",
+ "near-primitives-core 2.5.0",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.5.0-rc.3",
- "near-crypto 2.5.0-rc.3",
+ "near-config-utils 2.5.0",
+ "near-crypto 2.5.0",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.5.0-rc.3",
+ "near-indexer-primitives 2.5.0",
  "near-o11y",
- "near-parameters 2.5.0-rc.3",
- "near-primitives 2.5.0-rc.3",
+ "near-parameters 2.5.0",
+ "near-primitives 2.5.0",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4779,18 +4779,18 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
- "near-primitives 2.5.0-rc.3",
+ "near-primitives 2.5.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4808,7 +4808,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.5.0-rc.3",
+ "near-primitives 2.5.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -4819,29 +4819,29 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.5.0-rc.3",
+ "near-primitives 2.5.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.5.0-rc.3",
- "near-primitives 2.5.0-rc.3",
- "near-schema-checker-lib 2.5.0-rc.3",
+ "near-crypto 2.5.0",
+ "near-primitives 2.5.0",
+ "near-schema-checker-lib 2.5.0",
  "serde",
  "serde_json",
  "thiserror 2.0.11",
@@ -4876,19 +4876,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.5.0-rc.3",
+ "near-primitives 2.5.0",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "anyhow",
@@ -4908,13 +4908,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.5.0-rc.3",
- "near-fmt 2.5.0-rc.3",
+ "near-crypto 2.5.0",
+ "near-fmt 2.5.0",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.5.0-rc.3",
- "near-schema-checker-lib 2.5.0-rc.3",
+ "near-primitives 2.5.0",
+ "near-schema-checker-lib 2.5.0",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.3",
@@ -4939,14 +4939,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.5.0-rc.3",
- "near-primitives-core 2.5.0-rc.3",
+ "near-crypto 2.5.0",
+ "near-primitives-core 2.5.0",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -4983,14 +4983,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "borsh 1.5.5",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.5.0-rc.3",
- "near-schema-checker-lib 2.5.0-rc.3",
+ "near-primitives-core 2.5.0",
+ "near-schema-checker-lib 2.5.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5001,8 +5001,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -5016,8 +5016,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "quote",
  "syn 2.0.98",
@@ -5025,13 +5025,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "borsh 1.5.5",
- "near-crypto 2.5.0-rc.3",
+ "near-crypto 2.5.0",
  "near-o11y",
- "near-primitives 2.5.0-rc.3",
+ "near-primitives 2.5.0",
  "rand 0.8.5",
 ]
 
@@ -5076,8 +5076,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5092,13 +5092,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.5.0-rc.3",
- "near-fmt 2.5.0-rc.3",
- "near-parameters 2.5.0-rc.3",
- "near-primitives-core 2.5.0-rc.3",
- "near-schema-checker-lib 2.5.0-rc.3",
- "near-stdx 2.5.0-rc.3",
- "near-time 2.5.0-rc.3",
+ "near-crypto 2.5.0",
+ "near-fmt 2.5.0",
+ "near-parameters 2.5.0",
+ "near-primitives-core 2.5.0",
+ "near-schema-checker-lib 2.5.0",
+ "near-stdx 2.5.0",
+ "near-time 2.5.0",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5139,8 +5139,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5149,7 +5149,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.5.0-rc.3",
+ "near-schema-checker-lib 2.5.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5159,8 +5159,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5174,11 +5174,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.5.0-rc.3",
+ "near-crypto 2.5.0",
  "near-network",
  "near-o11y",
- "near-parameters 2.5.0-rc.3",
- "near-primitives 2.5.0-rc.3",
+ "near-parameters 2.5.0",
+ "near-primitives 2.5.0",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5196,8 +5196,8 @@ checksum = "03541d1dadd0b5dd0a2e1ae1fbe5735fdab79332ed556af36cdcbe50d4b8cf04"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5211,11 +5211,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
- "near-schema-checker-core 2.5.0-rc.3",
- "near-schema-checker-macro 2.5.0-rc.3",
+ "near-schema-checker-core 2.5.0",
+ "near-schema-checker-macro 2.5.0",
 ]
 
 [[package]]
@@ -5226,8 +5226,8 @@ checksum = "a1bca8c93ff0ad17138c147323a07f036d11c9e1602e3bc2ac9d29c3cf78b89d"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 
 [[package]]
 name = "near-stdx"
@@ -5237,13 +5237,13 @@ checksum = "427b4e4af5e32f682064772da8b1a7558b3f090e6151c8804cff24ee6c5c4966"
 
 [[package]]
 name = "near-stdx"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 
 [[package]]
 name = "near-store"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5260,14 +5260,14 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.5.0-rc.3",
- "near-fmt 2.5.0-rc.3",
+ "near-crypto 2.5.0",
+ "near-fmt 2.5.0",
  "near-o11y",
- "near-parameters 2.5.0-rc.3",
- "near-primitives 2.5.0-rc.3",
- "near-schema-checker-lib 2.5.0-rc.3",
- "near-stdx 2.5.0-rc.3",
- "near-time 2.5.0-rc.3",
+ "near-parameters 2.5.0",
+ "near-primitives 2.5.0",
+ "near-schema-checker-lib 2.5.0",
+ "near-stdx 2.5.0",
+ "near-time 2.5.0",
  "near-vm-runner",
  "num_cpus",
  "rand 0.8.5",
@@ -5287,8 +5287,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "awc",
@@ -5297,7 +5297,7 @@ dependencies = [
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-time 2.5.0-rc.3",
+ "near-time 2.5.0",
  "openssl",
  "serde",
  "serde_json",
@@ -5316,8 +5316,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "serde",
  "time",
@@ -5326,8 +5326,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5342,8 +5342,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5362,8 +5362,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5384,8 +5384,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "anyhow",
  "blst",
@@ -5396,12 +5396,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.5.0-rc.3",
+ "near-crypto 2.5.0",
  "near-o11y",
- "near-parameters 2.5.0-rc.3",
- "near-primitives-core 2.5.0-rc.3",
- "near-schema-checker-lib 2.5.0-rc.3",
- "near-stdx 2.5.0-rc.3",
+ "near-parameters 2.5.0",
+ "near-primitives-core 2.5.0",
+ "near-schema-checker-lib 2.5.0",
+ "near-stdx 2.5.0",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5440,8 +5440,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "indexmap 2.7.1",
  "num-traits",
@@ -5451,8 +5451,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "backtrace",
  "cc",
@@ -5472,18 +5472,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.5.0-rc.3",
+ "near-primitives-core 2.5.0",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5508,8 +5508,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.5.0-rc.3",
- "near-crypto 2.5.0-rc.3",
+ "near-config-utils 2.5.0",
+ "near-crypto 2.5.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5517,10 +5517,10 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.5.0-rc.3",
+ "near-parameters 2.5.0",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.5.0-rc.3",
+ "near-primitives 2.5.0",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5573,17 +5573,17 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.5.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.5.0-rc.3#aa803039d4e5a6a5ee2b42cab0ea026acfb19f36"
+version = "2.5.0"
+source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "borsh 1.5.5",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.5.0-rc.3",
+ "near-crypto 2.5.0",
  "near-o11y",
- "near-parameters 2.5.0-rc.3",
- "near-primitives 2.5.0-rc.3",
- "near-primitives-core 2.5.0-rc.3",
+ "near-parameters 2.5.0",
+ "near-primitives 2.5.0",
+ "near-primitives-core 2.5.0",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -33,7 +33,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -71,7 +71,7 @@ dependencies = [
  "actix-utils",
  "ahash 0.8.11",
  "base64 0.22.1",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "brotli",
  "bytes",
  "bytestring",
@@ -105,7 +105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -255,7 +255,7 @@ checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arbitrary"
@@ -450,18 +450,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -643,7 +643,7 @@ dependencies = [
  "prometheus",
  "rlp 0.6.1",
  "rocksdb",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "tempfile",
@@ -662,7 +662,7 @@ dependencies = [
  "aurora-engine-transactions",
  "aurora-engine-types",
  "borsh 1.5.5",
- "derive_builder 0.20.2",
+ "derive_builder",
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
  "near-crypto 2.5.0",
@@ -703,7 +703,7 @@ checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.5.16"
+version = "1.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50236e4d60fe8458de90a71c0922c761e41755adf091b1b03de1cef537179915"
+checksum = "490aa7465ee685b2ced076bb87ef654a47724a7844e2c7d3af4e749ce5b875dd"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -768,7 +768,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 0.2.12",
- "ring 0.17.8",
+ "ring 0.17.11",
  "time",
  "tokio",
  "tracing",
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.74.0"
+version = "1.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f551566d462b47c3e49b330f1b86e69e7dc6e4d4efb1959e28c5c82d22e79f7c"
+checksum = "34e87342432a3de0e94e82c99a7cbd9042f99de029ae1f4e368160f9e9929264"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.58.0"
+version = "1.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ff718c9ee45cc1ebd4774a0e086bb80a6ab752b4902edf1c9f56b86ee1f770"
+checksum = "60186fab60b24376d3e33b9ff0a43485f99efd470e3b75a9160c849741d63d56"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.59.0"
+version = "1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5183e088715cc135d8d396fdd3bc02f018f0da4c511f53cb8d795b6a31c55809"
+checksum = "7033130ce1ee13e6018905b7b976c915963755aef299c1521897679d6cd4f8ef"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.59.0"
+version = "1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f944ef032717596639cea4a2118a3a457268ef51bbb5fde9637e54c465da00"
+checksum = "c5c1cac7677179d622b4448b0d31bcb359185295dc6fca891920cfb17e2b5156"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.8"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc5bbd1e4a2648fd8c5982af03935972c24a2f9846b396de661d351ee3ce837"
+checksum = "9bfe75fad52793ce6dec0dc3d4b1f388f038b5eb866c8d4d7f3a8e21b5ea5051"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -961,7 +961,7 @@ dependencies = [
  "once_cell",
  "p256",
  "percent-encoding",
- "ring 0.17.8",
+ "ring 0.17.11",
  "sha2 0.10.8",
  "subtle",
  "time",
@@ -982,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.62.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f45a1c384d7a393026bc5f5c177105aa9fa68e4749653b985707ac27d77295"
+checksum = "db2dc8d842d872529355c72632de49ef8c5a2949a4472f10e802f28cf925770c"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -1004,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.6"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b18559a41e0c909b77625adf2b8c50de480a8041e5e4a3f5f7d177db70abc5a"
+checksum = "461e5e02f9864cba17cff30f007c2e37ade94d01e87cdb5204e44a84e6d38c17"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -1279,7 +1279,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1290,9 +1290,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitmaps"
@@ -1336,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.5"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+checksum = "675f87afced0413c9bb02843499dbbd3882a237645883f71a2b59644a6d2f753"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
@@ -1377,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
 dependencies = [
  "cc",
  "glob",
@@ -1430,7 +1430,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1506,9 +1506,9 @@ checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytecheck"
@@ -1552,7 +1552,7 @@ checksum = "efb7846e0cb180355c2dec69e721edafa36919850f1a9f52ffba4ebc0393cb71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1579,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "bytesize"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be86d344a38e89fbd55f1ea57796346ba10923e07a4b3d0516fdc76a27b2fb34"
+checksum = "2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e"
 dependencies = [
  "serde",
 ]
@@ -1597,39 +1597,19 @@ dependencies = [
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
 [[package]]
-name = "cbindgen"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
-dependencies = [
- "clap",
- "heck 0.4.1",
- "indexmap 2.7.1",
- "log",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn 2.0.98",
- "tempfile",
- "toml 0.8.20",
-]
-
-[[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -1665,9 +1645,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1675,7 +1655,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1691,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.28"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1701,14 +1681,14 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -1720,7 +1700,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1775,9 +1755,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -2001,11 +1981,10 @@ dependencies = [
 
 [[package]]
 name = "crc64fast-nvme"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5e2ee08013e3f228d6d2394116c4549a6df77708442c62d887d83f68ef2ee37"
+checksum = "4955638f00a809894c947f85a024020a20815b65a5eea633798ea7924edab2b3"
 dependencies = [
- "cbindgen",
  "crc",
 ]
 
@@ -2137,17 +2116,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2156,22 +2125,8 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core 0.20.10",
- "darling_macro 0.20.10",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -2184,19 +2139,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
+ "strsim",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2205,9 +2149,9 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core 0.20.10",
+ "darling_core",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2238,7 +2182,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2249,16 +2193,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f59169f400d8087f238c5c0c7db6a28af18681717f3b623227d92f397e938c7"
-dependencies = [
- "derive_builder_macro 0.13.1",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2267,19 +2202,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
- "derive_builder_macro 0.20.2",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ec317cc3e7ef0928b0ca6e4a634a4d6c001672ae210438cf114a83e56b018d"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "derive_builder_macro",
 ]
 
 [[package]]
@@ -2288,20 +2211,10 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling 0.20.10",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870368c3fb35b8031abb378861d4460f573b92238ec2152c927a21f77e3e0127"
-dependencies = [
- "derive_builder_core 0.13.1",
- "syn 1.0.109",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2310,8 +2223,8 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
- "derive_builder_core 0.20.2",
- "syn 2.0.98",
+ "derive_builder_core",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2324,7 +2237,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2344,7 +2257,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2404,14 +2317,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "dissimilar"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
+checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
 name = "dlv-list"
@@ -2520,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "elliptic-curve"
@@ -2621,7 +2534,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2639,10 +2552,10 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59c3b24c345d8c314966bdc1832f6c2635bfcce8e7cf363bd115987bba2ee242"
 dependencies = [
- "darling 0.20.10",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2653,9 +2566,9 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -2891,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3012,7 +2925,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3115,7 +3028,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -3160,9 +3073,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3346,9 +3259,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -3389,7 +3302,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
+ "h2 0.4.8",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -3426,10 +3339,10 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tower-service",
 ]
 
@@ -3631,7 +3544,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3701,9 +3614,9 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67aa010c1e3da95bf151bd8b4c059b2ed7e75387cdb969b4f8f2723a43f9941"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
 dependencies = [
  "parity-scale-codec 3.7.4",
 ]
@@ -3758,7 +3671,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3838,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
@@ -3930,9 +3843,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libgit2-sys"
@@ -3968,7 +3881,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
 ]
 
@@ -4057,9 +3970,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "local-channel"
@@ -4099,9 +4012,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lru"
@@ -4174,7 +4087,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4284,9 +4197,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -4311,29 +4224,29 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "munge"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64142d38c84badf60abf06ff9bd80ad2174306a5b11bd4706535090a30a419df"
+checksum = "a0091202c98cf06da46c279fdf50cccb6b1c43b4521abdf6a27b4c7e71d5d9d7"
 dependencies = [
  "munge_macro",
 ]
 
 [[package]]
 name = "munge_macro"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb5c1d8184f13f7d0ccbeeca0def2f9a181bce2624302793005f5ca8aa62e5e"
+checksum = "734799cf91479720b2f970c61a22850940dd91e27d4f02b1c6fc792778df2459"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -4383,7 +4296,7 @@ source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e3
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4438,7 +4351,7 @@ dependencies = [
  "serde",
  "strum 0.24.1",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tracing",
@@ -4476,7 +4389,7 @@ dependencies = [
  "near-crypto 2.5.0",
  "near-primitives 2.5.0",
  "near-time 2.5.0",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tracing",
 ]
@@ -4573,7 +4486,7 @@ dependencies = [
  "strum 0.24.1",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-stream",
@@ -4598,20 +4511,20 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.24.1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tracing",
 ]
 
 [[package]]
 name = "near-config-utils"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7b41110a20f1d82bb06f06e4800068c5ade6d8ff844787f8753bc2ce7b16f7"
+checksum = "bedc768765dd8229a1d960c94f517317f40771a003e78916124784c7d6ea9d74"
 dependencies = [
  "anyhow",
  "json_comments",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -4622,15 +4535,15 @@ source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e3
 dependencies = [
  "anyhow",
  "json_comments",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "near-crypto"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b17944c8d0f274c684227d79fcd46d583b1e36064b597c53a9ebec187a86f3"
+checksum = "4374804fdd45ac84c9e7cc3183312c98560c5518d81e6d8e2d92b77587e5a9f3"
 dependencies = [
  "blake2",
  "borsh 1.5.5",
@@ -4640,15 +4553,15 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 0.27.0",
- "near-schema-checker-lib 0.27.0",
- "near-stdx 0.27.0",
+ "near-config-utils 0.28.0",
+ "near-schema-checker-lib 0.28.0",
+ "near-stdx 0.28.0",
  "primitive-types 0.10.1",
  "secp256k1",
  "serde",
  "serde_json",
  "subtle",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4673,7 +4586,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subtle",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4690,7 +4603,7 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -4723,11 +4636,11 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eff0731995774d1498f017c968a3ebbfdadad84f556afea4b83679f6706ac9"
+checksum = "f14f36eee2dcb0ecd8febb9f198e0e1fa768c834db9e1982ad2acfcd04b45acf"
 dependencies = [
- "near-primitives-core 0.27.0",
+ "near-primitives-core 0.28.0",
 ]
 
 [[package]]
@@ -4768,11 +4681,11 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9644d23252a0af5c5151b40d440d64339618f356d7ec19ddfd1ce004863a1d"
+checksum = "008a7f45c5ffb9e65f7e44b60fb6128a3022aaf304010a9b72090391d7788f6b"
 dependencies = [
- "near-primitives 0.27.0",
+ "near-primitives 0.28.0",
  "serde",
  "serde_json",
 ]
@@ -4844,15 +4757,15 @@ dependencies = [
  "near-schema-checker-lib 2.5.0",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
 
 [[package]]
 name = "near-lake-framework"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b784d25c9eae449a09f432c85bfc98ab4ea30af0242ec81b37acf357652641d7"
+checksum = "5b71ff26c06b518f1e0c3ac7435cd735d93057362b22446dd01a27308e024720"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4862,13 +4775,13 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-types",
  "aws-types",
- "derive_builder 0.13.1",
+ "derive_builder",
  "futures",
- "near-indexer-primitives 0.27.0",
+ "near-indexer-primitives 0.28.0",
  "reqwest 0.12.12",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4929,7 +4842,7 @@ dependencies = [
  "smart-default 0.7.1",
  "strum 0.24.1",
  "stun",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-stream",
@@ -4954,7 +4867,7 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -4964,21 +4877,21 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4b4d014ac9f46baf0eeac7214567a08db97d5fd26157ea13edfbb8ffc5fd8c"
+checksum = "1279baa276725971d5e2b80c524d1aa42d5ad8bccf8901466fd579374cf58a14"
 dependencies = [
  "borsh 1.5.5",
  "enum-map",
  "near-account-id",
- "near-primitives-core 0.27.0",
- "near-schema-checker-lib 0.27.0",
+ "near-primitives-core 0.28.0",
+ "near-schema-checker-lib 0.28.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
  "serde_yaml",
  "strum 0.24.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4996,7 +4909,7 @@ dependencies = [
  "serde_repr",
  "serde_yaml",
  "strum 0.24.1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5020,7 +4933,7 @@ version = "2.5.0"
 source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e32c581e7e75cb8c388"
 dependencies = [
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5037,9 +4950,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45b4742a1817ff7d80dcf51c6facb8134478f8c4a6d717825cca2e4b834b17f"
+checksum = "6ab6ecc354e61c40b044c8b553c187383a587a1679d2e594f0b98ca58dbfb6e3"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5053,13 +4966,14 @@ dependencies = [
  "easy-ext",
  "enum-map",
  "hex",
- "near-crypto 0.27.0",
- "near-fmt 0.27.0",
- "near-parameters 0.27.0",
- "near-primitives-core 0.27.0",
- "near-schema-checker-lib 0.27.0",
- "near-stdx 0.27.0",
- "near-time 0.27.0",
+ "itertools 0.10.5",
+ "near-crypto 0.28.0",
+ "near-fmt 0.28.0",
+ "near-parameters 0.28.0",
+ "near-primitives-core 0.28.0",
+ "near-schema-checker-lib 0.28.0",
+ "near-stdx 0.28.0",
+ "near-time 0.28.0",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5069,7 +4983,7 @@ dependencies = [
  "sha3",
  "smart-default 0.6.0",
  "strum 0.24.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
  "zstd",
 ]
@@ -5111,16 +5025,16 @@ dependencies = [
  "sha3",
  "smart-default 0.7.1",
  "strum 0.24.1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "zstd",
 ]
 
 [[package]]
 name = "near-primitives-core"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de2c9da5de096b5cd4786a270900ff32a49d267e442a2e7f271fb23eb925c87"
+checksum = "d597af103bb7881d1fb9031fb126cfe6c1acb9c9a6c8296dca45b5b3beb0893d"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5129,12 +5043,12 @@ dependencies = [
  "derive_more 0.99.19",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 0.27.0",
+ "near-schema-checker-lib 0.28.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
  "sha2 0.10.8",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5154,7 +5068,7 @@ dependencies = [
  "serde",
  "serde_repr",
  "sha2 0.10.8",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5184,15 +5098,15 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.24.1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03541d1dadd0b5dd0a2e1ae1fbe5735fdab79332ed556af36cdcbe50d4b8cf04"
+checksum = "a48405425eca34de98e680416310df33fdb75768a78481cc75b43172b2748613"
 
 [[package]]
 name = "near-schema-checker-core"
@@ -5201,12 +5115,12 @@ source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e3
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9050b0822d2c0dbd90d8c523fd74634f77c5be4ed3337e7010c0d986121982"
+checksum = "dfb720bf5cc256af687a9eb7a6e05baf3668dc75cfd43098e83ba1b3d3900f08"
 dependencies = [
- "near-schema-checker-core 0.27.0",
- "near-schema-checker-macro 0.27.0",
+ "near-schema-checker-core 0.28.0",
+ "near-schema-checker-macro 0.28.0",
 ]
 
 [[package]]
@@ -5220,9 +5134,9 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1bca8c93ff0ad17138c147323a07f036d11c9e1602e3bc2ac9d29c3cf78b89d"
+checksum = "b41a159cbf732acc0279febdde046d9036330a32a951796bce42f9529bce799d"
 
 [[package]]
 name = "near-schema-checker-macro"
@@ -5231,9 +5145,9 @@ source = "git+https://github.com/near/nearcore?tag=2.5.0#a0f052f220301e2b73e37e3
 
 [[package]]
 name = "near-stdx"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427b4e4af5e32f682064772da8b1a7558b3f090e6151c8804cff24ee6c5c4966"
+checksum = "7a91674768828a593f4bac4aeca9334c4b56fe19344a2ccf7bd795b2325f0b5e"
 
 [[package]]
 name = "near-stdx"
@@ -5280,7 +5194,7 @@ dependencies = [
  "smallvec",
  "strum 0.24.1",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -5306,9 +5220,9 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ade805f0ca8211f0ca2e6ea130f8ddd03bf70c9c93ebeabdddf37314e3f30b"
+checksum = "c92bf9dffb11126e8db9a6a51bcb330c8584d0bab0d6d14c20cf2ff1f16d684d"
 dependencies = [
  "serde",
  "time",
@@ -5335,7 +5249,7 @@ dependencies = [
  "near-vm-vm",
  "rkyv 0.8.10",
  "target-lexicon 0.12.16",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "wasmparser 0.99.0",
 ]
@@ -5378,7 +5292,7 @@ dependencies = [
  "rustc-demangle",
  "rustix",
  "target-lexicon 0.12.16",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -5422,7 +5336,7 @@ dependencies = [
  "sha3",
  "strum 0.24.1",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "wasm-encoder 0.218.1",
  "wasmer-compiler-near",
@@ -5446,7 +5360,7 @@ dependencies = [
  "indexmap 2.7.1",
  "num-traits",
  "rkyv 0.8.10",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5465,7 +5379,7 @@ dependencies = [
  "near-vm-types",
  "region",
  "rkyv 0.8.10",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "winapi",
 ]
@@ -5539,7 +5453,7 @@ dependencies = [
  "smart-default 0.7.1",
  "strum 0.24.1",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5594,7 +5508,7 @@ dependencies = [
  "rayon",
  "serde_json",
  "sha2 0.10.8",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -5792,11 +5706,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -5813,7 +5727,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5824,18 +5738,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "300.4.2+3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -5985,7 +5899,7 @@ dependencies = [
  "paperclip-actix",
  "paperclip-core",
  "paperclip-macros",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6066,7 +5980,7 @@ checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec 1.0.1",
- "byte-slice-cast 1.2.2",
+ "byte-slice-cast 1.2.3",
  "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -6083,7 +5997,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6165,7 +6079,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.10",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -6219,22 +6133,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6261,9 +6175,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain_hasher"
@@ -6276,9 +6190,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "postcard"
@@ -6358,12 +6272,12 @@ checksum = "aa06bd51638b6e76ac9ba9b6afb4164fa647bd2916d722f2623fbb6d1ed8bdba"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "f1ccf34da56fc294e7d4ccf69a85992b7dfb826b7cf57bac6a70bba3494cc08a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6407,7 +6321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
 dependencies = [
  "fixed-hash 0.8.0",
- "impl-codec 0.7.0",
+ "impl-codec 0.7.1",
  "impl-rlp 0.4.0",
  "impl-serde 0.5.0",
  "uint 0.10.0",
@@ -6474,14 +6388,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -6521,7 +6435,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6583,9 +6497,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
+checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
 dependencies = [
  "cc",
 ]
@@ -6627,7 +6541,7 @@ checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6654,9 +6568,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -6714,8 +6628,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.0",
- "zerocopy 0.8.17",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -6745,7 +6659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -6769,12 +6683,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -6841,11 +6754,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -7020,7 +6933,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
+ "h2 0.4.8",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -7081,15 +6994,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
@@ -7159,7 +7071,7 @@ checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -7199,7 +7111,7 @@ checksum = "652db34deaaa57929e10ca18e5454a32cb0efc351ae80d320334bbf907b908b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -7293,7 +7205,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.25",
+ "semver 1.0.26",
 ]
 
 [[package]]
@@ -7302,7 +7214,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno 0.3.10",
  "libc",
  "linux-raw-sys",
@@ -7316,16 +7228,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring 0.17.11",
  "rustls-webpki 0.101.7",
  "sct",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -7376,7 +7288,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.11",
  "untrusted 0.9.0",
 ]
 
@@ -7386,16 +7298,16 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.11",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rxml"
@@ -7416,9 +7328,9 @@ checksum = "22a197350ece202f19a166d1ad6d9d6de145e1d2a8ef47db299abe164dbd7530"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scale-info"
@@ -7442,7 +7354,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -7466,7 +7378,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.11",
  "untrusted 0.9.0",
 ]
 
@@ -7515,7 +7427,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -7543,9 +7455,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "semver-parser"
@@ -7555,9 +7467,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
@@ -7586,38 +7498,38 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+checksum = "364fec0df39c49a083c9a8a18a23a6bcfd9af130fe9fe321d18520a0d113e09e"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "serde_ignored"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e319a36d1b52126a0d608f24e93b2d81297091818cd70625fcf50a15d84ddf"
+checksum = "566da67d80e92e009728b3731ff0e5360cb181432b8ca73ea30bb1d170700d76"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -7627,13 +7539,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -7681,10 +7593,10 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
- "darling 0.20.10",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -7835,9 +7747,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 dependencies = [
  "serde",
 ]
@@ -7861,7 +7773,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -7938,12 +7850,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -7989,7 +7895,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -8030,9 +7936,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8062,7 +7968,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -8097,7 +8003,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "system-configuration-sys 0.6.0",
 ]
@@ -8142,9 +8048,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
@@ -8174,11 +8080,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -8189,18 +8095,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -8295,9 +8201,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -8344,7 +8250,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -8406,11 +8312,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "tokio",
 ]
 
@@ -8587,7 +8493,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -8675,9 +8581,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "uint"
@@ -8729,9 +8635,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
@@ -8815,9 +8721,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.13.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 
 [[package]]
 name = "valuable"
@@ -8838,7 +8744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d2f179f8075b805a43a2a21728a46f0cc2921b3c58695b28fa8817e103cd9a"
 dependencies = [
  "anyhow",
- "derive_builder 0.20.2",
+ "derive_builder",
  "rustversion",
  "time",
  "vergen-lib",
@@ -8851,7 +8757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86bae87104cb2790cdee615c2bb54729804d307191732ab27b1c5357ea6ddc5"
 dependencies = [
  "anyhow",
- "derive_builder 0.20.2",
+ "derive_builder",
  "git2",
  "rustversion",
  "time",
@@ -8866,7 +8772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
 dependencies = [
  "anyhow",
- "derive_builder 0.20.2",
+ "derive_builder",
  "rustversion",
 ]
 
@@ -8967,7 +8873,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -9002,7 +8908,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9254,10 +9160,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059739c2eac26eea736389a7d6d30b41a8201490bea204d0facde19183359849"
 dependencies = [
  "ahash 0.8.11",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "hashbrown 0.14.5",
  "indexmap 2.7.1",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
 ]
 
@@ -9289,7 +9195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e762e163fd305770c6c341df3290f0cabb3c264e7952943018e9a1ced8d917"
 dependencies = [
  "anyhow",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bumpalo",
  "cc",
  "cfg-if 1.0.0",
@@ -9341,7 +9247,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -9427,7 +9333,7 @@ checksum = "db8efb877c9e5e67239d4553bb44dd2a34ae5cfb728f3cf2c5e64439c6ca6ee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -9513,7 +9419,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.10",
  "wasite",
  "web-sys",
 ]
@@ -9563,6 +9469,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"
@@ -9744,9 +9656,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]
@@ -9767,7 +9679,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -9780,7 +9692,7 @@ dependencies = [
  "id-arena",
  "indexmap 2.7.1",
  "log",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9856,7 +9768,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -9872,11 +9784,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.17"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
 dependencies = [
- "zerocopy-derive 0.8.17",
+ "zerocopy-derive 0.8.21",
 ]
 
 [[package]]
@@ -9887,38 +9799,38 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.17"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -9939,7 +9851,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -9975,32 +9887,32 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.14+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.2-2.5.0-rc.3"
+version = "0.30.2-2.5.0"
 edition = "2021"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -36,9 +36,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.5.0-rc.3" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.5.0-rc.3" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.5.0-rc.3" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.5.0" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.5.0" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.5.0" }
 near-lake-framework = "0.7"
 prometheus = "0.13"
 rlp = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
 version = "0.30.2-2.5.0"
-edition = "2021"
+edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
 license = "CC0-1.0"

--- a/engine/src/batch_tx_processing.rs
+++ b/engine/src/batch_tx_processing.rs
@@ -1,7 +1,7 @@
 use aurora_engine_sdk::io::IO;
 use engine_standalone_storage::{
-    engine_state::{EngineStateAccess, EngineStorageValue},
     Diff,
+    engine_state::{EngineStateAccess, EngineStorageValue},
 };
 use std::cell::RefCell;
 

--- a/engine/src/gas.rs
+++ b/engine/src/gas.rs
@@ -6,13 +6,12 @@ use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_sdk::io::IO;
 use aurora_engine_transactions::NormalizedEthTransaction;
 use aurora_engine_types::{
-    storage,
+    H160, H256, U256, storage,
     types::{Address, Wei},
-    H160, H256, U256,
 };
 use engine_standalone_storage::{
-    engine_state::{EngineStateAccess, EngineStorageValue},
     Storage,
+    engine_state::{EngineStateAccess, EngineStorageValue},
 };
 use std::collections::HashMap;
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,7 +1,7 @@
 use aurora_engine_modexp::ModExpAlgorithm;
-use aurora_engine_types::{account_id::AccountId, H256};
+use aurora_engine_types::{H256, account_id::AccountId};
 use aurora_refiner_types::{near_block::NEARBlock, near_primitives::hash::CryptoHash};
-use engine_standalone_storage::{error, sync::TransactionIncludedOutcome, Storage};
+use engine_standalone_storage::{Storage, error, sync::TransactionIncludedOutcome};
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::path::Path;

--- a/engine/src/sync.rs
+++ b/engine/src/sync.rs
@@ -2,7 +2,7 @@ use aurora_engine::parameters;
 use aurora_engine_modexp::ModExpAlgorithm;
 use aurora_engine_sdk::env;
 use aurora_engine_types::borsh::BorshDeserialize;
-use aurora_engine_types::{account_id::AccountId, H256};
+use aurora_engine_types::{H256, account_id::AccountId};
 use aurora_refiner_types::near_primitives::{
     self,
     hash::CryptoHash,
@@ -10,12 +10,11 @@ use aurora_refiner_types::near_primitives::{
 };
 use engine_standalone_storage::sync::types::TransactionKind;
 use engine_standalone_storage::{
-    sync::{
-        self,
-        types::{self, Message},
-        ConsumeMessageOutcome, TransactionExecutionResult, TransactionIncludedOutcome,
-    },
     BlockMetadata, Diff, Storage,
+    sync::{
+        self, ConsumeMessageOutcome, TransactionExecutionResult, TransactionIncludedOutcome,
+        types::{self, Message},
+    },
 };
 use lru::LruCache;
 use std::{cell::RefCell, collections::HashMap};
@@ -260,13 +259,13 @@ pub fn consume_near_block<M: ModExpAlgorithm>(
                                 );
                             }
                         }
-                        Err(_) => warn!(
-                             "Unable to deserialize receipt_id={receipt_id:?} as SubmitResult",
-                        ),
+                        Err(_) => {
+                            warn!("Unable to deserialize receipt_id={receipt_id:?} as SubmitResult",)
+                        }
                     }
                 }
                 None => warn!(
-                     "Expected receipt_id={receipt_id:?} to have a return result, but there was none",
+                    "Expected receipt_id={receipt_id:?} to have a return result, but there was none",
                 ),
             }
         }

--- a/engine/src/tests.rs
+++ b/engine/src/tests.rs
@@ -1,10 +1,10 @@
 use aurora_engine::parameters::TransactionStatus;
 use aurora_engine_modexp::AuroraModExp;
-use aurora_engine_types::{account_id::AccountId, H256};
+use aurora_engine_types::{H256, account_id::AccountId};
 use aurora_refiner_types::near_block::NEARBlock;
+use engine_standalone_storage::Storage;
 use engine_standalone_storage::json_snapshot::{self, types::JsonSnapshot};
 use engine_standalone_storage::sync::TransactionExecutionResult;
-use engine_standalone_storage::Storage;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 

--- a/engine/src/tracing/alchemy/conversion/mod.rs
+++ b/engine/src/tracing/alchemy/conversion/mod.rs
@@ -4,7 +4,7 @@ use crate::tracing::alchemy::{
     AlchemySuicideAction, AlchemySuicideResult, AlchemySuicideTrace, AlchemySuicideType,
     AlchemyTrace,
 };
-use aurora_engine_types::{types::Address, H256, U256};
+use aurora_engine_types::{H256, U256, types::Address};
 use engine_standalone_tracing::types::call_tracer::{CallFrame, CallType};
 use std::collections::VecDeque;
 

--- a/engine/src/tracing/alchemy/conversion/tests.rs
+++ b/engine/src/tracing/alchemy/conversion/tests.rs
@@ -1,5 +1,5 @@
-use crate::tracing::alchemy::{conversion, AlchemyCallTrace, AlchemyTrace};
-use aurora_engine_types::{types::Address, U256};
+use crate::tracing::alchemy::{AlchemyCallTrace, AlchemyTrace, conversion};
+use aurora_engine_types::{U256, types::Address};
 use engine_standalone_tracing::types::call_tracer::{CallFrame, CallType};
 use std::path::Path;
 

--- a/engine/src/tracing/alchemy/mod.rs
+++ b/engine/src/tracing/alchemy/mod.rs
@@ -1,4 +1,4 @@
-use aurora_engine_types::{types::Address, H256, U256};
+use aurora_engine_types::{H256, U256, types::Address};
 
 pub mod conversion;
 pub mod serialization;

--- a/engine/src/tracing/alchemy/serialization.rs
+++ b/engine/src/tracing/alchemy/serialization.rs
@@ -3,7 +3,7 @@ use crate::tracing::alchemy::{
     AlchemyCreateResult, AlchemyCreateType, AlchemySuicideAction, AlchemySuicideResult,
     AlchemySuicideType, AlchemyTraceTemplate,
 };
-use aurora_engine_types::{types::Address, H256, U256};
+use aurora_engine_types::{H256, U256, types::Address};
 use std::{borrow::Cow, fmt, str::FromStr, string::ToString};
 
 pub const ALCHEMY_CREATE_TYPE_TAG: &str = "create";

--- a/engine/src/tracing/lib.rs
+++ b/engine/src/tracing/lib.rs
@@ -1,8 +1,8 @@
 use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_types::H256;
 use engine_standalone_storage::{
-    sync::{self, TransactionIncludedOutcome},
     Storage,
+    sync::{self, TransactionIncludedOutcome},
 };
 use engine_standalone_tracing::{sputnik, types::call_tracer::CallTracer};
 

--- a/etc/integration-tests/src/nearcore_utils.rs
+++ b/etc/integration-tests/src/nearcore_utils.rs
@@ -116,7 +116,6 @@ pub async fn neard_path() -> anyhow::Result<PathBuf> {
     crate::refiner_utils::get_repository_root()
         .await
         .map(|dir| dir.join("target").join("release").join("neard"))
-        .map_err(Into::into)
 }
 
 async fn create_dirs() -> anyhow::Result<()> {

--- a/refiner-app/src/conversion/mod.rs
+++ b/refiner-app/src/conversion/mod.rs
@@ -9,7 +9,7 @@ pub fn convert(block: StreamerMessage) -> NEARBlock {
             .shards
             .into_iter()
             .map(|shard| Shard {
-                shard_id: shard.shard_id.into(),
+                shard_id: ch_json(shard.shard_id),
                 chunk: shard.chunk.map(|chunk| ChunkView {
                     author: ch_json(chunk.author),
                     header: ChunkHeaderView {

--- a/refiner-app/src/conversion/mod.rs
+++ b/refiner-app/src/conversion/mod.rs
@@ -1,6 +1,6 @@
 use aurora_refiner_types::near_block::{ChunkHeaderView, ChunkView, NEARBlock, Shard};
 use near_lake_framework::near_indexer_primitives::StreamerMessage;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 pub fn convert(block: StreamerMessage) -> NEARBlock {
     NEARBlock {

--- a/refiner-app/src/socket.rs
+++ b/refiner-app/src/socket.rs
@@ -2,8 +2,8 @@ use std::io;
 use std::path::Path;
 
 use aurora_standalone_engine::{
-    gas::{estimate_gas, EthCallRequest},
-    tracing::lib::{trace_transaction, DebugTraceTransactionRequest},
+    gas::{EthCallRequest, estimate_gas},
+    tracing::lib::{DebugTraceTransactionRequest, trace_transaction},
 };
 use engine_standalone_storage::Storage;
 use engine_standalone_tracing::types::call_tracer::SerializableCallFrame;

--- a/refiner-lib/src/hashchain.rs
+++ b/refiner-lib/src/hashchain.rs
@@ -5,8 +5,8 @@ use aurora_engine::parameters::{
     CallArgs, FunctionCallArgsV1, FunctionCallArgsV2, SubmitArgs, SubmitResult, TransactionStatus,
 };
 use aurora_engine_hashchain::merkle::StreamCompactMerkleTree;
-use aurora_engine_transactions::{eip_1559, eip_2930, legacy, EthTransactionKind};
-use aurora_engine_types::{types::u256_to_arr, H256};
+use aurora_engine_transactions::{EthTransactionKind, eip_1559, eip_2930, legacy};
+use aurora_engine_types::{H256, types::u256_to_arr};
 use aurora_refiner_types::aurora_block::{
     AuroraBlock, AuroraTransaction, CallArgsVersion, HashchainInputKind, HashchainOutputKind,
     ResultStatusTag,
@@ -257,7 +257,7 @@ pub enum ValidationError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::near_stream::tests::{read_block, TestContext};
+    use crate::near_stream::tests::{TestContext, read_block};
 
     // All transactions in test blocks should pass `validate_tx_hashchain`.
     // I.e. the method of reproducing the original Near input and output

--- a/refiner-lib/src/lib.rs
+++ b/refiner-lib/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::literal_string_with_formatting_args)]
+
 pub mod hashchain;
 mod metrics;
 pub mod near_stream;

--- a/refiner-lib/src/metrics.rs
+++ b/refiner-lib/src/metrics.rs
@@ -1,12 +1,10 @@
 use engine_standalone_storage::sync::types::TransactionKindTag;
 use lazy_static::lazy_static;
-use prometheus::{self, register_int_counter, register_int_gauge, IntCounter, IntGauge, Opts};
+use prometheus::{self, IntCounter, IntGauge, Opts, register_int_counter, register_int_gauge};
 
 lazy_static! {
-    pub static ref MISSING_SHARDS: IntCounter = counter(
-        "refiner_missing_shards",
-        "Blocks that are missing shards"
-    );
+    pub static ref MISSING_SHARDS: IntCounter =
+        counter("refiner_missing_shards", "Blocks that are missing shards");
     pub static ref BATCHED_ACTIONS: IntCounter = counter(
         "refiner_batched_actions",
         "Transactions that uses batched actions"
@@ -19,10 +17,8 @@ lazy_static! {
         "refiner_number_of_latest_block_processed",
         "Height of last block processed. Can be slightly out of sync with the actual height given multiple process"
     );
-    pub static ref FAILING_NEAR_TRANSACTION: IntCounter = counter(
-        "refiner_near_transaction_failed",
-        "NEAR Transaction failed"
-    );
+    pub static ref FAILING_NEAR_TRANSACTION: IntCounter =
+        counter("refiner_near_transaction_failed", "NEAR Transaction failed");
     pub static ref TRANSACTIONS: IntCounter = counter(
         "refiner_transactions",
         "Number of transactions after filter"
@@ -191,27 +187,27 @@ lazy_static! {
         "refiner_tx_type_remove_relayer_key",
         "Number of transactions of type: remove_relayer_key"
     );
-    pub static ref TRANSACTION_TYPE_START_HASHCHAIN : IntCounter = counter(
+    pub static ref TRANSACTION_TYPE_START_HASHCHAIN: IntCounter = counter(
         "refiner_tx_type_start_hashchain",
         "Number of transactions of type: start_hashchain"
     );
-    pub static ref TRANSACTION_TYPE_SET_ERC20_METADATA : IntCounter = counter(
+    pub static ref TRANSACTION_TYPE_SET_ERC20_METADATA: IntCounter = counter(
         "refiner_tx_type_set_erc20_metadata",
         "Number of transactions of type: set_erc20_metadata"
     );
-    pub static ref TRANSACTION_TYPE_EXIT_TO_NEAR : IntCounter = counter(
+    pub static ref TRANSACTION_TYPE_EXIT_TO_NEAR: IntCounter = counter(
         "refiner_tx_type_exit_to_near",
         "Number of transactions of type: exit_to_near"
     );
-    pub static ref TRANSACTION_TYPE_SET_FIXED_GAS : IntCounter = counter(
+    pub static ref TRANSACTION_TYPE_SET_FIXED_GAS: IntCounter = counter(
         "refiner_tx_type_set_fixed_gas",
         "Number of transactions of type: set_fixed_gas"
     );
-    pub static ref TRANSACTION_TYPE_SET_SILO_PARAMS : IntCounter = counter(
+    pub static ref TRANSACTION_TYPE_SET_SILO_PARAMS: IntCounter = counter(
         "refiner_tx_type_set_silo_params",
         "Number of transactions of type: set_silo_params"
     );
-    pub static ref TRANSACTION_TYPE_SET_ETH_CONNECTOR_CONTRACT_ACCOUNT : IntCounter = counter(
+    pub static ref TRANSACTION_TYPE_SET_ETH_CONNECTOR_CONTRACT_ACCOUNT: IntCounter = counter(
         "refiner_tx_type_set_eth_connector_contract_account",
         "Number of transactions of type: set_eth_connector_contract_account"
     );

--- a/refiner-lib/src/near_stream.rs
+++ b/refiner-lib/src/near_stream.rs
@@ -120,9 +120,9 @@ pub mod tests {
     use aurora_engine_sdk::types::near_account_to_evm_address;
     use aurora_engine_types::parameters::connector::Erc20Metadata;
     use aurora_engine_types::{
+        U256,
         account_id::AccountId,
         types::{Address, Balance, Wei},
-        U256,
     };
     use aurora_refiner_types::aurora_block::NearBlock;
     use engine_standalone_storage::json_snapshot::{initialize_engine_state, types::JsonSnapshot};

--- a/refiner-lib/src/refiner_inner.rs
+++ b/refiner-lib/src/refiner_inner.rs
@@ -1,8 +1,8 @@
 use crate::legacy::decode_submit_result;
-use crate::metrics::{record_metric, LATEST_BLOCK_PROCESSED};
-use crate::utils::{as_h256, keccak256, TxMetadata};
+use crate::metrics::{LATEST_BLOCK_PROCESSED, record_metric};
+use crate::utils::{TxMetadata, as_h256, keccak256};
 use aurora_engine::contract_methods::connector::deposit_event::FtTransferMessageData;
-use aurora_engine::engine::{create_legacy_address, GetErc20FromNep141Error};
+use aurora_engine::engine::{GetErc20FromNep141Error, create_legacy_address};
 use aurora_engine::parameters::{
     CallArgs, FunctionCallArgsV1, NEP141FtOnTransferArgs, ResultLog, SubmitArgs, SubmitResult,
 };
@@ -29,10 +29,10 @@ use aurora_refiner_types::near_primitives::views::{
     ActionView, ExecutionStatusView, ReceiptEnumView,
 };
 use byteorder::{BigEndian, WriteBytesExt};
-use engine_standalone_storage::sync::{
-    types::TransactionKindTag, TransactionExecutionResult, TransactionIncludedOutcome,
-};
 use engine_standalone_storage::Storage;
+use engine_standalone_storage::sync::{
+    TransactionExecutionResult, TransactionIncludedOutcome, types::TransactionKindTag,
+};
 use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -503,7 +503,9 @@ fn normalize_output(
             // We have a result from both sources, so we should compare them to
             // make sure they match. Log a warning and use the Near output if they don't.
             if near_output.0 != engine_output {
-                tracing::warn!("Mismatch between Near and Engine outputs. The internal Engine instance may not have the correct state.");
+                tracing::warn!(
+                    "Mismatch between Near and Engine outputs. The internal Engine instance may not have the correct state."
+                );
             }
             Ok(near_output)
         }

--- a/refiner-lib/src/storage.rs
+++ b/refiner-lib/src/storage.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use aurora_engine_types::{account_id::AccountId, H256, U256};
+use aurora_engine_types::{H256, U256, account_id::AccountId};
 use engine_standalone_storage::{Storage, StoragePrefix};
 
 /// Must match the VERSION in `engine_standalone_storage`

--- a/refiner-types/src/aurora_block.rs
+++ b/refiner-types/src/aurora_block.rs
@@ -1,4 +1,4 @@
-use crate::utils::{u128_dec_serde, u64_hex_serde};
+use crate::utils::{u64_hex_serde, u128_dec_serde};
 use aurora_engine::parameters::{ResultLog, TransactionStatus};
 use aurora_engine_transactions::eip_2930::AccessTuple;
 use aurora_engine_types::types::{Address, Wei};

--- a/refiner-types/src/lib.rs
+++ b/refiner-types/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::literal_string_with_formatting_args)]
+
 pub use near_primitives;
 
 pub mod aurora_block;

--- a/refiner-types/src/utils.rs
+++ b/refiner-types/src/utils.rs
@@ -71,11 +71,7 @@ pub mod u128_dec_serde {
 
 /// Cast a U256 value down to u64; if the value is too large then return u64::MAX.
 pub fn saturating_cast(x: U256) -> u64 {
-    if x < U64_MAX {
-        x.as_u64()
-    } else {
-        u64::MAX
-    }
+    if x < U64_MAX { x.as_u64() } else { u64::MAX }
 }
 
 pub fn keccak256(input: &[u8]) -> H256 {
@@ -86,7 +82,7 @@ pub fn keccak256(input: &[u8]) -> H256 {
 
 #[cfg(test)]
 mod tests {
-    use super::{u128_dec_serde, u64_hex_serde};
+    use super::{u64_hex_serde, u128_dec_serde};
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
- Updated nearcore to 2.5.0;
- Use toolchain 1.85.0;
- Use Rust edition 2024.