### PR TITLE
fix: Temporary pin the `tempfile` crate to version 3.14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.3-2.5.1] 2025-03-08
+
+## Changes
+
+### Fixes
+
+* Temporary pin the `tempfile` crate to version 3.14 due to [issue 12944](https://github.com/near/nearcore/issues/12944#issuecomment-2707438357)
+
 ## [0.30.2-2.5.0-rc.3] 2025-02-27
 
-## Changeds
+## Changes
 
 * Disable build for arm64 due to qemu failure by [@spilin] in [#199]
 * Use input tag to checkout proper release by [@spilin] in [#201]
@@ -171,7 +179,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.2-2.5.0-rc.3...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.3-2.5.1...main
+[0.30.3-2.5.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.2-2.5.0...0.30.2-2.5.1
+[0.30.2-2.5.0]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.2-2.5.0-rc.3...0.30.2-2.5.0
 [0.30.2-2.5.0-rc.3]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.1-2.4.0...0.30.2-2.5.0-rc.3
 [0.30.1-2.4.0]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.0-2.4.0...0.30.1-2.4.0
 [0.30.0-2.4.0]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.29.0-2.3.0...0.30.0-2.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.2-2.5.1"
+version = "0.30.3-2.5.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.2-2.5.1"
+version = "0.30.3-2.5.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.2-2.5.1"
+version = "0.30.3-2.5.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.2-2.5.1"
+version = "0.30.3-2.5.1"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.2-2.5.1"
+version = "0.30.3-2.5.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -8068,13 +8068,12 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.2-2.5.1"
+version = "0.30.3-2.5.1"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -47,7 +47,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 semver = "1.0.25"
 sha3 = "0.10"
-tempfile = "3"
+# Based on: https://github.com/near/nearcore/issues/12944#issuecomment-2707438357
+tempfile = "=3.14.0"
 tokio = "1"
 toml = "0.8"
 tracing = "0.1"


### PR DESCRIPTION
- Temporary pin the `tempfile` crate to version 3.14 due to [issue 12944](https://github.com/near/nearcore/issues/12944#issuecomment-2707438357)