### PR TITLE
chore: bump aurora-engine to 3.9.0 and nearcore to 2.6.0-rc.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,6 +93,7 @@ jobs:
       - name: Run tests
         run: |
           rustup target add wasm32-unknown-unknown
+          rustup component add rust-src
           cargo test -p aurora-refiner-app-integration-tests
           cargo test -p aurora-refiner-app-integration-tests --features ext-connector
       - name: Save cache

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-* chore: bump aurora-engine to 3.9.0 by [@alexander-borodulya] in [#208]
+* chore: bump aurora-engine to 3.9.0 and nearcore to 2.6.0-rc.1 by [@alexander-borodulya] in [#208]
 
 [#208]: https://github.com/aurora-is-near/borealis-engine-lib/pull/208
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.4-2.5.2] 2025-04-07
+
+### Changes
+
+* chore: bump aurora-engine to 3.9.0 by [@alexander-borodulya] in [#208]
+
+[#208]: https://github.com/aurora-is-near/borealis-engine-lib/pull/208
+
 ## [0.30.3-2.5.2] 2025-04-02
 
 ### Changes
@@ -185,9 +193,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.3-2.5.2...main
-[0.30.3-2.5.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.2-2.5.1...0.30.2-2.5.2
-[0.30.3-2.5.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.2-2.5.0...0.30.2-2.5.1
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.4-2.5.2...main
+[0.30.4-2.5.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.3-2.5.2...0.30.4-2.5.2
+[0.30.3-2.5.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.3-2.5.1...0.30.3-2.5.2
+[0.30.3-2.5.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.2-2.5.0...0.30.3-2.5.1
 [0.30.2-2.5.0]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.2-2.5.0-rc.3...0.30.2-2.5.0
 [0.30.2-2.5.0-rc.3]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.1-2.4.0...0.30.2-2.5.0-rc.3
 [0.30.1-2.4.0]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.0-2.4.0...0.30.1-2.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,8 +682,8 @@ dependencies = [
  "derive_builder",
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
- "near-crypto 2.5.2",
- "near-primitives 2.5.2",
+ "near-crypto 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "serde",
  "serde_json",
  "sha3",
@@ -1534,6 +1534,9 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "byte-slice-cast"
@@ -1878,19 +1881,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-bforest"
-version = "0.113.1"
+name = "cranelift-assembler-x64"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540b193ff98b825a1f250a75b3118911af918a734154c69d80bcfcf91e7e9522"
+checksum = "d2b83fcf2fc1c8954561490d02079b496fd0c757da88129981e15bfe3a548229"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7496a6e92b5cee48c5d772b0443df58816dee30fed6ba19b2a28e78037ecedf"
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73a9dc0a8d3d49ee772101924968830f1c1937d650c571d3c2dd69dc36a68f41"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb269598b9557ab942d687d3c1086d77c4b50dcf35813f3a65ba306fd42279"
+checksum = "573c641174c40ef31021ae4a5a3ad78974e280633502d0dfc6e362385e0c100f"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1898,11 +1916,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46566d7c83a8bff4150748d66020f4c7224091952aa4b4df1ec4959c39d937a1"
+checksum = "2d7c94d572615156f2db682181cadbd96342892c31e08cc26a757344319a9220"
 dependencies = [
  "bumpalo",
+ "cranelift-assembler-x64",
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-codegen-meta",
@@ -1911,43 +1930,47 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "log",
+ "pulley-interpreter",
  "regalloc2",
  "rustc-hash 2.1.1",
+ "serde",
  "smallvec",
- "target-lexicon 0.12.16",
+ "target-lexicon 0.13.2",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df8a86a34236cc75a8a6a271973da779c2aeb36c43b6e14da474cf931317082"
+checksum = "beecd9fcf2c3e06da436d565de61a42676097ea6eb6b4499346ac6264b6bb9ce"
 dependencies = [
+ "cranelift-assembler-x64",
  "cranelift-codegen-shared",
+ "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf75340b6a57b7c7c1b74f10d3d90883ee6d43a554be8131a4046c2ebcf5eb65"
+checksum = "0f4ff8d2e1235f2d6e7fc3c6738be6954ba972cd295f09079ebffeca2f864e22"
 
 [[package]]
 name = "cranelift-control"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e84495bc5d23d86aad8c86f8ade4af765b94882af60d60e271d3153942f1978"
+checksum = "001312e9fbc7d9ca9517474d6fe71e29d07e52997fd7efe18f19e8836446ceb2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963c17147b80df351965e57c04d20dbedc85bcaf44c3436780a59a3f1ff1b1c2"
+checksum = "eb0fd6d4aae680275fcbceb08683416b744e65c8b607352043d3f0951d72b3b2"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1956,31 +1979,31 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727f02acbc4b4cb2ba38a6637101d579db50190df1dd05168c68e762851a3dd5"
+checksum = "9fd44e7e5dcea20ca104d45894748205c51365ce4cdb18f4418e3ba955971d1b"
 dependencies = [
  "cranelift-codegen",
  "log",
  "smallvec",
- "target-lexicon 0.12.16",
+ "target-lexicon 0.13.2",
 ]
 
 [[package]]
 name = "cranelift-isle"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b00cc2e03c748f2531eea01c871f502b909d30295fdcad43aec7bf5c5b4667"
+checksum = "f900e0a3847d51eed0321f0777947fb852ccfce0da7fb070100357f69a2f37fc"
 
 [[package]]
 name = "cranelift-native"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbeaf978dc7c1a2de8bbb9162510ed218eb156697bc45590b8fbdd69bb08e8de"
+checksum = "7617f13f392ebb63c5126258aca8b8eca739636ca7e4eeee301d3eff68489a6a"
 dependencies = [
  "cranelift-codegen",
  "libc",
- "target-lexicon 0.12.16",
+ "target-lexicon 0.13.2",
 ]
 
 [[package]]
@@ -3096,16 +3119,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.11",
- "serde",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -3113,6 +3126,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -3528,12 +3542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3688,6 +3696,22 @@ dependencies = [
  "rayon",
  "unicode-width",
  "web-time",
+]
+
+[[package]]
+name = "insta"
+version = "1.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "pin-project",
+ "serde",
+ "similar",
 ]
 
 [[package]]
@@ -3943,10 +3967,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "litemap"
@@ -4098,7 +4134,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -4251,8 +4287,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "derive_more 1.0.0",
@@ -4260,7 +4296,7 @@ dependencies = [
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.5.2",
+ "near-time 2.6.0-rc.1",
  "once_cell",
  "serde",
  "serde_json",
@@ -4271,8 +4307,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4281,16 +4317,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "lru 0.12.5",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "anyhow",
@@ -4309,17 +4345,17 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.5.2",
+ "near-crypto 2.6.0-rc.1",
  "near-epoch-manager",
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.5.2",
+ "near-parameters 2.6.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.5.2",
- "near-schema-checker-lib 2.5.2",
+ "near-primitives 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4339,19 +4375,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 1.0.0",
- "near-config-utils 2.5.2",
- "near-crypto 2.5.2",
+ "near-config-utils 2.6.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-parameters 2.5.2",
- "near-primitives 2.5.2",
- "near-time 2.5.2",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_json",
@@ -4363,12 +4399,12 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
- "near-crypto 2.5.2",
- "near-primitives 2.5.2",
- "near-time 2.5.2",
+ "near-crypto 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "thiserror 2.0.12",
  "time",
  "tracing",
@@ -4376,8 +4412,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "borsh 1.5.5",
@@ -4390,14 +4426,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.5.2",
+ "near-crypto 2.6.0-rc.1",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.5.2",
+ "near-primitives 2.6.0-rc.1",
  "near-store",
  "rand 0.8.5",
  "reed-solomon-erasure",
@@ -4408,17 +4444,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.5.2",
+ "near-primitives 2.6.0-rc.1",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4439,16 +4475,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.5.2",
+ "near-crypto 2.6.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.5.2",
+ "near-parameters 2.6.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.5.2",
+ "near-primitives 2.6.0-rc.1",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4477,17 +4513,17 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.5.2",
- "near-primitives 2.5.2",
- "near-time 2.5.2",
+ "near-crypto 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "serde",
  "serde_json",
  "strum 0.24.1",
@@ -4510,8 +4546,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4546,8 +4582,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "blake2",
  "borsh 1.5.5",
@@ -4557,9 +4593,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.5.2",
- "near-schema-checker-lib 2.5.2",
- "near-stdx 2.5.2",
+ "near-config-utils 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
+ "near-stdx 2.6.0-rc.1",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4571,15 +4607,15 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "anyhow",
  "near-chain-configs",
- "near-crypto 2.5.2",
+ "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-primitives 2.5.2",
- "near-time 2.5.2",
+ "near-primitives 2.6.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "prometheus",
  "serde",
  "serde_json",
@@ -4590,18 +4626,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "borsh 1.5.5",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.5.2",
+ "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-primitives 2.5.2",
- "near-schema-checker-lib 2.5.2",
+ "near-primitives 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4625,30 +4661,30 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
- "near-primitives-core 2.5.2",
+ "near-primitives-core 2.6.0-rc.1",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.5.2",
- "near-crypto 2.5.2",
+ "near-config-utils 2.6.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.5.2",
+ "near-indexer-primitives 2.6.0-rc.1",
  "near-o11y",
- "near-parameters 2.5.2",
- "near-primitives 2.5.2",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4672,18 +4708,18 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
- "near-primitives 2.5.2",
+ "near-primitives 2.6.0-rc.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4697,11 +4733,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-jsonrpc-client",
+ "near-jsonrpc-client-internal",
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.5.2",
+ "near-primitives 2.6.0-rc.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -4711,30 +4747,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-jsonrpc-client"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+name = "near-jsonrpc-client-internal"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.5.2",
+ "near-primitives 2.6.0-rc.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.5.2",
- "near-primitives 2.5.2",
- "near-schema-checker-lib 2.5.2",
+ "near-crypto 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4769,19 +4805,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.5.2",
+ "near-primitives 2.6.0-rc.1",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "anyhow",
@@ -4801,13 +4837,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.5.2",
- "near-fmt 2.5.2",
+ "near-crypto 2.6.0-rc.1",
+ "near-fmt 2.6.0-rc.1",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.5.2",
- "near-schema-checker-lib 2.5.2",
+ "near-primitives 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.3",
@@ -4832,14 +4868,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.5.2",
- "near-primitives-core 2.5.2",
+ "near-crypto 2.6.0-rc.1",
+ "near-primitives-core 2.6.0-rc.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -4876,14 +4912,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "borsh 1.5.5",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.5.2",
- "near-schema-checker-lib 2.5.2",
+ "near-primitives-core 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -4894,8 +4930,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4909,8 +4945,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "quote",
  "syn 2.0.99",
@@ -4918,13 +4954,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "borsh 1.5.5",
- "near-crypto 2.5.2",
+ "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-primitives 2.5.2",
+ "near-primitives 2.6.0-rc.1",
  "rand 0.8.5",
 ]
 
@@ -4970,8 +5006,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4986,13 +5022,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.5.2",
- "near-fmt 2.5.2",
- "near-parameters 2.5.2",
- "near-primitives-core 2.5.2",
- "near-schema-checker-lib 2.5.2",
- "near-stdx 2.5.2",
- "near-time 2.5.2",
+ "near-crypto 2.6.0-rc.1",
+ "near-fmt 2.6.0-rc.1",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives-core 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
+ "near-stdx 2.6.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5033,8 +5069,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5043,7 +5079,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.5.2",
+ "near-schema-checker-lib 2.6.0-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5053,8 +5089,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5064,15 +5100,16 @@ dependencies = [
  "derive_more 1.0.0",
  "futures",
  "hex",
+ "insta",
  "near-account-id",
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.5.2",
+ "near-crypto 2.6.0-rc.1",
  "near-network",
  "near-o11y",
- "near-parameters 2.5.2",
- "near-primitives 2.5.2",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5090,8 +5127,8 @@ checksum = "a48405425eca34de98e680416310df33fdb75768a78481cc75b43172b2748613"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5105,11 +5142,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
- "near-schema-checker-core 2.5.2",
- "near-schema-checker-macro 2.5.2",
+ "near-schema-checker-core 2.6.0-rc.1",
+ "near-schema-checker-macro 2.6.0-rc.1",
 ]
 
 [[package]]
@@ -5120,8 +5157,8 @@ checksum = "b41a159cbf732acc0279febdde046d9036330a32a951796bce42f9529bce799d"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 
 [[package]]
 name = "near-stdx"
@@ -5131,13 +5168,13 @@ checksum = "7a91674768828a593f4bac4aeca9334c4b56fe19344a2ccf7bd795b2325f0b5e"
 
 [[package]]
 name = "near-stdx"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 
 [[package]]
 name = "near-store"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5154,14 +5191,14 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.5.2",
- "near-fmt 2.5.2",
+ "near-crypto 2.6.0-rc.1",
+ "near-fmt 2.6.0-rc.1",
  "near-o11y",
- "near-parameters 2.5.2",
- "near-primitives 2.5.2",
- "near-schema-checker-lib 2.5.2",
- "near-stdx 2.5.2",
- "near-time 2.5.2",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
+ "near-stdx 2.6.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "near-vm-runner",
  "num_cpus",
  "rand 0.8.5",
@@ -5172,17 +5209,19 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "static_assertions",
  "strum 0.24.1",
  "tempfile",
  "thiserror 2.0.12",
+ "thread_local",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "near-telemetry"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "awc",
@@ -5191,7 +5230,7 @@ dependencies = [
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-time 2.5.2",
+ "near-time 2.6.0-rc.1",
  "openssl",
  "serde",
  "serde_json",
@@ -5210,8 +5249,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "serde",
  "time",
@@ -5220,8 +5259,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5236,8 +5275,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5256,8 +5295,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5270,7 +5309,7 @@ dependencies = [
  "region",
  "rkyv 0.8.10",
  "rustc-demangle",
- "rustix",
+ "rustix 1.0.5",
  "target-lexicon 0.12.16",
  "thiserror 2.0.12",
  "tracing",
@@ -5278,8 +5317,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "anyhow",
  "blst",
@@ -5290,12 +5329,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.5.2",
+ "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-parameters 2.5.2",
- "near-primitives-core 2.5.2",
- "near-schema-checker-lib 2.5.2",
- "near-stdx 2.5.2",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives-core 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
+ "near-stdx 2.6.0-rc.1",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5307,9 +5346,10 @@ dependencies = [
  "prefix-sum-vec",
  "prometheus",
  "pwasm-utils",
+ "rand 0.8.5",
  "rayon",
  "ripemd",
- "rustix",
+ "rustix 1.0.5",
  "serde",
  "serde_repr",
  "sha2 0.10.8",
@@ -5318,7 +5358,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tracing",
- "wasm-encoder 0.218.1",
+ "wasm-encoder 0.224.1",
  "wasmer-compiler-near",
  "wasmer-compiler-singlepass-near",
  "wasmer-engine-near",
@@ -5334,8 +5374,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "indexmap 2.7.1",
  "num-traits",
@@ -5345,8 +5385,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "backtrace",
  "cc",
@@ -5366,18 +5406,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.5.2",
+ "near-primitives-core 2.6.0-rc.1",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5402,8 +5442,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.5.2",
- "near-crypto 2.5.2",
+ "near-config-utils 2.6.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5411,10 +5451,10 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.5.2",
+ "near-parameters 2.6.0-rc.1",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.5.2",
+ "near-primitives 2.6.0-rc.1",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5467,17 +5507,17 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.5.2"
-source = "git+https://github.com/near/nearcore?tag=2.5.2#f5d3027a6de26cf2aa10d59b56701054d2fba23b"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "borsh 1.5.5",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.5.2",
+ "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-parameters 2.5.2",
- "near-primitives 2.5.2",
- "near-primitives-core 2.5.2",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-primitives-core 2.6.0-rc.1",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",
@@ -6094,6 +6134,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6526,13 +6611,13 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33e7f8a43ccc7f93b330fef4baf271764674926f3f4d40f4a196d54de8af26"
+checksum = "cb0ecb9823083f71df8735f21f6c44f2f2b55986d674802831df20f27e26c907"
 dependencies = [
  "cranelift-bitset",
  "log",
- "sptr",
+ "wasmtime-math",
 ]
 
 [[package]]
@@ -6769,14 +6854,15 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.10.2"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
+checksum = "dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a"
 dependencies = [
- "hashbrown 0.14.5",
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.2",
  "log",
  "rustc-hash 2.1.1",
- "slice-group-by",
  "smallvec",
 ]
 
@@ -7197,8 +7283,21 @@ dependencies = [
  "bitflags 2.9.0",
  "errno 0.3.10",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno 0.3.10",
+ "libc",
+ "linux-raw-sys 0.9.3",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7684,6 +7783,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7718,12 +7823,6 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "slice-group-by"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
@@ -8027,6 +8126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8035,7 +8140,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -8565,6 +8670,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uint"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8912,11 +9023,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.218.1"
+version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491f7e48672d0a1efdeadf897d98ac1f45942c26c3829cb44a6b828f6f26155f"
+checksum = "1ab7a13a23790fe91ea4eb7526a1f3131001d874e3e00c2976c48861f2e82920"
 dependencies = [
  "leb128",
+ "wasmparser 0.224.1",
 ]
 
 [[package]]
@@ -9134,13 +9246,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.218.1"
+version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059739c2eac26eea736389a7d6d30b41a8201490bea204d0facde19183359849"
+checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
 dependencies = [
- "ahash 0.8.11",
  "bitflags 2.9.0",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "indexmap 2.7.1",
  "semver 1.0.26",
  "serde",
@@ -9158,30 +9269,30 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.218.1"
+version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b30ceafa77646f56747369b0f2a0296016a40b447d32e6907439f2e4bb7695"
+checksum = "0095b53a3b09cbc2f90f789ea44aa1b17ecc2dad8b267e657c7391f3ded6293d"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.218.1",
+ "wasmparser 0.224.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e762e163fd305770c6c341df3290f0cabb3c264e7952943018e9a1ced8d917"
+checksum = "809cc8780708f1deed0a7c3fcab46954f0e8c08a6fe0252772481fbc88fcf946"
 dependencies = [
+ "addr2line",
  "anyhow",
  "bitflags 2.9.0",
  "bumpalo",
  "cc",
  "cfg-if 1.0.0",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "indexmap 2.7.1",
  "libc",
- "libm",
  "log",
  "mach2",
  "memfd",
@@ -9191,18 +9302,19 @@ dependencies = [
  "postcard",
  "psm",
  "pulley-interpreter",
- "rustix",
+ "rustix 0.38.44",
  "serde",
  "serde_derive",
  "smallvec",
  "sptr",
- "target-lexicon 0.12.16",
- "wasmparser 0.218.1",
+ "target-lexicon 0.13.2",
+ "wasmparser 0.224.1",
  "wasmtime-asm-macros",
- "wasmtime-component-macro",
  "wasmtime-cranelift",
  "wasmtime-environ",
+ "wasmtime-fiber",
  "wasmtime-jit-icache-coherence",
+ "wasmtime-math",
  "wasmtime-slab",
  "wasmtime-versioned-export-macros",
  "windows-sys 0.59.0",
@@ -9210,39 +9322,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63caa7aebb546374e26257a1900fb93579171e7c02514cde26805b9ece3ef812"
+checksum = "236964b6b35af0f08879c9c56dbfbc5adc12e8d624672341a0121df31adaa3fa"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
-name = "wasmtime-component-macro"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61a4b5ce2ad9c15655e830f0eac0c38b8def30c74ecac71f452d3901e491b68"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.99",
- "wasmtime-component-util",
- "wasmtime-wit-bindgen",
- "wit-parser",
-]
-
-[[package]]
-name = "wasmtime-component-util"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e87a1212270dbb84a49af13d82594e00a92769d6952b0ea7fc4366c949f6ad"
-
-[[package]]
 name = "wasmtime-cranelift"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb40dddf38c6a5eefd5ce7c1baf43b00fe44eada11a319fab22e993a960262f"
+checksum = "abcc9179097235c91f299a8ff56b358ee921266b61adff7d14d6e48428954dd2"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -9255,19 +9346,20 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "object",
+ "pulley-interpreter",
  "smallvec",
- "target-lexicon 0.12.16",
+ "target-lexicon 0.13.2",
  "thiserror 1.0.69",
- "wasmparser 0.218.1",
+ "wasmparser 0.224.1",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8613075e89e94a48c05862243c2b718eef1b9c337f51493ebf951e149a10fa19"
+checksum = "8e90f6cba665939381839bbf2ddf12d732fca03278867910348ef1281b700954"
 dependencies = [
  "anyhow",
  "cranelift-bitset",
@@ -9280,17 +9372,32 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "target-lexicon 0.12.16",
- "wasm-encoder 0.218.1",
- "wasmparser 0.218.1",
- "wasmprinter 0.218.1",
+ "target-lexicon 0.13.2",
+ "wasm-encoder 0.224.1",
+ "wasmparser 0.224.1",
+ "wasmprinter 0.224.1",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5c2ac21f0b39d72d2dac198218a12b3ddeb4ab388a8fa0d2e429855876783c"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if 1.0.0",
+ "rustix 0.38.44",
+ "wasmtime-asm-macros",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da47fba49af72581bc0dc67c8faaf5ee550e6f106e285122a184a675193701a5"
+checksum = "3f180cc0d2745e3a5df5d02231cd3046f49c75512eaa987b8202363b112e125d"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -9299,32 +9406,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-slab"
-version = "26.0.1"
+name = "wasmtime-math"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770e10cdefb15f2b6304152978e115bd062753c1ebe7221c0b6b104fa0419ff6"
+checksum = "f5f04c5dcf5b2f88f81cfb8d390294b2f67109dc4d0197ea7303c60a092df27c"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-slab"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9681707f1ae9a4708ca22058722fca5c135775c495ba9b9624fe3732b94c97"
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8efb877c9e5e67239d4553bb44dd2a34ae5cfb728f3cf2c5e64439c6ca6ee7"
+checksum = "dd2fe69d04986a12fc759d2e79494100d600adcb3bb79e63dedfc8e6bb2ab03e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.99",
-]
-
-[[package]]
-name = "wasmtime-wit-bindgen"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bef2a726fd8d1ee9b0144655e16c492dc32eb4c7c9f7e3309fcffe637870933"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.7.1",
- "wit-parser",
 ]
 
 [[package]]
@@ -9389,7 +9493,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -9659,24 +9763,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags 2.9.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.218.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f104473e8546f8096f1fa483d337101a98dc9525d67f4275816bcd177fe3e2be"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.7.1",
- "log",
- "semver 1.0.26",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.218.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,8 +488,8 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine"
-version = "3.8.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.8.0#00fb22f926ec96822b12a24d6bf9dfe9e8faf7f4"
+version = "3.9.0"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.9.0#69a864f790f7dfd750c1e7f6eec8d65b16c118f4"
 dependencies = [
  "aurora-engine-hashchain",
  "aurora-engine-modexp",
@@ -497,9 +497,9 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-transactions",
  "aurora-engine-types",
+ "aurora-evm",
  "bitflags 1.3.2",
  "ethabi",
- "evm",
  "function_name",
  "hex",
  "rlp 0.6.1",
@@ -511,7 +511,7 @@ dependencies = [
 [[package]]
 name = "aurora-engine-hashchain"
 version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.8.0#00fb22f926ec96822b12a24d6bf9dfe9e8faf7f4"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.9.0#69a864f790f7dfd750c1e7f6eec8d65b16c118f4"
 dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-types",
@@ -521,8 +521,8 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine-modexp"
-version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.8.0#00fb22f926ec96822b12a24d6bf9dfe9e8faf7f4"
+version = "1.2.0"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.9.0#69a864f790f7dfd750c1e7f6eec8d65b16c118f4"
 dependencies = [
  "hex",
  "num",
@@ -530,16 +530,15 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine-precompiles"
-version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.8.0#00fb22f926ec96822b12a24d6bf9dfe9e8faf7f4"
+version = "1.2.0"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.9.0#69a864f790f7dfd750c1e7f6eec8d65b16c118f4"
 dependencies = [
  "aurora-engine-modexp",
  "aurora-engine-sdk",
  "aurora-engine-types",
+ "aurora-evm",
  "ethabi",
- "evm",
  "hex",
- "libsecp256k1",
  "num",
  "ripemd",
  "sha2 0.10.8",
@@ -549,32 +548,32 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine-sdk"
-version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.8.0#00fb22f926ec96822b12a24d6bf9dfe9e8faf7f4"
+version = "1.2.0"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.9.0#69a864f790f7dfd750c1e7f6eec8d65b16c118f4"
 dependencies = [
  "aurora-engine-types",
  "base64 0.22.1",
+ "libsecp256k1",
  "sha2 0.10.8",
  "sha3",
 ]
 
 [[package]]
 name = "aurora-engine-transactions"
-version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.8.0#00fb22f926ec96822b12a24d6bf9dfe9e8faf7f4"
+version = "1.2.0"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.9.0#69a864f790f7dfd750c1e7f6eec8d65b16c118f4"
 dependencies = [
- "aurora-engine-precompiles",
  "aurora-engine-sdk",
  "aurora-engine-types",
- "evm",
+ "aurora-evm",
  "rlp 0.6.1",
  "serde",
 ]
 
 [[package]]
 name = "aurora-engine-types"
-version = "1.0.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.8.0#00fb22f926ec96822b12a24d6bf9dfe9e8faf7f4"
+version = "1.2.0"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.9.0#69a864f790f7dfd750c1e7f6eec8d65b16c118f4"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.5",
@@ -587,8 +586,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "aurora-evm"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c137cde01ce10801a70dc5352117a77fdab62281032b4536b646cf1044c38564"
+dependencies = [
+ "auto_impl",
+ "environmental",
+ "log",
+ "parity-scale-codec 3.7.4",
+ "primitive-types 0.13.1",
+ "rlp 0.6.1",
+ "scale-info",
+ "serde",
+ "sha3",
+ "smallvec",
+]
+
+[[package]]
 name = "aurora-refiner"
-version = "0.30.3-2.5.2"
+version = "0.30.4-2.5.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -612,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.3-2.5.2"
+version = "0.30.4-2.5.2"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -623,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.3-2.5.2"
+version = "0.30.4-2.5.2"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -655,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.3-2.5.2"
+version = "0.30.4-2.5.2"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
@@ -674,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.3-2.5.2"
+version = "0.30.4-2.5.2"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -2507,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "engine-standalone-storage"
 version = "0.1.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.8.0#00fb22f926ec96822b12a24d6bf9dfe9e8faf7f4"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.9.0#69a864f790f7dfd750c1e7f6eec8d65b16c118f4"
 dependencies = [
  "aurora-engine",
  "aurora-engine-modexp",
@@ -2526,13 +2543,10 @@ dependencies = [
 [[package]]
 name = "engine-standalone-tracing"
 version = "0.1.0"
-source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.8.0#00fb22f926ec96822b12a24d6bf9dfe9e8faf7f4"
+source = "git+https://github.com/aurora-is-near/aurora-engine.git?tag=3.9.0#69a864f790f7dfd750c1e7f6eec8d65b16c118f4"
 dependencies = [
  "aurora-engine-types",
- "evm",
- "evm-core",
- "evm-gasometer",
- "evm-runtime",
+ "aurora-evm",
  "hex",
  "serde",
 ]
@@ -2683,60 +2697,6 @@ dependencies = [
  "fixed-hash 0.8.0",
  "primitive-types 0.12.2",
  "uint 0.9.5",
-]
-
-[[package]]
-name = "evm"
-version = "0.46.2"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.47.0-beta.1#e4ee27342f0bac34b376d031953f697a3437dbdd"
-dependencies = [
- "auto_impl",
- "environmental",
- "evm-core",
- "evm-gasometer",
- "evm-runtime",
- "log",
- "parity-scale-codec 3.7.4",
- "primitive-types 0.13.1",
- "rlp 0.6.1",
- "scale-info",
- "serde",
- "sha3",
- "smallvec",
-]
-
-[[package]]
-name = "evm-core"
-version = "0.46.2"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.47.0-beta.1#e4ee27342f0bac34b376d031953f697a3437dbdd"
-dependencies = [
- "parity-scale-codec 3.7.4",
- "primitive-types 0.13.1",
- "scale-info",
- "serde",
-]
-
-[[package]]
-name = "evm-gasometer"
-version = "0.46.2"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.47.0-beta.1#e4ee27342f0bac34b376d031953f697a3437dbdd"
-dependencies = [
- "environmental",
- "evm-core",
- "evm-runtime",
- "primitive-types 0.13.1",
-]
-
-[[package]]
-name = "evm-runtime"
-version = "0.46.2"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.47.0-beta.1#e4ee27342f0bac34b376d031953f697a3437dbdd"
-dependencies = [
- "auto_impl",
- "environmental",
- "evm-core",
- "primitive-types 0.13.1",
- "sha3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.3-2.5.2"
+version = "0.30.4-2.5.2"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -19,14 +19,14 @@ license = "CC0-1.0"
 [workspace.dependencies]
 actix = "0.13"
 anyhow = "1"
-aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.8.0", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
-aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.8.0", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.8.0", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.8.0", default-features = false, features = ["std"] }
-aurora-engine-modexp = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.8.0", default-features = false, features = ["std"] }
-aurora-engine-hashchain = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.8.0", default-features = false, features = ["std"] }
-engine-standalone-storage = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.8.0", default-features = false }
-engine-standalone-tracing = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.8.0", default-features = false, features = ["impl-serde"] }
+aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.9.0", default-features = false, features = ["std", "tracing", "log", "impl-serde"] }
+aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.9.0", default-features = false, features = ["std", "impl-serde"] }
+aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.9.0", default-features = false, features = ["std", "impl-serde"] }
+aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.9.0", default-features = false, features = ["std"] }
+aurora-engine-modexp = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.9.0", default-features = false, features = ["std"] }
+aurora-engine-hashchain = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.9.0", default-features = false, features = ["std"] }
+engine-standalone-storage = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.9.0", default-features = false }
+engine-standalone-tracing = { git = "https://github.com/aurora-is-near/aurora-engine.git", tag = "3.9.0", default-features = false, features = ["impl-serde"] }
 borsh = { version = "1", features = ["borsh-derive"] }
 byteorder = "1"
 clap = { version = "4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.5.2" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.5.2" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.5.2" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
 near-lake-framework = "0.7"
 prometheus = "0.13"
 rlp = "0.6"

--- a/engine/src/gas.rs
+++ b/engine/src/gas.rs
@@ -7,7 +7,7 @@ use aurora_engine_sdk::io::IO;
 use aurora_engine_transactions::NormalizedEthTransaction;
 use aurora_engine_types::{
     H160, H256, U256, storage,
-    types::{Address, Wei},
+    types::{Address, NearGas, Wei},
 };
 use engine_standalone_storage::{
     Storage,
@@ -297,7 +297,8 @@ fn eth_call(
         block_timestamp: block_metadata.timestamp,
         attached_deposit: 1,
         random_seed: block_metadata.random_seed,
-        prepaid_gas: aurora_engine_types::types::NearGas::new(300),
+        prepaid_gas: NearGas::new(300),
+        used_gas: NearGas::new(0),
     };
     storage
         .with_engine_access(block_height + 1, 0, &[], |io| {

--- a/engine/src/sync.rs
+++ b/engine/src/sync.rs
@@ -119,6 +119,9 @@ pub fn consume_near_block<M: ModExpAlgorithm>(
                     (signer_id, maybe_tx, input_data)
                 }
                 near_primitives::views::ReceiptEnumView::Data { .. } => return None,
+                near_primitives::views::ReceiptEnumView::GlobalContractDistribution { .. } => {
+                    return None;
+                }
             };
 
             let signer = signer.as_str().parse().ok()?;

--- a/refiner-lib/src/metrics.rs
+++ b/refiner-lib/src/metrics.rs
@@ -31,10 +31,6 @@ lazy_static! {
         "refiner_transaction_data",
         "Number of receipts that are of type Data"
     );
-    pub static ref GLOBAL_CONTRACT_DISTRIBUTION: IntCounter = counter(
-        "refiner_global_contract_distribution",
-        "Number of receipts that are of type GlobalContractDistribution"
-    );
     pub static ref TRANSACTION_TYPE_SUBMIT: IntCounter = counter(
         "refiner_tx_type_submit",
         "Number of transactions of type: submit"

--- a/refiner-lib/src/metrics.rs
+++ b/refiner-lib/src/metrics.rs
@@ -235,6 +235,15 @@ lazy_static! {
         "refiner_tx_type_withdraw_wnear_to_router",
         "Number of transactions of type: withdraw_wnear_to_router"
     );
+    pub static ref TRANSACTION_TYPE_SET_ERC20_FALLBACK_ADDRESS: IntCounter = counter(
+        "refiner_tx_type_set_erc20_fallback_address",
+        "Number of transactions of type: set_erc20_fallback_address"
+    );
+    // TransactionKindTag::SetWhitelistsStatuses
+    pub static ref TRANSACTION_TYPE_SET_WHITELIST_STATUSES: IntCounter = counter(
+        "refiner_tx_type_set_whitelist_statuses",
+        "Number of transactions of type: set_whitelist_statuses"
+    );
 }
 
 pub fn record_metric(tx_kind: &TransactionKindTag) {
@@ -377,6 +386,12 @@ pub fn record_metric(tx_kind: &TransactionKindTag) {
         }
         TransactionKindTag::WithdrawWnearToRouter => {
             TRANSACTION_TYPE_WITHDRAW_WNEAR_TO_ROUTER.inc();
+        }
+        TransactionKindTag::SetErc20FallbackAddress => {
+            TRANSACTION_TYPE_SET_ERC20_FALLBACK_ADDRESS.inc();
+        }
+        TransactionKindTag::SetWhitelistsStatuses => {
+            TRANSACTION_TYPE_SET_WHITELIST_STATUSES.inc();
         }
     }
 }

--- a/refiner-lib/src/metrics.rs
+++ b/refiner-lib/src/metrics.rs
@@ -29,7 +29,11 @@ lazy_static! {
     );
     pub static ref TRANSACTIONS_DATA: IntCounter = counter(
         "refiner_transaction_data",
-        "Number of receipts that are of type data"
+        "Number of receipts that are of type Data"
+    );
+    pub static ref GLOBAL_CONTRACT_DISTRIBUTION: IntCounter = counter(
+        "refiner_global_contract_distribution",
+        "Number of receipts that are of type GlobalContractDistribution"
     );
     pub static ref TRANSACTION_TYPE_SUBMIT: IntCounter = counter(
         "refiner_tx_type_submit",

--- a/refiner-lib/src/refiner_inner.rs
+++ b/refiner-lib/src/refiner_inner.rs
@@ -282,6 +282,13 @@ impl Refiner {
                     data_id,
                 )
             }
+            ReceiptEnumView::GlobalContractDistribution { id, .. } => {
+                crate::metrics::GLOBAL_CONTRACT_DISTRIBUTION.inc();
+                tracing::warn!(target: "transactions",
+                    "Ignore receipt data. Receipt Id: {}, GlobalContractIdentifier: {:?}",
+                    execution_outcome.receipt.receipt_id, id
+                )
+            }
         }
     }
 

--- a/refiner-lib/src/refiner_inner.rs
+++ b/refiner-lib/src/refiner_inner.rs
@@ -282,13 +282,8 @@ impl Refiner {
                     data_id,
                 )
             }
-            ReceiptEnumView::GlobalContractDistribution { id, .. } => {
-                crate::metrics::GLOBAL_CONTRACT_DISTRIBUTION.inc();
-                tracing::warn!(target: "transactions",
-                    "Ignore receipt data. Receipt Id: {}, GlobalContractIdentifier: {:?}",
-                    execution_outcome.receipt.receipt_id, id
-                )
-            }
+            // Safe to ignore as it doesn't impact Aurora state
+            ReceiptEnumView::GlobalContractDistribution { .. } => {}
         }
     }
 


### PR DESCRIPTION
This PR includes:
- Bump `aurora-engine` to `3.9.0`;
- Bump `nearcore` to `2.6.0-rc.1`.