### PR TITLE
fix: Coordinated shutdown for the input and output streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
 name = "aurora-refiner-lib"
 version = "0.30.4-2.6.0-rc.2"
 dependencies = [
+ "actix",
  "anyhow",
  "aurora-engine",
  "aurora-engine-hashchain",

--- a/refiner-app/src/store.rs
+++ b/refiner-app/src/store.rs
@@ -1,7 +1,10 @@
+use std::path::{Path, PathBuf};
+
 use aurora_refiner_lib::BlockWithMetadata;
 use aurora_refiner_types::aurora_block::AuroraBlock;
 use serde::Deserialize;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tracing::info;
 
 const STORE_INFO_FILE: &str = ".REFINER_LAST_BLOCK";
 
@@ -15,7 +18,7 @@ pub struct OutputStoreConfig {
 
 pub async fn store(config: &OutputStoreConfig, block: &AuroraBlock) {
     tracing::trace!("Storing block {}", block.height);
-    let folder_path = std::path::PathBuf::from(&config.path);
+    let folder_path = PathBuf::from(&config.path);
 
     if !folder_path.exists() {
         std::fs::create_dir_all(&folder_path).unwrap();
@@ -54,33 +57,51 @@ pub async fn store(config: &OutputStoreConfig, block: &AuroraBlock) {
     save_last_block_height(&config.path, block.height).await;
 }
 
+/// Spawns a task that stores Aurora blocks to the output storage.
+/// The `shutdown_rx` is used to signal the task to stop.
+/// Returns a channel to send Aurora blocks to the task and a handle to the task.
 pub fn get_output_stream(
     mut total_blocks: Option<u64>,
     config: OutputStoreConfig,
-) -> tokio::sync::mpsc::Sender<BlockWithMetadata<AuroraBlock, ()>> {
+    mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+) -> (
+    tokio::sync::mpsc::Sender<BlockWithMetadata<AuroraBlock, ()>>,
+    tokio::task::JoinHandle<()>,
+) {
     tracing::info!("get_output_stream: starting output stream, total_blocks: {total_blocks:?}...");
-    let (sender, mut receiver) =
+    let (aurora_blocks_tx, mut aurora_blocks_rx) =
         tokio::sync::mpsc::channel::<BlockWithMetadata<AuroraBlock, ()>>(1000);
 
-    tokio::spawn(async move {
+    let task_handle = tokio::spawn(async move {
         let config = config.clone();
-        while let Some(block) = receiver.recv().await {
-            store(&config, &block.block).await;
-            if let Some(total_blocks) = total_blocks.as_mut() {
-                *total_blocks -= 1;
-                if *total_blocks == 0 {
+
+        loop {
+            tokio::select! {
+                // Handle incoming blocks
+                Some(block) = aurora_blocks_rx.recv() => {
+                    store(&config, &block.block).await;
+                    if let Some(total_blocks) = total_blocks.as_mut() {
+                        *total_blocks -= 1;
+                        if *total_blocks == 0 {
+                            break;
+                        }
+                    }
+                }
+                // Handle shutdown signal
+                _ = shutdown_rx.recv() => {
+                    // Explicitly close the channel, so the tx side should stop sending blocks
+                    aurora_blocks_rx.close();
+                    info!("get_output_stream: Received shutdown signal, Aurora blocks storage stopped");
                     break;
                 }
             }
         }
     });
 
-    sender
+    (aurora_blocks_tx, task_handle)
 }
 
-pub async fn load_last_block_height<P: AsRef<std::path::Path> + Send>(
-    storage_path: P,
-) -> Option<u64> {
+pub async fn load_last_block_height<P: AsRef<Path> + Send>(storage_path: P) -> Option<u64> {
     let path = storage_path.as_ref();
     if !path.exists() {
         tokio::fs::create_dir_all(path).await.unwrap();
@@ -97,10 +118,7 @@ pub async fn load_last_block_height<P: AsRef<std::path::Path> + Send>(
     }
 }
 
-async fn save_last_block_height<P: AsRef<std::path::Path> + Send>(
-    storage_path: P,
-    block_height: u64,
-) {
+async fn save_last_block_height<P: AsRef<Path> + Send>(storage_path: P, block_height: u64) {
     let path = storage_path.as_ref();
     if !path.exists() {
         tokio::fs::create_dir_all(path).await.unwrap();

--- a/refiner-lib/Cargo.toml
+++ b/refiner-lib/Cargo.toml
@@ -22,6 +22,7 @@ aurora-standalone-engine.workspace = true
 engine-standalone-storage.workspace = true
 
 anyhow.workspace = true
+actix.workspace = true
 borsh.workspace = true
 triehash-ethereum.workspace = true
 byteorder.workspace = true

--- a/refiner-lib/src/signal_handlers.rs
+++ b/refiner-lib/src/signal_handlers.rs
@@ -1,106 +1,135 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicI32, Ordering};
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::broadcast::error::SendError;
 use tracing::{info, warn};
 
-static SIGNAL: AtomicUsize = AtomicUsize::new(0);
+static SIGNAL: AtomicI32 = AtomicI32::new(0);
 
-const CUSTOM_CTRL_C_SIGNAL: usize = 602437500;
+static SIGNAL_USR1: i32 = 10;
+static SIGNAL_USR2: i32 = 12;
 
 /// Tests a `signal_value` representing a system signal
-/// to ensure it matches one of the following values: 602437500 | 15 | 12 | 10 | 1
+/// to ensure it matches one of the following values: 2 | 15 | 12 | 10 | 1
 pub fn is_matching_signal() -> bool {
-    let signal_value = SIGNAL.load(Ordering::SeqCst) as i32;
-    let signal_value = SignalKind::from(signal_value);
+    let signal_value: SignalKind = SIGNAL.load(Ordering::SeqCst).into();
 
     match signal_value {
-        // CUSTOM_CTRL_C_SIGNAL (602437500)
-        val if val == SignalKind::from(CUSTOM_CTRL_C_SIGNAL as i32) => true,
+        // SIGINT (2)
+        val if val == SignalKind::interrupt() => true,
         // TERM (15)
         val if val == SignalKind::terminate() => true,
         // USR2 (12)
-        val if val == SignalKind::from_raw(12) => true,
+        val if val == SignalKind::from_raw(SIGNAL_USR2) => true,
         // USR1 (10)
-        val if val == SignalKind::from_raw(10) => true,
+        val if val == SignalKind::from_raw(SIGNAL_USR1) => true,
         // SIGHUP (1)
-        val if val == SignalKind::from_raw(1) => true,
+        val if val == SignalKind::hangup() => true,
         _ => false,
     }
 }
 
+/// Creates a future that handles SIGQUIT signal and sends shutdown signal when triggered
+pub async fn handle_quit(shutdown_tx: tokio::sync::broadcast::Sender<()>) -> anyhow::Result<()> {
+    let sigquit = SignalKind::quit();
+    let mut quit_signal_stream = signal(sigquit)?;
+    info!("Signal handler for SIGQUIT installed");
+
+    quit_signal_stream.recv().await;
+
+    info!("Signal handler for SIGQUIT triggered");
+    SIGNAL.store(sigquit.into(), Ordering::SeqCst);
+    match shutdown_tx.send(()) {
+        Ok(_) => info!("Originated by SIGQUIT shutdown signal sent successfully"),
+        Err(SendError(_)) => warn!("No active receivers for shutdown signal originated by SIGQUIT"),
+    }
+
+    Ok(())
+}
+
 /// Creates a future that handles USR1 signal and sends shutdown signal when triggered
 pub async fn handle_usr1(shutdown_tx: tokio::sync::broadcast::Sender<()>) -> anyhow::Result<()> {
-    let mut kill_signal_stream = signal(SignalKind::from_raw(10))?;
-    info!("Kill signal (USR1) handler installed");
-    if kill_signal_stream.recv().await == Some(()) {
-        info!("Kill signal (USR1) handler triggered");
-        SIGNAL.store(10, Ordering::SeqCst);
-        match shutdown_tx.send(()) {
-            Ok(_) => info!("Shutdown signal sent successfully"),
-            Err(SendError(_)) => warn!("No active receivers for shutdown signal"),
-        }
+    let mut kill_signal_stream = signal(SignalKind::from_raw(SIGNAL_USR1))?;
+    info!("Custom signal handler for SIGUSR1 {SIGNAL_USR1} installed");
+
+    kill_signal_stream.recv().await;
+
+    info!("Custom signal handler for SIGUSR1 {SIGNAL_USR1} triggered");
+    SIGNAL.store(SIGNAL_USR1, Ordering::SeqCst);
+    match shutdown_tx.send(()) {
+        Ok(_) => info!("Originated by SIGUSR1 shutdown signal sent successfully"),
+        Err(SendError(_)) => warn!("No active receivers for shutdown signal originated by SIGUSR1"),
     }
+
     Ok(())
 }
 
 /// Creates a future that handles USR2 signal and sends shutdown signal when triggered
 pub async fn handle_usr2(shutdown_tx: tokio::sync::broadcast::Sender<()>) -> anyhow::Result<()> {
-    let mut kill_signal_stream = signal(SignalKind::from_raw(12))?;
-    info!("Kill signal (USR2) handler installed");
-    if kill_signal_stream.recv().await == Some(()) {
-        info!("Kill signal (USR2) handler triggered");
-        SIGNAL.store(12, Ordering::SeqCst);
-        match shutdown_tx.send(()) {
-            Ok(_) => info!("Shutdown signal sent successfully"),
-            Err(SendError(_)) => warn!("No active receivers for shutdown signal"),
-        }
+    let mut kill_signal_stream = signal(SignalKind::from_raw(SIGNAL_USR2))?;
+    info!("Custom signal handler for SIGUSR2 {SIGNAL_USR2} installed");
+
+    kill_signal_stream.recv().await;
+
+    info!("Custom signal handler for SIGUSR2 {SIGNAL_USR2} triggered");
+    SIGNAL.store(SIGNAL_USR2, Ordering::SeqCst);
+    match shutdown_tx.send(()) {
+        Ok(_) => info!("Originated by SIGUSR2 shutdown signal sent successfully"),
+        Err(SendError(_)) => warn!("No active receivers for shutdown signal originated by SIGUSR2"),
     }
+
     Ok(())
 }
 
 /// Creates a future that handles TERM signal and sends shutdown signal when triggered
 pub async fn handle_term(shutdown_tx: tokio::sync::broadcast::Sender<()>) -> anyhow::Result<()> {
-    let mut term_signal_stream = signal(SignalKind::terminate())?;
-    if term_signal_stream.recv().await == Some(()) {
-        info!("Terminate signal handler triggered");
-        SIGNAL.store(15, Ordering::SeqCst);
-        match shutdown_tx.send(()) {
-            Ok(_) => info!("Shutdown signal sent successfully"),
-            Err(SendError(_)) => warn!("No active receivers for shutdown signal"),
-        }
+    let sigterm = SignalKind::terminate();
+    let mut term_signal_stream = signal(sigterm)?;
+    info!("Signal handler for SIGTERM installed");
+
+    term_signal_stream.recv().await;
+
+    info!("Signal handler for SIGTERM triggered");
+    SIGNAL.store(sigterm.into(), Ordering::SeqCst);
+    match shutdown_tx.send(()) {
+        Ok(_) => info!("Originated by SIGTERM shutdown signal sent successfully"),
+        Err(SendError(_)) => warn!("No active receivers for shutdown signal originated by SIGTERM"),
     }
+
     Ok(())
 }
 
 /// Creates a future that handles HUP signal and sends shutdown signal when triggered
 pub async fn handle_hup(shutdown_tx: tokio::sync::broadcast::Sender<()>) -> anyhow::Result<()> {
-    let mut hup_signal_stream = signal(SignalKind::hangup())?;
-    info!("Hangup signal handler installed");
-    if hup_signal_stream.recv().await == Some(()) {
-        info!("Hangup signal handler triggered");
-        SIGNAL.store(1, Ordering::SeqCst);
-        match shutdown_tx.send(()) {
-            Ok(_) => info!("Shutdown signal sent successfully"),
-            Err(SendError(_)) => warn!("No active receivers for shutdown signal"),
-        }
+    let sighup = SignalKind::hangup();
+    let mut hup_signal_stream = signal(sighup)?;
+    info!("Signal handler for SIGHUP installed");
+
+    hup_signal_stream.recv().await;
+
+    info!("Signal handler for SIGHUP triggered");
+    SIGNAL.store(sighup.into(), Ordering::SeqCst);
+    match shutdown_tx.send(()) {
+        Ok(_) => info!("Originated by SIGHUP shutdown signal sent successfully"),
+        Err(SendError(_)) => warn!("No active receivers for shutdown signal originated by SIGHUP"),
     }
+
     Ok(())
 }
 
 /// Creates a future that handles Ctrl+C and sends shutdown signal when triggered
 pub async fn handle_ctrl_c(shutdown_tx: tokio::sync::broadcast::Sender<()>) -> anyhow::Result<()> {
-    info!("Ctrl-C key sequence handler installed");
-    match tokio::signal::ctrl_c().await {
-        Ok(_) => {
-            info!("Ctrl-C key sequence handler triggered");
-            SIGNAL.store(CUSTOM_CTRL_C_SIGNAL, Ordering::SeqCst);
-            match shutdown_tx.send(()) {
-                Ok(_) => info!("Shutdown signal sent successfully"),
-                Err(SendError(_)) => warn!("No active receivers for shutdown signal"),
-            }
-        }
-        Err(err) => anyhow::bail!("Error handling Ctrl-C signal: {err}"),
+    let sigint = SignalKind::interrupt();
+    info!("Signal handler for Ctrl-C installed");
+
+    tokio::signal::ctrl_c().await?;
+
+    info!("Signal handler for Ctrl-C triggered");
+    SIGNAL.store(sigint.into(), Ordering::SeqCst);
+    match shutdown_tx.send(()) {
+        Ok(_) => info!("Originated by Ctrl-C shutdown signal sent successfully"),
+        Err(SendError(_)) => warn!("No active receivers for shutdown signal originated by Ctrl-C"),
     }
+
     Ok(())
 }
 
@@ -121,33 +150,33 @@ pub async fn handle_all_signals(
             if let Err(e) = result {
                 warn!("Error handling USR1 signal: {}", e);
             }
-            Ok(())
         }
         result = &mut usr2 => {
             if let Err(e) = result {
                 warn!("Error handling USR2 signal: {}", e);
             }
-            Ok(())
         }
         result = &mut term => {
             if let Err(e) = result {
                 warn!("Error handling TERM signal: {}", e);
             }
-            Ok(())
         }
         result = &mut hup => {
             if let Err(e) = result {
                 warn!("Error handling HUP signal: {}", e);
             }
-            Ok(())
         }
         result = &mut ctrl_c => {
             if let Err(e) = result {
                 warn!("Error handling Ctrl-C signal: {}", e);
             }
-            Ok(())
         }
-    }
+    };
+
+    info!("Stopping actix system");
+    actix::System::current().stop();
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -156,22 +185,28 @@ mod tests {
 
     #[test]
     fn test_is_matching_signal() {
-        SIGNAL.store(2, Ordering::SeqCst);
+        // Non-matching value
+        SIGNAL.store(602437500, Ordering::SeqCst);
         assert!(!is_matching_signal());
 
-        SIGNAL.store(1, Ordering::SeqCst);
+        // SIGINT (2)
+        SIGNAL.store(SignalKind::interrupt().into(), Ordering::SeqCst);
         assert!(is_matching_signal());
 
-        SIGNAL.store(10, Ordering::SeqCst);
+        // SIGUSR1 (10)
+        SIGNAL.store(SignalKind::from_raw(SIGNAL_USR1).into(), Ordering::SeqCst);
         assert!(is_matching_signal());
 
-        SIGNAL.store(12, Ordering::SeqCst);
+        // SIGUSR2 (12)
+        SIGNAL.store(SignalKind::from_raw(SIGNAL_USR2).into(), Ordering::SeqCst);
         assert!(is_matching_signal());
 
-        SIGNAL.store(15, Ordering::SeqCst);
+        // TERM (15)
+        SIGNAL.store(SignalKind::terminate().into(), Ordering::SeqCst);
         assert!(is_matching_signal());
 
-        SIGNAL.store(602437500, Ordering::SeqCst);
+        // SIGHUP (1)
+        SIGNAL.store(SignalKind::hangup().into(), Ordering::SeqCst);
         assert!(is_matching_signal());
     }
 }

--- a/refiner-lib/src/signal_handlers.rs
+++ b/refiner-lib/src/signal_handlers.rs
@@ -9,25 +9,60 @@ static SIGNAL_USR1: i32 = 10;
 static SIGNAL_USR2: i32 = 12;
 
 /// Tests a `signal_value` representing a system signal
-/// to ensure it matches one of the following values: 2 | 15 | 12 | 10 | 1
+/// to ensure it matches one of the following values: 1 2 3 10 12 15
 pub fn is_matching_signal() -> bool {
     let signal_value: SignalKind = SIGNAL.load(Ordering::SeqCst).into();
 
     match signal_value {
-        // SIGINT (2)
-        val if val == SignalKind::interrupt() => true,
-        // TERM (15)
-        val if val == SignalKind::terminate() => true,
-        // USR2 (12)
-        val if val == SignalKind::from_raw(SIGNAL_USR2) => true,
-        // USR1 (10)
-        val if val == SignalKind::from_raw(SIGNAL_USR1) => true,
         // SIGHUP (1)
         val if val == SignalKind::hangup() => true,
+        // SIGINT (2)
+        val if val == SignalKind::interrupt() => true,
         // SIGQUIT (3)
         val if val == SignalKind::quit() => true,
+        // USR1 (10)
+        val if val == SignalKind::from_raw(SIGNAL_USR1) => true,
+        // USR2 (12)
+        val if val == SignalKind::from_raw(SIGNAL_USR2) => true,
+        // TERM (15)
+        val if val == SignalKind::terminate() => true,
         _ => false,
     }
+}
+
+/// Creates a future that handles HUP signal and sends shutdown signal when triggered
+pub async fn handle_hup(shutdown_tx: tokio::sync::broadcast::Sender<()>) -> anyhow::Result<()> {
+    let sighup = SignalKind::hangup();
+    let mut hup_signal_stream = signal(sighup)?;
+    info!("Signal handler for SIGHUP installed");
+
+    hup_signal_stream.recv().await;
+
+    info!("Signal handler for SIGHUP triggered");
+    SIGNAL.store(sighup.into(), Ordering::SeqCst);
+    match shutdown_tx.send(()) {
+        Ok(_) => info!("Originated by SIGHUP shutdown signal sent successfully"),
+        Err(SendError(_)) => warn!("No active receivers for shutdown signal originated by SIGHUP"),
+    }
+
+    Ok(())
+}
+
+/// Creates a future that handles Ctrl+C and sends shutdown signal when triggered
+pub async fn handle_ctrl_c(shutdown_tx: tokio::sync::broadcast::Sender<()>) -> anyhow::Result<()> {
+    let sigint = SignalKind::interrupt();
+    info!("Signal handler for Ctrl-C installed");
+
+    tokio::signal::ctrl_c().await?;
+
+    info!("Signal handler for Ctrl-C triggered");
+    SIGNAL.store(sigint.into(), Ordering::SeqCst);
+    match shutdown_tx.send(()) {
+        Ok(_) => info!("Originated by Ctrl-C shutdown signal sent successfully"),
+        Err(SendError(_)) => warn!("No active receivers for shutdown signal originated by Ctrl-C"),
+    }
+
+    Ok(())
 }
 
 /// Creates a future that handles SIGQUIT signal and sends shutdown signal when triggered
@@ -100,83 +135,66 @@ pub async fn handle_term(shutdown_tx: tokio::sync::broadcast::Sender<()>) -> any
     Ok(())
 }
 
-/// Creates a future that handles HUP signal and sends shutdown signal when triggered
-pub async fn handle_hup(shutdown_tx: tokio::sync::broadcast::Sender<()>) -> anyhow::Result<()> {
-    let sighup = SignalKind::hangup();
-    let mut hup_signal_stream = signal(sighup)?;
-    info!("Signal handler for SIGHUP installed");
-
-    hup_signal_stream.recv().await;
-
-    info!("Signal handler for SIGHUP triggered");
-    SIGNAL.store(sighup.into(), Ordering::SeqCst);
-    match shutdown_tx.send(()) {
-        Ok(_) => info!("Originated by SIGHUP shutdown signal sent successfully"),
-        Err(SendError(_)) => warn!("No active receivers for shutdown signal originated by SIGHUP"),
-    }
-
-    Ok(())
-}
-
-/// Creates a future that handles Ctrl+C and sends shutdown signal when triggered
-pub async fn handle_ctrl_c(shutdown_tx: tokio::sync::broadcast::Sender<()>) -> anyhow::Result<()> {
-    let sigint = SignalKind::interrupt();
-    info!("Signal handler for Ctrl-C installed");
-
-    tokio::signal::ctrl_c().await?;
-
-    info!("Signal handler for Ctrl-C triggered");
-    SIGNAL.store(sigint.into(), Ordering::SeqCst);
-    match shutdown_tx.send(()) {
-        Ok(_) => info!("Originated by Ctrl-C shutdown signal sent successfully"),
-        Err(SendError(_)) => warn!("No active receivers for shutdown signal originated by Ctrl-C"),
-    }
-
-    Ok(())
-}
-
 /// Creates a future that handles all signals and sends shutdown signal when any is triggered
 pub async fn handle_all_signals(
     shutdown_tx: tokio::sync::broadcast::Sender<()>,
 ) -> anyhow::Result<()> {
     info!("Installing signal handlers");
 
-    let mut usr1 = Box::pin(handle_usr1(shutdown_tx.clone()));
-    let mut usr2 = Box::pin(handle_usr2(shutdown_tx.clone()));
-    let mut term = Box::pin(handle_term(shutdown_tx.clone()));
     let mut hup = Box::pin(handle_hup(shutdown_tx.clone()));
     let mut ctrl_c = Box::pin(handle_ctrl_c(shutdown_tx.clone()));
-    let mut quit = Box::pin(handle_quit(shutdown_tx));
+    let mut quit = Box::pin(handle_quit(shutdown_tx.clone()));
+    let mut usr1 = Box::pin(handle_usr1(shutdown_tx.clone()));
+    let mut usr2 = Box::pin(handle_usr2(shutdown_tx.clone()));
+    let mut term = Box::pin(handle_term(shutdown_tx));
 
-    tokio::select! {
-        result = &mut usr1 => {
-            if let Err(e) = result {
-                warn!("Error handling USR1 signal: {}", e);
-            }
-        }
-        result = &mut usr2 => {
-            if let Err(e) = result {
-                warn!("Error handling USR2 signal: {}", e);
-            }
-        }
-        result = &mut term => {
-            if let Err(e) = result {
-                warn!("Error handling TERM signal: {}", e);
-            }
-        }
+    let result = tokio::select! {
         result = &mut hup => {
             if let Err(e) = result {
                 warn!("Error handling HUP signal: {}", e);
+                Err(e)
+            } else {
+                Ok(())
             }
         }
         result = &mut ctrl_c => {
             if let Err(e) = result {
                 warn!("Error handling Ctrl-C signal: {}", e);
+                Err(e)
+            } else {
+                Ok(())
             }
         }
         result = &mut quit => {
             if let Err(e) = result {
                 warn!("Error handling QUIT signal: {}", e);
+                Err(e)
+            } else {
+                Ok(())
+            }
+        }
+        result = &mut usr1 => {
+            if let Err(e) = result {
+                warn!("Error handling USR1 signal: {}", e);
+                Err(e)
+            } else {
+                Ok(())
+            }
+        }
+        result = &mut usr2 => {
+            if let Err(e) = result {
+                warn!("Error handling USR2 signal: {}", e);
+                Err(e)
+            } else {
+                Ok(())
+            }
+        }
+        result = &mut term => {
+            if let Err(e) = result {
+                warn!("Error handling TERM signal: {}", e);
+                Err(e)
+            } else {
+                Ok(())
             }
         }
     };
@@ -184,7 +202,7 @@ pub async fn handle_all_signals(
     info!("Stopping actix system");
     actix::System::current().stop();
 
-    Ok(())
+    result
 }
 
 #[cfg(test)]
@@ -197,8 +215,16 @@ mod tests {
         SIGNAL.store(602437500, Ordering::SeqCst);
         assert!(!is_matching_signal());
 
+        // SIGHUP (1)
+        SIGNAL.store(SignalKind::hangup().into(), Ordering::SeqCst);
+        assert!(is_matching_signal());
+
         // SIGINT (2)
         SIGNAL.store(SignalKind::interrupt().into(), Ordering::SeqCst);
+        assert!(is_matching_signal());
+
+        // SIGQUIT (3)
+        SIGNAL.store(SignalKind::quit().into(), Ordering::SeqCst);
         assert!(is_matching_signal());
 
         // SIGUSR1 (10)
@@ -211,14 +237,6 @@ mod tests {
 
         // TERM (15)
         SIGNAL.store(SignalKind::terminate().into(), Ordering::SeqCst);
-        assert!(is_matching_signal());
-
-        // SIGHUP (1)
-        SIGNAL.store(SignalKind::hangup().into(), Ordering::SeqCst);
-        assert!(is_matching_signal());
-
-        // SIGQUIT (3)
-        SIGNAL.store(SignalKind::quit().into(), Ordering::SeqCst);
         assert!(is_matching_signal());
     }
 }


### PR DESCRIPTION
In this PR:

1. Added coordinated explicit shutdown to the following tasks:
 - Near Data Lake stream;
 - Nearcore stream;
 - AuroraBlocks stream.
 2. Signal handlers reuse the system codes, instead of hardcoded values;
 3. Added SIGQUIT handler.