### PR TITLE
chore: Bump nearcore to 2.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.4-2.6.0-rc.2"
+version = "0.30.4-2.6.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.4-2.6.0-rc.2"
+version = "0.30.4-2.6.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.4-2.6.0-rc.2"
+version = "0.30.4-2.6.0"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.4-2.6.0-rc.2"
+version = "0.30.4-2.6.0"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
@@ -682,8 +682,8 @@ dependencies = [
  "derive_builder",
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
- "near-crypto 2.6.0-rc.2",
- "near-primitives 2.6.0-rc.2",
+ "near-crypto 2.6.0",
+ "near-primitives 2.6.0",
  "serde",
  "serde_json",
  "sha3",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.4-2.6.0-rc.2"
+version = "0.30.4-2.6.0"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -4287,8 +4287,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "derive_more 1.0.0",
@@ -4296,7 +4296,7 @@ dependencies = [
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.6.0-rc.2",
+ "near-time 2.6.0",
  "once_cell",
  "serde",
  "serde_json",
@@ -4307,8 +4307,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4317,16 +4317,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "lru 0.12.5",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "anyhow",
@@ -4345,17 +4345,17 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.6.0-rc.2",
+ "near-crypto 2.6.0",
  "near-epoch-manager",
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.0-rc.2",
+ "near-parameters 2.6.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.0-rc.2",
- "near-schema-checker-lib 2.6.0-rc.2",
+ "near-primitives 2.6.0",
+ "near-schema-checker-lib 2.6.0",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4375,19 +4375,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 1.0.0",
- "near-config-utils 2.6.0-rc.2",
- "near-crypto 2.6.0-rc.2",
+ "near-config-utils 2.6.0",
+ "near-crypto 2.6.0",
  "near-o11y",
- "near-parameters 2.6.0-rc.2",
- "near-primitives 2.6.0-rc.2",
- "near-time 2.6.0-rc.2",
+ "near-parameters 2.6.0",
+ "near-primitives 2.6.0",
+ "near-time 2.6.0",
  "num-rational 0.3.2",
  "serde",
  "serde_json",
@@ -4399,12 +4399,12 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
- "near-crypto 2.6.0-rc.2",
- "near-primitives 2.6.0-rc.2",
- "near-time 2.6.0-rc.2",
+ "near-crypto 2.6.0",
+ "near-primitives 2.6.0",
+ "near-time 2.6.0",
  "thiserror 2.0.12",
  "time",
  "tracing",
@@ -4412,8 +4412,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "borsh 1.5.5",
@@ -4426,14 +4426,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.6.0-rc.2",
+ "near-crypto 2.6.0",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.0-rc.2",
+ "near-primitives 2.6.0",
  "near-store",
  "rand 0.8.5",
  "reed-solomon-erasure",
@@ -4444,17 +4444,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.6.0-rc.2",
+ "near-primitives 2.6.0",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4475,16 +4475,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.6.0-rc.2",
+ "near-crypto 2.6.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.0-rc.2",
+ "near-parameters 2.6.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.0-rc.2",
+ "near-primitives 2.6.0",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4513,17 +4513,17 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.6.0-rc.2",
- "near-primitives 2.6.0-rc.2",
- "near-time 2.6.0-rc.2",
+ "near-crypto 2.6.0",
+ "near-primitives 2.6.0",
+ "near-time 2.6.0",
  "serde",
  "serde_json",
  "strum 0.24.1",
@@ -4546,8 +4546,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4582,8 +4582,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "blake2",
  "borsh 1.5.5",
@@ -4593,9 +4593,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.6.0-rc.2",
- "near-schema-checker-lib 2.6.0-rc.2",
- "near-stdx 2.6.0-rc.2",
+ "near-config-utils 2.6.0",
+ "near-schema-checker-lib 2.6.0",
+ "near-stdx 2.6.0",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4607,15 +4607,15 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "anyhow",
  "near-chain-configs",
- "near-crypto 2.6.0-rc.2",
+ "near-crypto 2.6.0",
  "near-o11y",
- "near-primitives 2.6.0-rc.2",
- "near-time 2.6.0-rc.2",
+ "near-primitives 2.6.0",
+ "near-time 2.6.0",
  "prometheus",
  "serde",
  "serde_json",
@@ -4626,18 +4626,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "borsh 1.5.5",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.6.0-rc.2",
+ "near-crypto 2.6.0",
  "near-o11y",
- "near-primitives 2.6.0-rc.2",
- "near-schema-checker-lib 2.6.0-rc.2",
+ "near-primitives 2.6.0",
+ "near-schema-checker-lib 2.6.0",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4661,30 +4661,30 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
- "near-primitives-core 2.6.0-rc.2",
+ "near-primitives-core 2.6.0",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.6.0-rc.2",
- "near-crypto 2.6.0-rc.2",
+ "near-config-utils 2.6.0",
+ "near-crypto 2.6.0",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.6.0-rc.2",
+ "near-indexer-primitives 2.6.0",
  "near-o11y",
- "near-parameters 2.6.0-rc.2",
- "near-primitives 2.6.0-rc.2",
+ "near-parameters 2.6.0",
+ "near-primitives 2.6.0",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4708,18 +4708,18 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
- "near-primitives 2.6.0-rc.2",
+ "near-primitives 2.6.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4737,7 +4737,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.6.0-rc.2",
+ "near-primitives 2.6.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -4748,29 +4748,29 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.6.0-rc.2",
+ "near-primitives 2.6.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.6.0-rc.2",
- "near-primitives 2.6.0-rc.2",
- "near-schema-checker-lib 2.6.0-rc.2",
+ "near-crypto 2.6.0",
+ "near-primitives 2.6.0",
+ "near-schema-checker-lib 2.6.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4805,19 +4805,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.6.0-rc.2",
+ "near-primitives 2.6.0",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "anyhow",
@@ -4837,13 +4837,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.6.0-rc.2",
- "near-fmt 2.6.0-rc.2",
+ "near-crypto 2.6.0",
+ "near-fmt 2.6.0",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.6.0-rc.2",
- "near-schema-checker-lib 2.6.0-rc.2",
+ "near-primitives 2.6.0",
+ "near-schema-checker-lib 2.6.0",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.3",
@@ -4868,14 +4868,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.6.0-rc.2",
- "near-primitives-core 2.6.0-rc.2",
+ "near-crypto 2.6.0",
+ "near-primitives-core 2.6.0",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -4912,14 +4912,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "borsh 1.5.5",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.6.0-rc.2",
- "near-schema-checker-lib 2.6.0-rc.2",
+ "near-primitives-core 2.6.0",
+ "near-schema-checker-lib 2.6.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -4930,8 +4930,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4945,8 +4945,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "quote",
  "syn 2.0.99",
@@ -4954,13 +4954,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "borsh 1.5.5",
- "near-crypto 2.6.0-rc.2",
+ "near-crypto 2.6.0",
  "near-o11y",
- "near-primitives 2.6.0-rc.2",
+ "near-primitives 2.6.0",
  "rand 0.8.5",
 ]
 
@@ -5006,8 +5006,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5022,13 +5022,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.6.0-rc.2",
- "near-fmt 2.6.0-rc.2",
- "near-parameters 2.6.0-rc.2",
- "near-primitives-core 2.6.0-rc.2",
- "near-schema-checker-lib 2.6.0-rc.2",
- "near-stdx 2.6.0-rc.2",
- "near-time 2.6.0-rc.2",
+ "near-crypto 2.6.0",
+ "near-fmt 2.6.0",
+ "near-parameters 2.6.0",
+ "near-primitives-core 2.6.0",
+ "near-schema-checker-lib 2.6.0",
+ "near-stdx 2.6.0",
+ "near-time 2.6.0",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5069,8 +5069,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5079,7 +5079,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.6.0-rc.2",
+ "near-schema-checker-lib 2.6.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5089,8 +5089,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5105,11 +5105,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.6.0-rc.2",
+ "near-crypto 2.6.0",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.0-rc.2",
- "near-primitives 2.6.0-rc.2",
+ "near-parameters 2.6.0",
+ "near-primitives 2.6.0",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5127,8 +5127,8 @@ checksum = "a48405425eca34de98e680416310df33fdb75768a78481cc75b43172b2748613"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5142,11 +5142,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
- "near-schema-checker-core 2.6.0-rc.2",
- "near-schema-checker-macro 2.6.0-rc.2",
+ "near-schema-checker-core 2.6.0",
+ "near-schema-checker-macro 2.6.0",
 ]
 
 [[package]]
@@ -5157,8 +5157,8 @@ checksum = "b41a159cbf732acc0279febdde046d9036330a32a951796bce42f9529bce799d"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 
 [[package]]
 name = "near-stdx"
@@ -5168,13 +5168,13 @@ checksum = "7a91674768828a593f4bac4aeca9334c4b56fe19344a2ccf7bd795b2325f0b5e"
 
 [[package]]
 name = "near-stdx"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 
 [[package]]
 name = "near-store"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5191,14 +5191,14 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.6.0-rc.2",
- "near-fmt 2.6.0-rc.2",
+ "near-crypto 2.6.0",
+ "near-fmt 2.6.0",
  "near-o11y",
- "near-parameters 2.6.0-rc.2",
- "near-primitives 2.6.0-rc.2",
- "near-schema-checker-lib 2.6.0-rc.2",
- "near-stdx 2.6.0-rc.2",
- "near-time 2.6.0-rc.2",
+ "near-parameters 2.6.0",
+ "near-primitives 2.6.0",
+ "near-schema-checker-lib 2.6.0",
+ "near-stdx 2.6.0",
+ "near-time 2.6.0",
  "near-vm-runner",
  "num_cpus",
  "rand 0.8.5",
@@ -5220,8 +5220,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "awc",
@@ -5230,7 +5230,7 @@ dependencies = [
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-time 2.6.0-rc.2",
+ "near-time 2.6.0",
  "openssl",
  "serde",
  "serde_json",
@@ -5249,8 +5249,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "serde",
  "time",
@@ -5259,8 +5259,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5275,8 +5275,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5295,8 +5295,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5317,8 +5317,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "anyhow",
  "blst",
@@ -5329,12 +5329,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.6.0-rc.2",
+ "near-crypto 2.6.0",
  "near-o11y",
- "near-parameters 2.6.0-rc.2",
- "near-primitives-core 2.6.0-rc.2",
- "near-schema-checker-lib 2.6.0-rc.2",
- "near-stdx 2.6.0-rc.2",
+ "near-parameters 2.6.0",
+ "near-primitives-core 2.6.0",
+ "near-schema-checker-lib 2.6.0",
+ "near-stdx 2.6.0",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5374,8 +5374,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "indexmap 2.7.1",
  "num-traits",
@@ -5385,8 +5385,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "backtrace",
  "cc",
@@ -5406,18 +5406,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.6.0-rc.2",
+ "near-primitives-core 2.6.0",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5442,8 +5442,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.6.0-rc.2",
- "near-crypto 2.6.0-rc.2",
+ "near-config-utils 2.6.0",
+ "near-crypto 2.6.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5451,10 +5451,10 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.0-rc.2",
+ "near-parameters 2.6.0",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.6.0-rc.2",
+ "near-primitives 2.6.0",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5507,17 +5507,17 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.6.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.2#8b59519fe11fe1fd7f7b6d83e37a4e5ca643e175"
+version = "2.6.0"
+source = "git+https://github.com/near/nearcore?tag=2.6.0#b5530e990901418ae09eb727174c49fc97bcd06b"
 dependencies = [
  "borsh 1.5.5",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.6.0-rc.2",
+ "near-crypto 2.6.0",
  "near-o11y",
- "near-parameters 2.6.0-rc.2",
- "near-primitives 2.6.0-rc.2",
- "near-primitives-core 2.6.0-rc.2",
+ "near-parameters 2.6.0",
+ "near-primitives 2.6.0",
+ "near-primitives-core 2.6.0",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.4-2.6.0-rc.2"
+version = "0.30.4-2.6.0"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -36,9 +36,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.2" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.2" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.2" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.0" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.0" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.0" }
 near-lake-framework = "0.7"
 prometheus = "0.13"
 rlp = "0.6"


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.6.0). New package version: 0.30.4-2.6.0