### PR TITLE
chore: Bump nearcore to 2.6.2-rc.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.4-2.6.2-rc.1] 2025-05-09
+
+### Changes
+
+* chore: bump nearcore to 2.6.2-rc.1 in [#220]
+
+[#220]: https://github.com/aurora-is-near/borealis-engine-lib/pull/220
+
 ## [0.30.4-2.6.1-rc.1] 2025-05-05
 
 ### Changes
@@ -225,7 +233,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.4-2.6.1-rc.1...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.4-2.6.2-rc.1...main
+[0.30.4-2.6.2-rc.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.1-rc.1...0.30.4-2.6.2-rc.1
 [0.30.4-2.6.1-rc.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.1...0.30.4-2.6.1-rc.1
 [0.30.4-2.6.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.0...0.30.4-2.6.1
 [0.30.4-2.6.0]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.0-rc.2...0.30.4-2.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.4-2.6.1-rc.1"
+version = "0.30.4-2.6.2-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.4-2.6.1-rc.1"
+version = "0.30.4-2.6.2-rc.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.4-2.6.1-rc.1"
+version = "0.30.4-2.6.2-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.4-2.6.1-rc.1"
+version = "0.30.4-2.6.2-rc.1"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
@@ -683,8 +683,8 @@ dependencies = [
  "derive_builder",
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
- "near-crypto 2.6.1-rc.1",
- "near-primitives 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
+ "near-primitives 2.6.2-rc.1",
  "serde",
  "serde_json",
  "sha3",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.4-2.6.1-rc.1"
+version = "0.30.4-2.6.2-rc.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -4288,8 +4288,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "derive_more 1.0.0",
@@ -4297,7 +4297,7 @@ dependencies = [
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.6.1-rc.1",
+ "near-time 2.6.2-rc.1",
  "once_cell",
  "serde",
  "serde_json",
@@ -4308,8 +4308,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4318,16 +4318,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "lru 0.12.5",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "anyhow",
@@ -4346,17 +4346,17 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
  "near-epoch-manager",
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.1-rc.1",
+ "near-parameters 2.6.2-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.1-rc.1",
- "near-schema-checker-lib 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
+ "near-schema-checker-lib 2.6.2-rc.1",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4376,19 +4376,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 1.0.0",
- "near-config-utils 2.6.1-rc.1",
- "near-crypto 2.6.1-rc.1",
+ "near-config-utils 2.6.2-rc.1",
+ "near-crypto 2.6.2-rc.1",
  "near-o11y",
- "near-parameters 2.6.1-rc.1",
- "near-primitives 2.6.1-rc.1",
- "near-time 2.6.1-rc.1",
+ "near-parameters 2.6.2-rc.1",
+ "near-primitives 2.6.2-rc.1",
+ "near-time 2.6.2-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_json",
@@ -4400,12 +4400,12 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
- "near-crypto 2.6.1-rc.1",
- "near-primitives 2.6.1-rc.1",
- "near-time 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
+ "near-primitives 2.6.2-rc.1",
+ "near-time 2.6.2-rc.1",
  "thiserror 2.0.12",
  "time",
  "tracing",
@@ -4413,8 +4413,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "borsh 1.5.5",
@@ -4427,14 +4427,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
  "near-store",
  "rand 0.8.5",
  "reed-solomon-erasure",
@@ -4445,17 +4445,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4476,16 +4476,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.1-rc.1",
+ "near-parameters 2.6.2-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4514,17 +4514,17 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.6.1-rc.1",
- "near-primitives 2.6.1-rc.1",
- "near-time 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
+ "near-primitives 2.6.2-rc.1",
+ "near-time 2.6.2-rc.1",
  "serde",
  "serde_json",
  "strum 0.24.1",
@@ -4547,8 +4547,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4583,8 +4583,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "blake2",
  "borsh 1.5.5",
@@ -4594,9 +4594,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.6.1-rc.1",
- "near-schema-checker-lib 2.6.1-rc.1",
- "near-stdx 2.6.1-rc.1",
+ "near-config-utils 2.6.2-rc.1",
+ "near-schema-checker-lib 2.6.2-rc.1",
+ "near-stdx 2.6.2-rc.1",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4608,15 +4608,15 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "anyhow",
  "near-chain-configs",
- "near-crypto 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
  "near-o11y",
- "near-primitives 2.6.1-rc.1",
- "near-time 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
+ "near-time 2.6.2-rc.1",
  "prometheus",
  "serde",
  "serde_json",
@@ -4627,18 +4627,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "borsh 1.5.5",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
  "near-o11y",
- "near-primitives 2.6.1-rc.1",
- "near-schema-checker-lib 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
+ "near-schema-checker-lib 2.6.2-rc.1",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4662,30 +4662,30 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
- "near-primitives-core 2.6.1-rc.1",
+ "near-primitives-core 2.6.2-rc.1",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.6.1-rc.1",
- "near-crypto 2.6.1-rc.1",
+ "near-config-utils 2.6.2-rc.1",
+ "near-crypto 2.6.2-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.6.1-rc.1",
+ "near-indexer-primitives 2.6.2-rc.1",
  "near-o11y",
- "near-parameters 2.6.1-rc.1",
- "near-primitives 2.6.1-rc.1",
+ "near-parameters 2.6.2-rc.1",
+ "near-primitives 2.6.2-rc.1",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4709,18 +4709,18 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
- "near-primitives 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4738,7 +4738,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -4749,29 +4749,29 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.6.1-rc.1",
- "near-primitives 2.6.1-rc.1",
- "near-schema-checker-lib 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
+ "near-primitives 2.6.2-rc.1",
+ "near-schema-checker-lib 2.6.2-rc.1",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4806,19 +4806,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "anyhow",
@@ -4838,13 +4838,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.6.1-rc.1",
- "near-fmt 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
+ "near-fmt 2.6.2-rc.1",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.6.1-rc.1",
- "near-schema-checker-lib 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
+ "near-schema-checker-lib 2.6.2-rc.1",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.3",
@@ -4869,14 +4869,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.6.1-rc.1",
- "near-primitives-core 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
+ "near-primitives-core 2.6.2-rc.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -4913,14 +4913,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "borsh 1.5.5",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.6.1-rc.1",
- "near-schema-checker-lib 2.6.1-rc.1",
+ "near-primitives-core 2.6.2-rc.1",
+ "near-schema-checker-lib 2.6.2-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -4931,8 +4931,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4946,8 +4946,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "quote",
  "syn 2.0.99",
@@ -4955,13 +4955,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "borsh 1.5.5",
- "near-crypto 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
  "near-o11y",
- "near-primitives 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
  "rand 0.8.5",
 ]
 
@@ -5007,8 +5007,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5023,13 +5023,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.6.1-rc.1",
- "near-fmt 2.6.1-rc.1",
- "near-parameters 2.6.1-rc.1",
- "near-primitives-core 2.6.1-rc.1",
- "near-schema-checker-lib 2.6.1-rc.1",
- "near-stdx 2.6.1-rc.1",
- "near-time 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
+ "near-fmt 2.6.2-rc.1",
+ "near-parameters 2.6.2-rc.1",
+ "near-primitives-core 2.6.2-rc.1",
+ "near-schema-checker-lib 2.6.2-rc.1",
+ "near-stdx 2.6.2-rc.1",
+ "near-time 2.6.2-rc.1",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5070,8 +5070,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5080,7 +5080,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.6.1-rc.1",
+ "near-schema-checker-lib 2.6.2-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5090,8 +5090,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5106,11 +5106,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.1-rc.1",
- "near-primitives 2.6.1-rc.1",
+ "near-parameters 2.6.2-rc.1",
+ "near-primitives 2.6.2-rc.1",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5128,8 +5128,8 @@ checksum = "a48405425eca34de98e680416310df33fdb75768a78481cc75b43172b2748613"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5143,11 +5143,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
- "near-schema-checker-core 2.6.1-rc.1",
- "near-schema-checker-macro 2.6.1-rc.1",
+ "near-schema-checker-core 2.6.2-rc.1",
+ "near-schema-checker-macro 2.6.2-rc.1",
 ]
 
 [[package]]
@@ -5158,8 +5158,8 @@ checksum = "b41a159cbf732acc0279febdde046d9036330a32a951796bce42f9529bce799d"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 
 [[package]]
 name = "near-stdx"
@@ -5169,13 +5169,13 @@ checksum = "7a91674768828a593f4bac4aeca9334c4b56fe19344a2ccf7bd795b2325f0b5e"
 
 [[package]]
 name = "near-stdx"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 
 [[package]]
 name = "near-store"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5192,14 +5192,14 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.6.1-rc.1",
- "near-fmt 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
+ "near-fmt 2.6.2-rc.1",
  "near-o11y",
- "near-parameters 2.6.1-rc.1",
- "near-primitives 2.6.1-rc.1",
- "near-schema-checker-lib 2.6.1-rc.1",
- "near-stdx 2.6.1-rc.1",
- "near-time 2.6.1-rc.1",
+ "near-parameters 2.6.2-rc.1",
+ "near-primitives 2.6.2-rc.1",
+ "near-schema-checker-lib 2.6.2-rc.1",
+ "near-stdx 2.6.2-rc.1",
+ "near-time 2.6.2-rc.1",
  "near-vm-runner",
  "num_cpus",
  "rand 0.8.5",
@@ -5221,8 +5221,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "awc",
@@ -5231,7 +5231,7 @@ dependencies = [
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-time 2.6.1-rc.1",
+ "near-time 2.6.2-rc.1",
  "openssl",
  "serde",
  "serde_json",
@@ -5250,8 +5250,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "serde",
  "time",
@@ -5260,8 +5260,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5276,8 +5276,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5296,8 +5296,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5318,8 +5318,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "anyhow",
  "blst",
@@ -5330,12 +5330,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
  "near-o11y",
- "near-parameters 2.6.1-rc.1",
- "near-primitives-core 2.6.1-rc.1",
- "near-schema-checker-lib 2.6.1-rc.1",
- "near-stdx 2.6.1-rc.1",
+ "near-parameters 2.6.2-rc.1",
+ "near-primitives-core 2.6.2-rc.1",
+ "near-schema-checker-lib 2.6.2-rc.1",
+ "near-stdx 2.6.2-rc.1",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5375,8 +5375,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "indexmap 2.7.1",
  "num-traits",
@@ -5386,8 +5386,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "backtrace",
  "cc",
@@ -5407,18 +5407,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.6.1-rc.1",
+ "near-primitives-core 2.6.2-rc.1",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5443,8 +5443,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.6.1-rc.1",
- "near-crypto 2.6.1-rc.1",
+ "near-config-utils 2.6.2-rc.1",
+ "near-crypto 2.6.2-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5452,10 +5452,10 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.1-rc.1",
+ "near-parameters 2.6.2-rc.1",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.6.1-rc.1",
+ "near-primitives 2.6.2-rc.1",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5508,17 +5508,17 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.6.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.1-rc.1#eda51b5f5105fe8d8cab79f9a7198ba8fd1c01a6"
+version = "2.6.2-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.2-rc.1#3cabc0c14292601cadce847801b1f6a619b5313b"
 dependencies = [
  "borsh 1.5.5",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.6.1-rc.1",
+ "near-crypto 2.6.2-rc.1",
  "near-o11y",
- "near-parameters 2.6.1-rc.1",
- "near-primitives 2.6.1-rc.1",
- "near-primitives-core 2.6.1-rc.1",
+ "near-parameters 2.6.2-rc.1",
+ "near-primitives 2.6.2-rc.1",
+ "near-primitives-core 2.6.2-rc.1",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.4-2.6.1-rc.1"
+version = "0.30.4-2.6.2-rc.1"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -39,9 +39,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.1-rc.1" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.1-rc.1" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.1-rc.1" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.2-rc.1" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.2-rc.1" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.2-rc.1" }
 near-lake-framework = "0.7"
 prometheus = "0.13"
 rlp = "0.6"


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.6.2-rc.1). New package version: 0.30.4-2.6.2-rc.1