### PR TITLE
chore: Bump nearcore to 2.6.3-rc.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.4-2.6.3-rc.1] 2025-05-14
+
+### Changes
+
+* chore: bump nearcore to 2.6.3-rc.1 in [#223]
+
+[#223]: https://github.com/aurora-is-near/borealis-engine-lib/pull/223
+
 ## [0.30.4-2.6.2] 2025-05-10
 
 ### Changes
@@ -241,7 +249,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.4-2.6.2...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.4-2.6.3-rc.1...main
+[0.30.4-2.6.3-rc.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.2...0.30.4-2.6.3-rc.1
 [0.30.4-2.6.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.2-rc.1...0.30.4-2.6.2
 [0.30.4-2.6.2-rc.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.1-rc.1...0.30.4-2.6.2-rc.1
 [0.30.4-2.6.1-rc.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.1...0.30.4-2.6.1-rc.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.4-2.6.2"
+version = "0.30.4-2.6.3-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.4-2.6.2"
+version = "0.30.4-2.6.3-rc.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.4-2.6.2"
+version = "0.30.4-2.6.3-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.4-2.6.2"
+version = "0.30.4-2.6.3-rc.1"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
@@ -670,8 +670,8 @@ dependencies = [
  "derive_builder",
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
- "near-crypto 2.6.2",
- "near-primitives 2.6.2",
+ "near-crypto 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.1",
  "serde",
  "serde_json",
  "sha3",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.4-2.6.2"
+version = "0.30.4-2.6.3-rc.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -4380,8 +4380,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "derive_more 1.0.0",
@@ -4389,7 +4389,7 @@ dependencies = [
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.6.2",
+ "near-time 2.6.3-rc.1",
  "once_cell",
  "serde",
  "serde_json",
@@ -4400,8 +4400,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4410,16 +4410,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "lru 0.12.5",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "anyhow",
@@ -4438,17 +4438,17 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.6.2",
+ "near-crypto 2.6.3-rc.1",
  "near-epoch-manager",
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.2",
+ "near-parameters 2.6.3-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.2",
- "near-schema-checker-lib 2.6.2",
+ "near-primitives 2.6.3-rc.1",
+ "near-schema-checker-lib 2.6.3-rc.1",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4468,19 +4468,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 1.0.0",
- "near-config-utils 2.6.2",
- "near-crypto 2.6.2",
+ "near-config-utils 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.1",
  "near-o11y",
- "near-parameters 2.6.2",
- "near-primitives 2.6.2",
- "near-time 2.6.2",
+ "near-parameters 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.1",
+ "near-time 2.6.3-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_json",
@@ -4492,12 +4492,12 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
- "near-crypto 2.6.2",
- "near-primitives 2.6.2",
- "near-time 2.6.2",
+ "near-crypto 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.1",
+ "near-time 2.6.3-rc.1",
  "thiserror 2.0.12",
  "time",
  "tracing",
@@ -4505,8 +4505,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "borsh 1.5.7",
@@ -4519,14 +4519,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.6.2",
+ "near-crypto 2.6.3-rc.1",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3-rc.1",
  "near-store",
  "rand 0.8.5",
  "reed-solomon-erasure",
@@ -4537,17 +4537,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3-rc.1",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4568,16 +4568,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.6.2",
+ "near-crypto 2.6.3-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.2",
+ "near-parameters 2.6.3-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3-rc.1",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4606,17 +4606,17 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.6.2",
- "near-primitives 2.6.2",
- "near-time 2.6.2",
+ "near-crypto 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.1",
+ "near-time 2.6.3-rc.1",
  "serde",
  "serde_json",
  "strum 0.24.1",
@@ -4639,8 +4639,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4675,8 +4675,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "blake2",
  "borsh 1.5.7",
@@ -4686,9 +4686,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.6.2",
- "near-schema-checker-lib 2.6.2",
- "near-stdx 2.6.2",
+ "near-config-utils 2.6.3-rc.1",
+ "near-schema-checker-lib 2.6.3-rc.1",
+ "near-stdx 2.6.3-rc.1",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4700,15 +4700,15 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "anyhow",
  "near-chain-configs",
- "near-crypto 2.6.2",
+ "near-crypto 2.6.3-rc.1",
  "near-o11y",
- "near-primitives 2.6.2",
- "near-time 2.6.2",
+ "near-primitives 2.6.3-rc.1",
+ "near-time 2.6.3-rc.1",
  "prometheus",
  "serde",
  "serde_json",
@@ -4719,18 +4719,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "borsh 1.5.7",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.6.2",
+ "near-crypto 2.6.3-rc.1",
  "near-o11y",
- "near-primitives 2.6.2",
- "near-schema-checker-lib 2.6.2",
+ "near-primitives 2.6.3-rc.1",
+ "near-schema-checker-lib 2.6.3-rc.1",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4754,30 +4754,30 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
- "near-primitives-core 2.6.2",
+ "near-primitives-core 2.6.3-rc.1",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.6.2",
- "near-crypto 2.6.2",
+ "near-config-utils 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.6.2",
+ "near-indexer-primitives 2.6.3-rc.1",
  "near-o11y",
- "near-parameters 2.6.2",
- "near-primitives 2.6.2",
+ "near-parameters 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.1",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4801,18 +4801,18 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3-rc.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4830,7 +4830,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3-rc.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -4841,29 +4841,29 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3-rc.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.6.2",
- "near-primitives 2.6.2",
- "near-schema-checker-lib 2.6.2",
+ "near-crypto 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.1",
+ "near-schema-checker-lib 2.6.3-rc.1",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4898,19 +4898,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3-rc.1",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "anyhow",
@@ -4930,13 +4930,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.6.2",
- "near-fmt 2.6.2",
+ "near-crypto 2.6.3-rc.1",
+ "near-fmt 2.6.3-rc.1",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.6.2",
- "near-schema-checker-lib 2.6.2",
+ "near-primitives 2.6.3-rc.1",
+ "near-schema-checker-lib 2.6.3-rc.1",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.3",
@@ -4961,14 +4961,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.6.2",
- "near-primitives-core 2.6.2",
+ "near-crypto 2.6.3-rc.1",
+ "near-primitives-core 2.6.3-rc.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -5005,14 +5005,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "borsh 1.5.7",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.6.2",
- "near-schema-checker-lib 2.6.2",
+ "near-primitives-core 2.6.3-rc.1",
+ "near-schema-checker-lib 2.6.3-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5023,8 +5023,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -5038,8 +5038,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -5047,13 +5047,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "borsh 1.5.7",
- "near-crypto 2.6.2",
+ "near-crypto 2.6.3-rc.1",
  "near-o11y",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3-rc.1",
  "rand 0.8.5",
 ]
 
@@ -5099,8 +5099,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5115,13 +5115,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.6.2",
- "near-fmt 2.6.2",
- "near-parameters 2.6.2",
- "near-primitives-core 2.6.2",
- "near-schema-checker-lib 2.6.2",
- "near-stdx 2.6.2",
- "near-time 2.6.2",
+ "near-crypto 2.6.3-rc.1",
+ "near-fmt 2.6.3-rc.1",
+ "near-parameters 2.6.3-rc.1",
+ "near-primitives-core 2.6.3-rc.1",
+ "near-schema-checker-lib 2.6.3-rc.1",
+ "near-stdx 2.6.3-rc.1",
+ "near-time 2.6.3-rc.1",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5162,8 +5162,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5172,7 +5172,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.6.2",
+ "near-schema-checker-lib 2.6.3-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5182,8 +5182,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5198,11 +5198,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.6.2",
+ "near-crypto 2.6.3-rc.1",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.2",
- "near-primitives 2.6.2",
+ "near-parameters 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.1",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5220,8 +5220,8 @@ checksum = "ed1fbfbc3c53b00aa893f8cb64abc5c12601edb8cecb878baf6f8f00e3184d3d"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5235,11 +5235,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
- "near-schema-checker-core 2.6.2",
- "near-schema-checker-macro 2.6.2",
+ "near-schema-checker-core 2.6.3-rc.1",
+ "near-schema-checker-macro 2.6.3-rc.1",
 ]
 
 [[package]]
@@ -5250,8 +5250,8 @@ checksum = "d191936f902770069255b16c95d1fb8edd6f3c3817c9228933a20ec8466737a3"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 
 [[package]]
 name = "near-stdx"
@@ -5261,13 +5261,13 @@ checksum = "f292226fd8f4c7c21cf6b1da1c17e9b484ebc1b9aeb4251d69336d28b7917ace"
 
 [[package]]
 name = "near-stdx"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 
 [[package]]
 name = "near-store"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5284,14 +5284,14 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.6.2",
- "near-fmt 2.6.2",
+ "near-crypto 2.6.3-rc.1",
+ "near-fmt 2.6.3-rc.1",
  "near-o11y",
- "near-parameters 2.6.2",
- "near-primitives 2.6.2",
- "near-schema-checker-lib 2.6.2",
- "near-stdx 2.6.2",
- "near-time 2.6.2",
+ "near-parameters 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.1",
+ "near-schema-checker-lib 2.6.3-rc.1",
+ "near-stdx 2.6.3-rc.1",
+ "near-time 2.6.3-rc.1",
  "near-vm-runner",
  "num_cpus",
  "rand 0.8.5",
@@ -5313,8 +5313,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "awc",
@@ -5323,7 +5323,7 @@ dependencies = [
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-time 2.6.2",
+ "near-time 2.6.3-rc.1",
  "openssl",
  "serde",
  "serde_json",
@@ -5342,8 +5342,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "serde",
  "time",
@@ -5352,8 +5352,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5368,8 +5368,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5388,8 +5388,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5410,8 +5410,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "anyhow",
  "blst",
@@ -5422,12 +5422,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.6.2",
+ "near-crypto 2.6.3-rc.1",
  "near-o11y",
- "near-parameters 2.6.2",
- "near-primitives-core 2.6.2",
- "near-schema-checker-lib 2.6.2",
- "near-stdx 2.6.2",
+ "near-parameters 2.6.3-rc.1",
+ "near-primitives-core 2.6.3-rc.1",
+ "near-schema-checker-lib 2.6.3-rc.1",
+ "near-stdx 2.6.3-rc.1",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5467,8 +5467,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "indexmap 2.9.0",
  "num-traits",
@@ -5478,8 +5478,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "backtrace",
  "cc",
@@ -5499,18 +5499,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.6.2",
+ "near-primitives-core 2.6.3-rc.1",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5535,8 +5535,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.6.2",
- "near-crypto 2.6.2",
+ "near-config-utils 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5544,10 +5544,10 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.2",
+ "near-parameters 2.6.3-rc.1",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3-rc.1",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5600,17 +5600,17 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.2#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
 dependencies = [
  "borsh 1.5.7",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.6.2",
+ "near-crypto 2.6.3-rc.1",
  "near-o11y",
- "near-parameters 2.6.2",
- "near-primitives 2.6.2",
- "near-primitives-core 2.6.2",
+ "near-parameters 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.1",
+ "near-primitives-core 2.6.3-rc.1",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.4-2.6.2"
+version = "0.30.4-2.6.3-rc.1"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -39,9 +39,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.2" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.2" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.2" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.3-rc.1" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.3-rc.1" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.3-rc.1" }
 near-lake-framework = "0.7"
 prometheus = "0.13"
 rlp = "0.6"


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.6.3-rc.1). New package version: 0.30.4-2.6.3-rc.1