### PR TITLE
chore: Bump nearcore to 2.6.3-rc.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.4-2.6.3-rc.2] 2025-05-15
+
+### Changes
+
+* chore: bump nearcore to 2.6.3-rc.2 in [#224]
+
+[#224]: https://github.com/aurora-is-near/borealis-engine-lib/pull/224
+
 ## [0.30.4-2.6.3-rc.1] 2025-05-14
 
 ### Changes
@@ -249,7 +257,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.4-2.6.3-rc.1...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.4-2.6.3-rc.2...main
+[0.30.4-2.6.3-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.3-rc.1...0.30.4-2.6.3-rc.2
 [0.30.4-2.6.3-rc.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.2...0.30.4-2.6.3-rc.1
 [0.30.4-2.6.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.2-rc.1...0.30.4-2.6.2
 [0.30.4-2.6.2-rc.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.1-rc.1...0.30.4-2.6.2-rc.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -33,7 +33,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -70,7 +70,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "base64 0.22.1",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "brotli",
  "bytes",
  "bytestring",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.4-2.6.3-rc.1"
+version = "0.30.4-2.6.3-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.4-2.6.3-rc.1"
+version = "0.30.4-2.6.3-rc.2"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.4-2.6.3-rc.1"
+version = "0.30.4-2.6.3-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.4-2.6.3-rc.1"
+version = "0.30.4-2.6.3-rc.2"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
@@ -670,8 +670,8 @@ dependencies = [
  "derive_builder",
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
- "near-crypto 2.6.3-rc.1",
- "near-primitives 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
+ "near-primitives 2.6.3-rc.2",
  "serde",
  "serde_json",
  "sha3",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.4-2.6.3-rc.1"
+version = "0.30.4-2.6.3-rc.2"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -1352,7 +1352,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -1375,7 +1375,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1395,9 +1395,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitmaps"
@@ -3151,7 +3151,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -3984,7 +3984,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
 ]
 
@@ -4380,8 +4380,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "derive_more 1.0.0",
@@ -4389,7 +4389,7 @@ dependencies = [
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.6.3-rc.1",
+ "near-time 2.6.3-rc.2",
  "once_cell",
  "serde",
  "serde_json",
@@ -4400,8 +4400,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4410,16 +4410,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "lru 0.12.5",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "anyhow",
@@ -4438,17 +4438,17 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
  "near-epoch-manager",
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.3-rc.1",
+ "near-parameters 2.6.3-rc.2",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.3-rc.1",
- "near-schema-checker-lib 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
+ "near-schema-checker-lib 2.6.3-rc.2",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4468,19 +4468,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 1.0.0",
- "near-config-utils 2.6.3-rc.1",
- "near-crypto 2.6.3-rc.1",
+ "near-config-utils 2.6.3-rc.2",
+ "near-crypto 2.6.3-rc.2",
  "near-o11y",
- "near-parameters 2.6.3-rc.1",
- "near-primitives 2.6.3-rc.1",
- "near-time 2.6.3-rc.1",
+ "near-parameters 2.6.3-rc.2",
+ "near-primitives 2.6.3-rc.2",
+ "near-time 2.6.3-rc.2",
  "num-rational 0.3.2",
  "serde",
  "serde_json",
@@ -4492,12 +4492,12 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
- "near-crypto 2.6.3-rc.1",
- "near-primitives 2.6.3-rc.1",
- "near-time 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
+ "near-primitives 2.6.3-rc.2",
+ "near-time 2.6.3-rc.2",
  "thiserror 2.0.12",
  "time",
  "tracing",
@@ -4505,8 +4505,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "borsh 1.5.7",
@@ -4519,14 +4519,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
  "near-store",
  "rand 0.8.5",
  "reed-solomon-erasure",
@@ -4537,17 +4537,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4568,16 +4568,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.3-rc.1",
+ "near-parameters 2.6.3-rc.2",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4606,17 +4606,17 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.6.3-rc.1",
- "near-primitives 2.6.3-rc.1",
- "near-time 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
+ "near-primitives 2.6.3-rc.2",
+ "near-time 2.6.3-rc.2",
  "serde",
  "serde_json",
  "strum 0.24.1",
@@ -4639,8 +4639,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4675,8 +4675,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "blake2",
  "borsh 1.5.7",
@@ -4686,9 +4686,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.6.3-rc.1",
- "near-schema-checker-lib 2.6.3-rc.1",
- "near-stdx 2.6.3-rc.1",
+ "near-config-utils 2.6.3-rc.2",
+ "near-schema-checker-lib 2.6.3-rc.2",
+ "near-stdx 2.6.3-rc.2",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4700,15 +4700,15 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "anyhow",
  "near-chain-configs",
- "near-crypto 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
  "near-o11y",
- "near-primitives 2.6.3-rc.1",
- "near-time 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
+ "near-time 2.6.3-rc.2",
  "prometheus",
  "serde",
  "serde_json",
@@ -4719,18 +4719,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "borsh 1.5.7",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
  "near-o11y",
- "near-primitives 2.6.3-rc.1",
- "near-schema-checker-lib 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
+ "near-schema-checker-lib 2.6.3-rc.2",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4754,30 +4754,30 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
- "near-primitives-core 2.6.3-rc.1",
+ "near-primitives-core 2.6.3-rc.2",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.6.3-rc.1",
- "near-crypto 2.6.3-rc.1",
+ "near-config-utils 2.6.3-rc.2",
+ "near-crypto 2.6.3-rc.2",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.6.3-rc.1",
+ "near-indexer-primitives 2.6.3-rc.2",
  "near-o11y",
- "near-parameters 2.6.3-rc.1",
- "near-primitives 2.6.3-rc.1",
+ "near-parameters 2.6.3-rc.2",
+ "near-primitives 2.6.3-rc.2",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4801,18 +4801,18 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
- "near-primitives 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4830,7 +4830,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -4841,29 +4841,29 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.6.3-rc.1",
- "near-primitives 2.6.3-rc.1",
- "near-schema-checker-lib 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
+ "near-primitives 2.6.3-rc.2",
+ "near-schema-checker-lib 2.6.3-rc.2",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4898,19 +4898,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "anyhow",
@@ -4930,13 +4930,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.6.3-rc.1",
- "near-fmt 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
+ "near-fmt 2.6.3-rc.2",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.6.3-rc.1",
- "near-schema-checker-lib 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
+ "near-schema-checker-lib 2.6.3-rc.2",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.3",
@@ -4961,14 +4961,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.6.3-rc.1",
- "near-primitives-core 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
+ "near-primitives-core 2.6.3-rc.2",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -5005,14 +5005,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "borsh 1.5.7",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.6.3-rc.1",
- "near-schema-checker-lib 2.6.3-rc.1",
+ "near-primitives-core 2.6.3-rc.2",
+ "near-schema-checker-lib 2.6.3-rc.2",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5023,8 +5023,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -5038,8 +5038,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -5047,13 +5047,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "borsh 1.5.7",
- "near-crypto 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
  "near-o11y",
- "near-primitives 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
  "rand 0.8.5",
 ]
 
@@ -5099,8 +5099,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5115,13 +5115,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.6.3-rc.1",
- "near-fmt 2.6.3-rc.1",
- "near-parameters 2.6.3-rc.1",
- "near-primitives-core 2.6.3-rc.1",
- "near-schema-checker-lib 2.6.3-rc.1",
- "near-stdx 2.6.3-rc.1",
- "near-time 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
+ "near-fmt 2.6.3-rc.2",
+ "near-parameters 2.6.3-rc.2",
+ "near-primitives-core 2.6.3-rc.2",
+ "near-schema-checker-lib 2.6.3-rc.2",
+ "near-stdx 2.6.3-rc.2",
+ "near-time 2.6.3-rc.2",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5162,8 +5162,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5172,7 +5172,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.6.3-rc.1",
+ "near-schema-checker-lib 2.6.3-rc.2",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5182,8 +5182,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5198,11 +5198,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.3-rc.1",
- "near-primitives 2.6.3-rc.1",
+ "near-parameters 2.6.3-rc.2",
+ "near-primitives 2.6.3-rc.2",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5220,8 +5220,8 @@ checksum = "ed1fbfbc3c53b00aa893f8cb64abc5c12601edb8cecb878baf6f8f00e3184d3d"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5235,11 +5235,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
- "near-schema-checker-core 2.6.3-rc.1",
- "near-schema-checker-macro 2.6.3-rc.1",
+ "near-schema-checker-core 2.6.3-rc.2",
+ "near-schema-checker-macro 2.6.3-rc.2",
 ]
 
 [[package]]
@@ -5250,8 +5250,8 @@ checksum = "d191936f902770069255b16c95d1fb8edd6f3c3817c9228933a20ec8466737a3"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 
 [[package]]
 name = "near-stdx"
@@ -5261,13 +5261,13 @@ checksum = "f292226fd8f4c7c21cf6b1da1c17e9b484ebc1b9aeb4251d69336d28b7917ace"
 
 [[package]]
 name = "near-stdx"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 
 [[package]]
 name = "near-store"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5284,14 +5284,14 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.6.3-rc.1",
- "near-fmt 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
+ "near-fmt 2.6.3-rc.2",
  "near-o11y",
- "near-parameters 2.6.3-rc.1",
- "near-primitives 2.6.3-rc.1",
- "near-schema-checker-lib 2.6.3-rc.1",
- "near-stdx 2.6.3-rc.1",
- "near-time 2.6.3-rc.1",
+ "near-parameters 2.6.3-rc.2",
+ "near-primitives 2.6.3-rc.2",
+ "near-schema-checker-lib 2.6.3-rc.2",
+ "near-stdx 2.6.3-rc.2",
+ "near-time 2.6.3-rc.2",
  "near-vm-runner",
  "num_cpus",
  "rand 0.8.5",
@@ -5313,8 +5313,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "awc",
@@ -5323,7 +5323,7 @@ dependencies = [
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-time 2.6.3-rc.1",
+ "near-time 2.6.3-rc.2",
  "openssl",
  "serde",
  "serde_json",
@@ -5342,8 +5342,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "serde",
  "time",
@@ -5352,8 +5352,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5368,8 +5368,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5388,8 +5388,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5410,8 +5410,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "anyhow",
  "blst",
@@ -5422,12 +5422,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
  "near-o11y",
- "near-parameters 2.6.3-rc.1",
- "near-primitives-core 2.6.3-rc.1",
- "near-schema-checker-lib 2.6.3-rc.1",
- "near-stdx 2.6.3-rc.1",
+ "near-parameters 2.6.3-rc.2",
+ "near-primitives-core 2.6.3-rc.2",
+ "near-schema-checker-lib 2.6.3-rc.2",
+ "near-stdx 2.6.3-rc.2",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5467,8 +5467,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "indexmap 2.9.0",
  "num-traits",
@@ -5478,8 +5478,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "backtrace",
  "cc",
@@ -5499,18 +5499,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.6.3-rc.1",
+ "near-primitives-core 2.6.3-rc.2",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5535,8 +5535,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.6.3-rc.1",
- "near-crypto 2.6.3-rc.1",
+ "near-config-utils 2.6.3-rc.2",
+ "near-crypto 2.6.3-rc.2",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5544,10 +5544,10 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.3-rc.1",
+ "near-parameters 2.6.3-rc.2",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.6.3-rc.1",
+ "near-primitives 2.6.3-rc.2",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5600,17 +5600,17 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.6.3-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.1#066689e9351445935963d69cc70c30aaa30c2222"
+version = "2.6.3-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
 dependencies = [
  "borsh 1.5.7",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.6.3-rc.1",
+ "near-crypto 2.6.3-rc.2",
  "near-o11y",
- "near-parameters 2.6.3-rc.1",
- "near-primitives 2.6.3-rc.1",
- "near-primitives-core 2.6.3-rc.1",
+ "near-parameters 2.6.3-rc.2",
+ "near-primitives 2.6.3-rc.2",
+ "near-primitives-core 2.6.3-rc.2",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",
@@ -5823,7 +5823,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -6930,7 +6930,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -7387,7 +7387,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno 0.3.11",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -7400,7 +7400,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno 0.3.11",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -7630,7 +7630,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -7643,7 +7643,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -8208,7 +8208,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -9377,7 +9377,7 @@ version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "hashbrown 0.15.3",
  "indexmap 2.9.0",
  "semver 1.0.26",
@@ -9413,7 +9413,7 @@ checksum = "809cc8780708f1deed0a7c3fcab46954f0e8c08a6fe0252772481fbc88fcf946"
 dependencies = [
  "addr2line",
  "anyhow",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "bumpalo",
  "cc",
  "cfg-if 1.0.0",
@@ -9987,7 +9987,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.4-2.6.3-rc.1"
+version = "0.30.4-2.6.3-rc.2"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -39,9 +39,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.3-rc.1" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.3-rc.1" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.3-rc.1" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.3-rc.2" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.3-rc.2" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.3-rc.2" }
 near-lake-framework = "0.7"
 prometheus = "0.13"
 rlp = "0.6"


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.6.3-rc.2). New package version: 0.30.4-2.6.3-rc.2