### PR TITLE
chore: Bump nearcore to 2.6.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.4-2.6.3] 2025-05-16
+
+### Changes
+
+* chore: bump nearcore to 2.6.3 in [#225]
+
+[#225]: https://github.com/aurora-is-near/borealis-engine-lib/pull/225
+
 ## [0.30.4-2.6.3-rc.2] 2025-05-15
 
 ### Changes
@@ -257,7 +265,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.4-2.6.3-rc.2...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.4-2.6.3...main
+[0.30.4-2.6.3]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.3-rc.2...0.30.4-2.6.3
 [0.30.4-2.6.3-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.3-rc.1...0.30.4-2.6.3-rc.2
 [0.30.4-2.6.3-rc.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.2...0.30.4-2.6.3-rc.1
 [0.30.4-2.6.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.2-rc.1...0.30.4-2.6.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.4-2.6.3-rc.2"
+version = "0.30.4-2.6.3"
 dependencies = [
  "actix",
  "anyhow",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.4-2.6.3-rc.2"
+version = "0.30.4-2.6.3"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.4-2.6.3-rc.2"
+version = "0.30.4-2.6.3"
 dependencies = [
  "actix",
  "anyhow",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.4-2.6.3-rc.2"
+version = "0.30.4-2.6.3"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
@@ -670,8 +670,8 @@ dependencies = [
  "derive_builder",
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
- "near-crypto 2.6.3-rc.2",
- "near-primitives 2.6.3-rc.2",
+ "near-crypto 2.6.3",
+ "near-primitives 2.6.3",
  "serde",
  "serde_json",
  "sha3",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.4-2.6.3-rc.2"
+version = "0.30.4-2.6.3"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -1012,16 +1012,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65d21e1ba6f2cdec92044f904356a19f5ad86961acf015741106cdfafd747c0"
+checksum = "0c4e5a89d8103b8090a3f04259fb851ebd3f33abf4fb3ac13326fefaa827618b"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
- "crc32c",
- "crc32fast",
- "crc64fast-nvme",
+ "crc-fast",
  "hex",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -1715,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "jobserver",
  "libc",
@@ -2109,12 +2107,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
-name = "crc32c"
-version = "0.6.8"
+name = "crc-fast"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+checksum = "add8d3a4c789d77eeb0f0e3c1035f73610d017f9047e87db94f89c02a56d8fef"
 dependencies = [
- "rustc_version 0.4.1",
+ "cc",
+ "crc",
+ "digest 0.10.7",
+ "libc",
+ "rand 0.9.1",
+ "regex",
 ]
 
 [[package]]
@@ -2124,15 +2127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "crc64fast-nvme"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4955638f00a809894c947f85a024020a20815b65a5eea633798ea7924edab2b3"
-dependencies = [
- "crc",
 ]
 
 [[package]]
@@ -2754,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -4380,8 +4374,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "derive_more 1.0.0",
@@ -4389,7 +4383,7 @@ dependencies = [
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.6.3-rc.2",
+ "near-time 2.6.3",
  "once_cell",
  "serde",
  "serde_json",
@@ -4400,8 +4394,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4410,16 +4404,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "lru 0.12.5",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4438,17 +4432,17 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.6.3-rc.2",
+ "near-crypto 2.6.3",
  "near-epoch-manager",
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.3-rc.2",
+ "near-parameters 2.6.3",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.3-rc.2",
- "near-schema-checker-lib 2.6.3-rc.2",
+ "near-primitives 2.6.3",
+ "near-schema-checker-lib 2.6.3",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4468,19 +4462,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 1.0.0",
- "near-config-utils 2.6.3-rc.2",
- "near-crypto 2.6.3-rc.2",
+ "near-config-utils 2.6.3",
+ "near-crypto 2.6.3",
  "near-o11y",
- "near-parameters 2.6.3-rc.2",
- "near-primitives 2.6.3-rc.2",
- "near-time 2.6.3-rc.2",
+ "near-parameters 2.6.3",
+ "near-primitives 2.6.3",
+ "near-time 2.6.3",
  "num-rational 0.3.2",
  "serde",
  "serde_json",
@@ -4492,12 +4486,12 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
- "near-crypto 2.6.3-rc.2",
- "near-primitives 2.6.3-rc.2",
- "near-time 2.6.3-rc.2",
+ "near-crypto 2.6.3",
+ "near-primitives 2.6.3",
+ "near-time 2.6.3",
  "thiserror 2.0.12",
  "time",
  "tracing",
@@ -4505,8 +4499,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "borsh 1.5.7",
@@ -4519,14 +4513,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.6.3-rc.2",
+ "near-crypto 2.6.3",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.3-rc.2",
+ "near-primitives 2.6.3",
  "near-store",
  "rand 0.8.5",
  "reed-solomon-erasure",
@@ -4537,17 +4531,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.6.3-rc.2",
+ "near-primitives 2.6.3",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4568,16 +4562,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.6.3-rc.2",
+ "near-crypto 2.6.3",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.3-rc.2",
+ "near-parameters 2.6.3",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.3-rc.2",
+ "near-primitives 2.6.3",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4606,17 +4600,17 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.6.3-rc.2",
- "near-primitives 2.6.3-rc.2",
- "near-time 2.6.3-rc.2",
+ "near-crypto 2.6.3",
+ "near-primitives 2.6.3",
+ "near-time 2.6.3",
  "serde",
  "serde_json",
  "strum 0.24.1",
@@ -4639,8 +4633,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4675,8 +4669,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "blake2",
  "borsh 1.5.7",
@@ -4686,9 +4680,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.6.3-rc.2",
- "near-schema-checker-lib 2.6.3-rc.2",
- "near-stdx 2.6.3-rc.2",
+ "near-config-utils 2.6.3",
+ "near-schema-checker-lib 2.6.3",
+ "near-stdx 2.6.3",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4700,15 +4694,15 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "anyhow",
  "near-chain-configs",
- "near-crypto 2.6.3-rc.2",
+ "near-crypto 2.6.3",
  "near-o11y",
- "near-primitives 2.6.3-rc.2",
- "near-time 2.6.3-rc.2",
+ "near-primitives 2.6.3",
+ "near-time 2.6.3",
  "prometheus",
  "serde",
  "serde_json",
@@ -4719,18 +4713,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "borsh 1.5.7",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.6.3-rc.2",
+ "near-crypto 2.6.3",
  "near-o11y",
- "near-primitives 2.6.3-rc.2",
- "near-schema-checker-lib 2.6.3-rc.2",
+ "near-primitives 2.6.3",
+ "near-schema-checker-lib 2.6.3",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4754,30 +4748,30 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
- "near-primitives-core 2.6.3-rc.2",
+ "near-primitives-core 2.6.3",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.6.3-rc.2",
- "near-crypto 2.6.3-rc.2",
+ "near-config-utils 2.6.3",
+ "near-crypto 2.6.3",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.6.3-rc.2",
+ "near-indexer-primitives 2.6.3",
  "near-o11y",
- "near-parameters 2.6.3-rc.2",
- "near-primitives 2.6.3-rc.2",
+ "near-parameters 2.6.3",
+ "near-primitives 2.6.3",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4801,18 +4795,18 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
- "near-primitives 2.6.3-rc.2",
+ "near-primitives 2.6.3",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4830,7 +4824,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.6.3-rc.2",
+ "near-primitives 2.6.3",
  "serde",
  "serde_json",
  "serde_with",
@@ -4841,29 +4835,29 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.6.3-rc.2",
+ "near-primitives 2.6.3",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.6.3-rc.2",
- "near-primitives 2.6.3-rc.2",
- "near-schema-checker-lib 2.6.3-rc.2",
+ "near-crypto 2.6.3",
+ "near-primitives 2.6.3",
+ "near-schema-checker-lib 2.6.3",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4898,19 +4892,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.6.3-rc.2",
+ "near-primitives 2.6.3",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4930,13 +4924,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.6.3-rc.2",
- "near-fmt 2.6.3-rc.2",
+ "near-crypto 2.6.3",
+ "near-fmt 2.6.3",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.6.3-rc.2",
- "near-schema-checker-lib 2.6.3-rc.2",
+ "near-primitives 2.6.3",
+ "near-schema-checker-lib 2.6.3",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.3",
@@ -4961,14 +4955,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.6.3-rc.2",
- "near-primitives-core 2.6.3-rc.2",
+ "near-crypto 2.6.3",
+ "near-primitives-core 2.6.3",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -5005,14 +4999,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "borsh 1.5.7",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.6.3-rc.2",
- "near-schema-checker-lib 2.6.3-rc.2",
+ "near-primitives-core 2.6.3",
+ "near-schema-checker-lib 2.6.3",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5023,8 +5017,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -5038,8 +5032,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -5047,13 +5041,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "borsh 1.5.7",
- "near-crypto 2.6.3-rc.2",
+ "near-crypto 2.6.3",
  "near-o11y",
- "near-primitives 2.6.3-rc.2",
+ "near-primitives 2.6.3",
  "rand 0.8.5",
 ]
 
@@ -5099,8 +5093,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5115,13 +5109,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.6.3-rc.2",
- "near-fmt 2.6.3-rc.2",
- "near-parameters 2.6.3-rc.2",
- "near-primitives-core 2.6.3-rc.2",
- "near-schema-checker-lib 2.6.3-rc.2",
- "near-stdx 2.6.3-rc.2",
- "near-time 2.6.3-rc.2",
+ "near-crypto 2.6.3",
+ "near-fmt 2.6.3",
+ "near-parameters 2.6.3",
+ "near-primitives-core 2.6.3",
+ "near-schema-checker-lib 2.6.3",
+ "near-stdx 2.6.3",
+ "near-time 2.6.3",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5162,8 +5156,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5172,7 +5166,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.6.3-rc.2",
+ "near-schema-checker-lib 2.6.3",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5182,8 +5176,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5198,11 +5192,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.6.3-rc.2",
+ "near-crypto 2.6.3",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.3-rc.2",
- "near-primitives 2.6.3-rc.2",
+ "near-parameters 2.6.3",
+ "near-primitives 2.6.3",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5220,8 +5214,8 @@ checksum = "ed1fbfbc3c53b00aa893f8cb64abc5c12601edb8cecb878baf6f8f00e3184d3d"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5235,11 +5229,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
- "near-schema-checker-core 2.6.3-rc.2",
- "near-schema-checker-macro 2.6.3-rc.2",
+ "near-schema-checker-core 2.6.3",
+ "near-schema-checker-macro 2.6.3",
 ]
 
 [[package]]
@@ -5250,8 +5244,8 @@ checksum = "d191936f902770069255b16c95d1fb8edd6f3c3817c9228933a20ec8466737a3"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 
 [[package]]
 name = "near-stdx"
@@ -5261,13 +5255,13 @@ checksum = "f292226fd8f4c7c21cf6b1da1c17e9b484ebc1b9aeb4251d69336d28b7917ace"
 
 [[package]]
 name = "near-stdx"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 
 [[package]]
 name = "near-store"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5284,14 +5278,14 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.6.3-rc.2",
- "near-fmt 2.6.3-rc.2",
+ "near-crypto 2.6.3",
+ "near-fmt 2.6.3",
  "near-o11y",
- "near-parameters 2.6.3-rc.2",
- "near-primitives 2.6.3-rc.2",
- "near-schema-checker-lib 2.6.3-rc.2",
- "near-stdx 2.6.3-rc.2",
- "near-time 2.6.3-rc.2",
+ "near-parameters 2.6.3",
+ "near-primitives 2.6.3",
+ "near-schema-checker-lib 2.6.3",
+ "near-stdx 2.6.3",
+ "near-time 2.6.3",
  "near-vm-runner",
  "num_cpus",
  "rand 0.8.5",
@@ -5313,8 +5307,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "awc",
@@ -5323,7 +5317,7 @@ dependencies = [
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-time 2.6.3-rc.2",
+ "near-time 2.6.3",
  "openssl",
  "serde",
  "serde_json",
@@ -5342,8 +5336,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "serde",
  "time",
@@ -5352,8 +5346,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5368,8 +5362,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5388,8 +5382,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5410,8 +5404,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "anyhow",
  "blst",
@@ -5422,12 +5416,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.6.3-rc.2",
+ "near-crypto 2.6.3",
  "near-o11y",
- "near-parameters 2.6.3-rc.2",
- "near-primitives-core 2.6.3-rc.2",
- "near-schema-checker-lib 2.6.3-rc.2",
- "near-stdx 2.6.3-rc.2",
+ "near-parameters 2.6.3",
+ "near-primitives-core 2.6.3",
+ "near-schema-checker-lib 2.6.3",
+ "near-stdx 2.6.3",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5467,8 +5461,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "indexmap 2.9.0",
  "num-traits",
@@ -5478,8 +5472,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "backtrace",
  "cc",
@@ -5499,18 +5493,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.6.3-rc.2",
+ "near-primitives-core 2.6.3",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5535,8 +5529,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.6.3-rc.2",
- "near-crypto 2.6.3-rc.2",
+ "near-config-utils 2.6.3",
+ "near-crypto 2.6.3",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5544,10 +5538,10 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.3-rc.2",
+ "near-parameters 2.6.3",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.6.3-rc.2",
+ "near-primitives 2.6.3",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5600,17 +5594,17 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.6.3-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.6.3-rc.2#e7d522740d91de7c1a1955df6cbd4edb63f78da7"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?tag=2.6.3#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "borsh 1.5.7",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.6.3-rc.2",
+ "near-crypto 2.6.3",
  "near-o11y",
- "near-parameters 2.6.3-rc.2",
- "near-primitives 2.6.3-rc.2",
- "near-primitives-core 2.6.3-rc.2",
+ "near-parameters 2.6.3",
+ "near-primitives 2.6.3",
+ "near-primitives-core 2.6.3",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",
@@ -7388,7 +7382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.9.1",
- "errno 0.3.11",
+ "errno 0.3.12",
  "libc",
  "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
@@ -7401,7 +7395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.1",
- "errno 0.3.11",
+ "errno 0.3.12",
  "libc",
  "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
@@ -9673,15 +9667,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.0",
+ "windows-strings 0.4.1",
 ]
 
 [[package]]
@@ -9725,9 +9719,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
 dependencies = [
  "windows-link",
 ]
@@ -9743,9 +9737,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.4-2.6.3-rc.2"
+version = "0.30.4-2.6.3"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -39,9 +39,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.3-rc.2" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.3-rc.2" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.3-rc.2" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.3" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.3" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.3" }
 near-lake-framework = "0.7"
 prometheus = "0.13"
 rlp = "0.6"


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.6.3). New package version: 0.30.4-2.6.3