### PR TITLE
fix: Correct sh syntax for the BEL gh action

### DIFF
--- a/.github/workflows/daily-network-tests.yml
+++ b/.github/workflows/daily-network-tests.yml
@@ -40,28 +40,32 @@ jobs:
           RUST_LOG: debug
 
       - name: Send failure notification
-        if: failure()
+        if: failure() && vars.ENABLE_BOREALIS_NETWORK_NOTIFICATIONS == 'true'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.BOREALIS_NETWORK_TESTS_SLACK_WEBHOOK_URL }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           if [ -n "$SLACK_WEBHOOK_URL" ]; then
             curl -X POST -H 'Content-type: application/json' --data "{
-              \"text\": \"Daily network tests failed in borealis-engine-lib. This could indicate issues with NEAR block deserialization or network connectivity. See details: $WORKFLOW_URL\"
+              \"text\": \"Borealis Engine Lib Network Tests FAILED - Daily network tests failed in borealis-engine-lib. This could indicate issues with NEAR block deserialization or network connectivity. See details: $WORKFLOW_URL\"
             }" $SLACK_WEBHOOK_URL
           else
-            echo "SLACK_WEBHOOK_URL not configured, skipping notification"
+            echo "BOREALIS_NETWORK_TESTS_SLACK_WEBHOOK_URL not configured, skipping notification"
           fi
 
       - name: Send success notification
-        if: success()
+        if: success() && vars.ENABLE_BOREALIS_NETWORK_NOTIFICATIONS == 'true'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.RELEASES_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.BOREALIS_NETWORK_TESTS_SLACK_WEBHOOK_URL }}
         run: |
           if [ -n "$SLACK_WEBHOOK_URL" ]; then
             curl -X POST -H 'Content-type: application/json' --data "{
-              \"text\": \"Daily network tests passed successfully in borealis-engine-lib. NEAR block deserialization is working correctly with latest mainnet and testnet blocks.\"
+              \"text\": \"Borealis Engine Lib Network Tests PASSED - Daily network tests passed successfully in borealis-engine-lib. NEAR block deserialization is working correctly with latest mainnet and testnet blocks.\"
             }" $SLACK_WEBHOOK_URL
           else
-            echo "SLACK_WEBHOOK_URL not configured, skipping notification"
+            echo "BOREALIS_NETWORK_TESTS_SLACK_WEBHOOK_URL not configured, skipping notification"
           fi
+
+      - name: Slack notifications disabled message
+        if: vars.ENABLE_BOREALIS_NETWORK_NOTIFICATIONS != 'true'
+        run: echo "Borealis network test notifications are currently disabled. Set ENABLE_BOREALIS_NETWORK_NOTIFICATIONS to 'true' to re-enable."

--- a/.github/workflows/daily-network-tests.yml
+++ b/.github/workflows/daily-network-tests.yml
@@ -39,28 +39,24 @@ jobs:
         env:
           RUST_LOG: debug
 
-      - name: Send failure notification
-        if: failure() && vars.ENABLE_BOREALIS_NETWORK_NOTIFICATIONS == 'true'
+      - name: Send Slack notification
+        if: always() && vars.ENABLE_BOREALIS_NETWORK_NOTIFICATIONS == 'true'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.BOREALIS_NETWORK_TESTS_SLACK_WEBHOOK_URL }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          JOB_STATUS: ${{ job.status }}
         run: |
           if [ -n "$SLACK_WEBHOOK_URL" ]; then
+            if [ "$JOB_STATUS" = "success" ]; then
+              MESSAGE="Borealis Engine Lib Network Tests PASSED - Daily network tests passed successfully in borealis-engine-lib. NEAR block deserialization is working correctly with latest mainnet and testnet blocks."
+            elif [ "$JOB_STATUS" = "failure" ]; then
+              MESSAGE="Borealis Engine Lib Network Tests FAILED - Daily network tests failed in borealis-engine-lib. This could indicate issues with NEAR block deserialization or network connectivity. See details: $WORKFLOW_URL"
+            else
+              MESSAGE="Borealis Engine Lib Network Tests completed with status: $JOB_STATUS"
+            fi
+            
             curl -X POST -H 'Content-type: application/json' --data "{
-              \"text\": \"Borealis Engine Lib Network Tests FAILED - Daily network tests failed in borealis-engine-lib. This could indicate issues with NEAR block deserialization or network connectivity. See details: $WORKFLOW_URL\"
-            }" $SLACK_WEBHOOK_URL
-          else
-            echo "BOREALIS_NETWORK_TESTS_SLACK_WEBHOOK_URL not configured, skipping notification"
-          fi
-
-      - name: Send success notification
-        if: success() && vars.ENABLE_BOREALIS_NETWORK_NOTIFICATIONS == 'true'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.BOREALIS_NETWORK_TESTS_SLACK_WEBHOOK_URL }}
-        run: |
-          if [ -n "$SLACK_WEBHOOK_URL" ]; then
-            curl -X POST -H 'Content-type: application/json' --data "{
-              \"text\": \"Borealis Engine Lib Network Tests PASSED - Daily network tests passed successfully in borealis-engine-lib. NEAR block deserialization is working correctly with latest mainnet and testnet blocks.\"
+              \"text\": \"$MESSAGE\"
             }" $SLACK_WEBHOOK_URL
           else
             echo "BOREALIS_NETWORK_TESTS_SLACK_WEBHOOK_URL not configured, skipping notification"

--- a/.github/workflows/daily-network-tests.yml
+++ b/.github/workflows/daily-network-tests.yml
@@ -54,10 +54,10 @@ jobs:
             else
               MESSAGE="Borealis Engine Lib Network Tests completed with status: $JOB_STATUS"
             fi
-            
-            curl -X POST -H 'Content-type: application/json' --data "{
+            set -e
+            curl --fail-with-body -sS -X POST -H 'Content-type: application/json' --data "{
               \"text\": \"$MESSAGE\"
-            }" $SLACK_WEBHOOK_URL
+            }" "$SLACK_WEBHOOK_URL"
           else
             echo "BOREALIS_NETWORK_TESTS_SLACK_WEBHOOK_URL not configured, skipping notification"
           fi

--- a/.github/workflows/daily-network-tests.yml
+++ b/.github/workflows/daily-network-tests.yml
@@ -45,7 +45,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.ALERTS_SLACK_WEBHOOK_URL }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [[ -n "$SLACK_WEBHOOK_URL" ]]; then
+          if [ -n "$SLACK_WEBHOOK_URL" ]; then
             curl -X POST -H 'Content-type: application/json' --data "{
               \"text\": \"Daily network tests failed in borealis-engine-lib. This could indicate issues with NEAR block deserialization or network connectivity. See details: $WORKFLOW_URL\"
             }" $SLACK_WEBHOOK_URL
@@ -58,7 +58,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.RELEASES_SLACK_WEBHOOK_URL }}
         run: |
-          if [[ -n "$SLACK_WEBHOOK_URL" ]]; then
+          if [ -n "$SLACK_WEBHOOK_URL" ]; then
             curl -X POST -H 'Content-type: application/json' --data "{
               \"text\": \"Daily network tests passed successfully in borealis-engine-lib. NEAR block deserialization is working correctly with latest mainnet and testnet blocks.\"
             }" $SLACK_WEBHOOK_URL

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * fix: use selfhosted runners for rust tests by [@aleksuss] in [#230]
 * fix: Add missing serde flag to ChunkHeaderView by [@aleksandr-borodulya] in [#231]
+* fix: Correct sh syntax for the BEL gh action by [@aleksandr-borodulya] in [#232]
 
 [#230]: https://github.com/aurora-is-near/borealis-engine-lib/pull/230
 [#231]: https://github.com/aurora-is-near/borealis-engine-lib/pull/231
+[#232]: https://github.com/aurora-is-near/borealis-engine-lib/pull/232
 
 ## [0.30.5-2.6.3] 2025-06-03
 


### PR DESCRIPTION
In this PR:
 - Fixed incorrect shell syntax in the `.github/workflows/daily-network-tests.yml`;
 - Env-based control to enable or disable Slack notifications using `ENABLE_BOREALIS_NETWORK_NOTIFICATIONS`;
 - Used dedicated webhook URL for the network tests action: `BOREALIS_NETWORK_TESTS_SLACK_WEBHOOK_URL`;
 - Use a single step with conditional messages.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Slack notifications for daily Borealis Engine Lib network tests are now consolidated into a single step and sent only if enabled via an environment variable.
	- Notification messages include a standardized prefix and detailed job status with a workflow link.
	- When notifications are disabled, a message explains how to re-enable them.
	- Updated changelog with a fix for shell syntax in the GitHub action and added a related pull request reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->