### PR TITLE
chore: Bump nearcore to 2.7.0-rc.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.6-2.7.0-rc.2] 2025-07-01
+
+### Changes
+
+* chore: bump nearcore to 2.7.0-rc.2 in [#237]
+
+[#237]: https://github.com/aurora-is-near/borealis-engine-lib/pull/237
+
 ## [0.30.6-2.7.0-rc.1] 2025-06-30
 
 ### Changes
@@ -291,7 +299,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.6-2.7.0-rc.1...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.6-2.7.0-rc.2...main
+[0.30.6-2.7.0-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.6-2.7.0-rc.1...0.30.6-2.7.0-rc.2
 [0.30.6-2.7.0-rc.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.6-2.6.3...0.30.6-2.7.0-rc.1
 [0.30.6-2.6.3]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.5-2.6.3...0.30.6-2.6.3
 [0.30.5-2.6.3]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.3...0.30.5-2.6.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.6-2.7.0-rc.1"
+version = "0.30.6-2.7.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.6-2.7.0-rc.1"
+version = "0.30.6-2.7.0-rc.2"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.6-2.7.0-rc.1"
+version = "0.30.6-2.7.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.6-2.7.0-rc.1"
+version = "0.30.6-2.7.0-rc.2"
 dependencies = [
  "aurora-engine",
  "aurora-engine-transactions",
@@ -677,12 +677,12 @@ dependencies = [
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
  "near-crypto 0.30.1",
- "near-crypto 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-indexer",
  "near-lake-framework",
  "near-primitives 0.30.1",
- "near-primitives 2.7.0-rc.1",
- "reqwest 0.12.20",
+ "near-primitives 2.7.0-rc.2",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "sha3",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.6-2.7.0-rc.1"
+version = "0.30.6-2.7.0-rc.2"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455e9fb7743c6f6267eb2830ccc08686fbb3d13c9a689369562fd4d4ef9ea462"
+checksum = "c18d005c70d2b9c0c1ea8876c039db0ec7fb71164d25c73ccea21bf41fd02171"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.94.0"
+version = "1.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc24d9d761bd464534d9e477a9f724c118ca2557a95444097cf6ce71f3229a72"
+checksum = "a316e3c4c38837084dfbf87c0fc6ea016b3dc3e1f867d9d7f5eddfe47e5cae37"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.73.0"
+version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ac1674cba7872061a29baaf02209fefe499ff034dfd91bd4cc59e4d7741489"
+checksum = "e0a69de9c1b9272da2872af60c7402683e7f45c06267735b4332deacb203239b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.74.0"
+version = "1.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6a22f077f5fd3e3c0270d4e1a110346cddf6769e9433eb9e6daceb4ca3b149"
+checksum = "f0b161d836fac72bdd5ac1a4cd1cdc38ab888c7af26cfd95f661be4409505e63"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.75.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3258fa707f2f585ee3049d9550954b959002abd59176975150a01d5cf38ae3f"
+checksum = "cb1cd79a3412751a341a28e2cd0d6fa4345241976da427b075a0c0cd5409f886"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.3"
+version = "0.63.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f77a921dbd2c78ebe70726799787c1d110a2245dd65e39b20923dfdfb2deee"
+checksum = "244f00666380d35c1c76b90f7b88a11935d11b84076ac22a4c014ea0939627af"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -1071,15 +1071,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f491388e741b7ca73b24130ff464c1478acc34d5b331b7dd0a2ee4643595a15"
+checksum = "f108f1ca850f3feef3009bdcc977be201bca9a91058864d9de0684e64514bee0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.26",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -1837,8 +1837,20 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3115,9 +3127,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3351,7 +3363,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -3717,15 +3729,15 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
 dependencies = [
- "console",
- "number_prefix",
+ "console 0.16.0",
  "portable-atomic",
  "rayon",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -3735,7 +3747,7 @@ version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
- "console",
+ "console 0.15.11",
  "once_cell",
  "pest",
  "pest_derive",
@@ -4313,15 +4325,15 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "futures",
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.7.0-rc.1",
+ "near-time 2.7.0-rc.2",
  "parking_lot 0.12.4",
  "serde",
  "serde_json",
@@ -4332,8 +4344,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4342,8 +4354,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "lru 0.12.5",
  "parking_lot 0.12.4",
@@ -4351,8 +4363,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "anyhow",
@@ -4368,16 +4380,16 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.7.0-rc.1",
- "near-schema-checker-lib 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4398,19 +4410,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 2.0.1",
- "near-config-utils 2.7.0-rc.1",
- "near-crypto 2.7.0-rc.1",
+ "near-config-utils 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.2",
  "near-o11y",
- "near-parameters 2.7.0-rc.1",
- "near-primitives 2.7.0-rc.1",
- "near-time 2.7.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "num-rational 0.3.2",
  "parking_lot 0.12.4",
  "serde",
@@ -4423,20 +4435,20 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
- "near-crypto 2.7.0-rc.1",
- "near-primitives 2.7.0-rc.1",
- "near-time 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "itertools 0.12.1",
@@ -4445,14 +4457,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "near-store",
  "parking_lot 0.12.4",
  "rand 0.8.5",
@@ -4464,17 +4476,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4491,16 +4503,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4512,7 +4524,7 @@ dependencies = [
  "rayon",
  "reed-solomon-erasure",
  "regex",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "rust-s3",
  "serde",
  "serde_json",
@@ -4529,16 +4541,16 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.7.0-rc.1",
- "near-primitives 2.7.0-rc.1",
- "near-time 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "serde",
  "strum 0.24.1",
  "thiserror 2.0.12",
@@ -4559,8 +4571,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4596,8 +4608,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "blake2",
  "borsh 1.5.7",
@@ -4607,9 +4619,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.7.0-rc.1",
- "near-schema-checker-lib 2.7.0-rc.1",
- "near-stdx 2.7.0-rc.1",
+ "near-config-utils 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
+ "near-stdx 2.7.0-rc.2",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4621,14 +4633,14 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
  "near-chain-configs",
  "near-o11y",
- "near-primitives 2.7.0-rc.1",
- "near-time 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
@@ -4636,18 +4648,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "borsh 1.5.7",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-o11y",
- "near-primitives 2.7.0-rc.1",
- "near-schema-checker-lib 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4670,29 +4682,29 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
- "near-primitives-core 2.7.0-rc.1",
+ "near-primitives-core 2.7.0-rc.2",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.7.0-rc.1",
+ "near-config-utils 2.7.0-rc.2",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.7.0-rc.1",
+ "near-indexer-primitives 2.7.0-rc.2",
  "near-o11y",
- "near-parameters 2.7.0-rc.1",
- "near-primitives 2.7.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4715,17 +4727,17 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
- "near-primitives 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "serde",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -4739,7 +4751,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "serde",
  "serde_json",
  "tokio",
@@ -4748,29 +4760,29 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.7.0-rc.1",
- "near-primitives 2.7.0-rc.1",
- "near-schema-checker-lib 2.7.0-rc.1",
- "near-time 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4794,7 +4806,7 @@ dependencies = [
  "derive_builder",
  "futures",
  "near-indexer-primitives 0.30.1",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4805,19 +4817,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "anyhow",
@@ -4834,13 +4846,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.7.0-rc.1",
- "near-fmt 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-fmt 2.7.0-rc.2",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.7.0-rc.1",
- "near-schema-checker-lib 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.4",
@@ -4862,14 +4874,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.7.0-rc.1",
- "near-primitives-core 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-primitives-core 2.7.0-rc.2",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -4906,14 +4918,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "borsh 1.5.7",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.7.0-rc.1",
- "near-schema-checker-lib 2.7.0-rc.1",
+ "near-primitives-core 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -4924,8 +4936,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "futures",
@@ -4936,8 +4948,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "quote",
  "syn 2.0.104",
@@ -4945,13 +4957,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "borsh 1.5.7",
- "near-crypto 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-o11y",
- "near-primitives 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "rand 0.8.5",
 ]
 
@@ -4997,8 +5009,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5012,13 +5024,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.7.0-rc.1",
- "near-fmt 2.7.0-rc.1",
- "near-parameters 2.7.0-rc.1",
- "near-primitives-core 2.7.0-rc.1",
- "near-schema-checker-lib 2.7.0-rc.1",
- "near-stdx 2.7.0-rc.1",
- "near-time 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-fmt 2.7.0-rc.2",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives-core 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
+ "near-stdx 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5059,8 +5071,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5069,7 +5081,7 @@ dependencies = [
  "derive_more 2.0.1",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.7.0-rc.1",
+ "near-schema-checker-lib 2.7.0-rc.2",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5079,8 +5091,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5093,11 +5105,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.0-rc.1",
- "near-primitives 2.7.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5115,8 +5127,8 @@ checksum = "ed1fbfbc3c53b00aa893f8cb64abc5c12601edb8cecb878baf6f8f00e3184d3d"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5130,11 +5142,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
- "near-schema-checker-core 2.7.0-rc.1",
- "near-schema-checker-macro 2.7.0-rc.1",
+ "near-schema-checker-core 2.7.0-rc.2",
+ "near-schema-checker-macro 2.7.0-rc.2",
 ]
 
 [[package]]
@@ -5145,8 +5157,8 @@ checksum = "d191936f902770069255b16c95d1fb8edd6f3c3817c9228933a20ec8466737a3"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 
 [[package]]
 name = "near-stdx"
@@ -5156,13 +5168,13 @@ checksum = "f292226fd8f4c7c21cf6b1da1c17e9b484ebc1b9aeb4251d69336d28b7917ace"
 
 [[package]]
 name = "near-stdx"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 
 [[package]]
 name = "near-store"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5179,14 +5191,14 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.7.0-rc.1",
- "near-fmt 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-fmt 2.7.0-rc.2",
  "near-o11y",
- "near-parameters 2.7.0-rc.1",
- "near-primitives 2.7.0-rc.1",
- "near-schema-checker-lib 2.7.0-rc.1",
- "near-stdx 2.7.0-rc.1",
- "near-time 2.7.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
+ "near-stdx 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "near-vm-runner",
  "num_cpus",
  "parking_lot 0.12.4",
@@ -5208,8 +5220,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "awc",
@@ -5235,8 +5247,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "parking_lot 0.12.4",
  "serde",
@@ -5246,8 +5258,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5262,8 +5274,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -5281,8 +5293,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "backtrace",
  "finite-wasm",
@@ -5300,8 +5312,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
  "blst",
@@ -5312,12 +5324,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-o11y",
- "near-parameters 2.7.0-rc.1",
- "near-primitives-core 2.7.0-rc.1",
- "near-schema-checker-lib 2.7.0-rc.1",
- "near-stdx 2.7.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives-core 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
+ "near-stdx 2.7.0-rc.2",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5346,8 +5358,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "indexmap 2.10.0",
  "num-traits",
@@ -5357,8 +5369,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "backtrace",
  "cc",
@@ -5378,18 +5390,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.7.0-rc.1",
+ "near-primitives-core 2.7.0-rc.2",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5411,8 +5423,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.7.0-rc.1",
- "near-crypto 2.7.0-rc.1",
+ "near-config-utils 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.2",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5420,10 +5432,10 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.7.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5433,7 +5445,7 @@ dependencies = [
  "object_store",
  "parking_lot 0.12.4",
  "rand 0.8.5",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -5460,17 +5472,17 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "borsh 1.5.7",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.7.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-o11y",
- "near-parameters 2.7.0-rc.1",
- "near-primitives 2.7.0-rc.1",
- "near-primitives-core 2.7.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
+ "near-primitives-core 2.7.0-rc.2",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",
@@ -5638,12 +5650,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5676,7 +5682,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.9.1",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "ring",
  "rustls-pemfile 2.2.0",
  "serde",
@@ -6994,9 +7000,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7004,7 +7010,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -7441,6 +7447,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7618,16 +7636,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.10.0",
- "schemars",
+ "schemars 0.9.0",
+ "schemars 1.0.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7637,9 +7656,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8721,6 +8740,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.6-2.7.0-rc.1"
+version = "0.30.6-2.7.0-rc.2"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -39,9 +39,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.1" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.1" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.1" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
 near-crypto-crates-io = { version = "0.30.1", package = "near-crypto" }
 near-primitives-crates-io = { version = "0.30.1", package = "near-primitives" }
 near-lake-framework = "0.7"


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.7.0-rc.2). New package version: 0.30.6-2.7.0-rc.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version and dependency tags to the latest release candidate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->