### PR TITLE
fix: Added backward compatible StateChangeCauseView

### DIFF
--- a/engine/src/sync.rs
+++ b/engine/src/sync.rs
@@ -72,9 +72,9 @@ pub fn consume_near_block<M: ModExpAlgorithm>(
     let mut expected_diffs: HashMap<H256, Diff> = HashMap::new();
     for (_, key, expected_value, cause) in aurora_state_changes {
         let receipt_id: H256 = match cause {
-            near_primitives::views::StateChangeCauseView::ReceiptProcessing { receipt_hash } => {
-                receipt_hash.0.into()
-            }
+            aurora_refiner_types::near_block::StateChangeCauseView::ReceiptProcessing {
+                receipt_hash,
+            } => receipt_hash.0.into(),
             other => panic!("Unexpected state change cause {:?}", other),
         };
 

--- a/refiner-types/src/conversion/nearcore.rs
+++ b/refiner-types/src/conversion/nearcore.rs
@@ -35,7 +35,10 @@ pub fn convert(message: StreamerMessage) -> NEARBlock {
                             receipt: r.receipt.into(),
                         })
                         .collect(),
-                    state_changes: indexer_shard.state_changes,
+                    // Own impl for state changes for backward compatibility, caused by nearcore update from 2.6.3 to 2.7.0-rc.1
+                    state_changes: crate::near_block::convert_state_changes(
+                        indexer_shard.state_changes,
+                    ),
                 }
             })
             .collect(),


### PR DESCRIPTION
In this PR:

Two problematic enum variants were removed from `nearcore` in `2.7.0-rc.1` but still exist in older data:
- FlatStorageReshardingAlreadyInProgress from [StorageError](https://github.com/near/nearcore/blob/15314c2529053070e18c71862ccfe09346e52bd1/core/primitives/src/errors.rs#L146)
- ReshardingV2 from [StateChangeCauseView](https://github.com/near/nearcore/blob/15314c2529053070e18c71862ccfe09346e52bd1/core/primitives/src/views.rs#L2516)

This PR implements borealis-engine-lib own backward-compatible types that can handle both old and new data:
 - Custom StateChangeCauseView enum that retains the ReshardingV2 variant
 - Custom StateChangeWithCauseView and StateChangesView types
 - Updated Shard struct to use these custom types