### PR TITLE
Release 0.30.8-2.7.0-rc.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.8-2.7.0-rc.2] 2025-07-08
+
 ### Fixes
 
 * fix: receipt_execution_outcomes order by [@aleksuss] in [#240]
@@ -313,7 +315,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.7-2.7.0-rc.2...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.8-2.7.0-rc.2...main
+[0.30.8-2.7.0-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.7-2.7.0-rc.2...0.30.8-2.7.0-rc.2
 [0.30.7-2.7.0-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.6-2.7.0-rc.2...0.30.7-2.7.0-rc.2
 [0.30.6-2.7.0-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.6-2.7.0-rc.1...0.30.6-2.7.0-rc.2
 [0.30.6-2.7.0-rc.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.6-2.6.3...0.30.6-2.7.0-rc.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.7-2.7.0-rc.2"
+version = "0.30.8-2.7.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.7-2.7.0-rc.2"
+version = "0.30.8-2.7.0-rc.2"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.7-2.7.0-rc.2"
+version = "0.30.8-2.7.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.7-2.7.0-rc.2"
+version = "0.30.8-2.7.0-rc.2"
 dependencies = [
  "aurora-engine",
  "aurora-engine-transactions",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.7-2.7.0-rc.2"
+version = "0.30.8-2.7.0-rc.2"
 dependencies = [
  "anyhow",
  "aurora-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.7-2.7.0-rc.2"
+version = "0.30.8-2.7.0-rc.2"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"


### PR DESCRIPTION
Prepare release `0.30.8-2.7.0-rc.2`

Fixes:

* fix: `receipt_execution_outcomes` order by [@aleksuss] in [#240]

[#240]: https://github.com/aurora-is-near/borealis-engine-lib/pull/240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the changelog with a new release entry for version 0.30.8-2.7.0-rc.2 and refreshed GitHub comparison links.
  * Bumped the workspace package version to 0.30.8-2.7.0-rc.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->