### PR TITLE
release 0.30.8-2.6.5 mainnet 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.8-2.6.5] 2025-07-03
+
+### Fixes
+
+* fix: receipt_execution_outcomes order by [@aleksuss] in [#240]
+
+[#240]: https://github.com/aurora-is-near/borealis-engine-lib/pull/240
+
 ## [0.30.6-2.6.5] 2025-07-03
 
 ### Changes
@@ -291,7 +299,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.6-2.6.5...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.8-2.6.5...main
+[0.30.8-2.6.5]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.6-2.6.3...0.30.8-2.6.5
 [0.30.6-2.6.5]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.6-2.6.3...0.30.6-2.6.5
 [0.30.6-2.6.3]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.5-2.6.3...0.30.6-2.6.3
 [0.30.5-2.6.3]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.4-2.6.3...0.30.5-2.6.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.6-2.6.5"
+version = "0.30.8-2.6.5"
 dependencies = [
  "actix",
  "anyhow",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.6-2.6.5"
+version = "0.30.8-2.6.5"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.6-2.6.5"
+version = "0.30.8-2.6.5"
 dependencies = [
  "actix",
  "anyhow",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.6-2.6.5"
+version = "0.30.8-2.6.5"
 dependencies = [
  "aurora-engine",
  "aurora-engine-transactions",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.6-2.6.5"
+version = "0.30.8-2.6.5"
 dependencies = [
  "anyhow",
  "aurora-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.6-2.6.5"
+version = "0.30.8-2.6.5"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"


### PR DESCRIPTION
In this PR

Lists the changes for **mainnet** since the lates mainnet release **(0.30.6-2.6.5)**

```
6e6e7d3 fix: receipt_execution_outcomes order (#240)
```