### PR TITLE
chore: Bump nearcore to 2.7.0-rc.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.8-2.7.0-rc.3] 2025-07-22
+
+### Changes
+
+* chore: bump nearcore to 2.7.0-rc.3 in [#243]
+
+[#243]: https://github.com/aurora-is-near/borealis-engine-lib/pull/243
+
 ## [0.30.8-2.7.0-rc.2] 2025-07-08
 
 ### Fixes
@@ -315,7 +323,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.8-2.7.0-rc.2...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.8-2.7.0-rc.3...main
+[0.30.8-2.7.0-rc.3]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.8-2.7.0-rc.2...0.30.8-2.7.0-rc.3
 [0.30.8-2.7.0-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.7-2.7.0-rc.2...0.30.8-2.7.0-rc.2
 [0.30.7-2.7.0-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.6-2.7.0-rc.2...0.30.7-2.7.0-rc.2
 [0.30.6-2.7.0-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.6-2.7.0-rc.1...0.30.6-2.7.0-rc.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
  "flate2",
  "foldhash",
  "futures-core",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -89,7 +89,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.1",
+ "rand 0.9.2",
  "sha1",
  "smallvec",
  "tokio",
@@ -146,7 +146,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
 ]
@@ -229,7 +229,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.5.10",
  "time",
  "tracing",
  "url",
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "aurora-evm"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd2614a871c17c70b154d830a0a30d3869eb3843944e7dbf531a9e459181a7d"
+checksum = "e1a673e2e96fc6e8a487dd160bc9f49099a0b1f20332f5ee6049bff4172f48f3"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.8-2.7.0-rc.2"
+version = "0.30.8-2.7.0-rc.3"
 dependencies = [
  "actix",
  "anyhow",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.8-2.7.0-rc.2"
+version = "0.30.8-2.7.0-rc.3"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.8-2.7.0-rc.2"
+version = "0.30.8-2.7.0-rc.3"
 dependencies = [
  "actix",
  "anyhow",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.8-2.7.0-rc.2"
+version = "0.30.8-2.7.0-rc.3"
 dependencies = [
  "aurora-engine",
  "aurora-engine-transactions",
@@ -676,12 +676,12 @@ dependencies = [
  "derive_builder",
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
- "near-crypto 0.30.1",
- "near-crypto 2.7.0-rc.2",
+ "near-crypto 0.30.3",
+ "near-crypto 2.7.0-rc.3",
  "near-indexer",
  "near-lake-framework",
- "near-primitives 0.30.1",
- "near-primitives 2.7.0-rc.2",
+ "near-primitives 0.30.3",
+ "near-primitives 2.7.0-rc.3",
  "reqwest 0.12.22",
  "serde",
  "serde_json",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.8-2.7.0-rc.2"
+version = "0.30.8-2.7.0-rc.3"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -747,7 +747,7 @@ dependencies = [
  "derive_more 2.0.1",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "itoa",
  "log",
@@ -755,7 +755,7 @@ dependencies = [
  "openssl",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c18d005c70d2b9c0c1ea8876c039db0ec7fb71164d25c73ccea21bf41fd02171"
+checksum = "ebd9b83179adf8998576317ce47785948bcff399ec5b15f4dfbdedd44ddf5b92"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -794,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+checksum = "b68c2194a190e1efc999612792e25b1ab3abfefe4306494efaaabc25933c0cbe"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.1"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.8"
+version = "1.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6c68419d8ba16d9a7463671593c54f81ba58cab466e9b759418da606dcc2e2"
+checksum = "b2090e664216c78e766b6bac10fe74d2f451c02441d43484cd76ac9a295075f7"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.95.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a316e3c4c38837084dfbf87c0fc6ea016b3dc3e1f867d9d7f5eddfe47e5cae37"
+checksum = "029e89cae7e628553643aecb3a3f054a0a0912ff0fd1f5d6a0b4fda421dce64b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.74.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a69de9c1b9272da2872af60c7402683e7f45c06267735b4332deacb203239b"
+checksum = "64bf26698dd6d238ef1486bdda46f22a589dc813368ba868dc3d94c8d27b56ba"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.75.0"
+version = "1.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b161d836fac72bdd5ac1a4cd1cdc38ab888c7af26cfd95f661be4409505e63"
+checksum = "09cd07ed1edd939fae854a22054299ae3576500f4e0fadc560ca44f9c6ea1664"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.76.0"
+version = "1.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1cd79a3412751a341a28e2cd0d6fa4345241976da427b075a0c0cd5409f886"
+checksum = "37f7766d2344f56d10d12f3c32993da36d78217f32594fe4fb8e57a538c1cdea"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.4"
+version = "0.63.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244f00666380d35c1c76b90f7b88a11935d11b84076ac22a4c014ea0939627af"
+checksum = "5ab9472f7a8ec259ddb5681d2ef1cb1cf16c0411890063e67cdc7b62562cc496"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -1039,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.9"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338a3642c399c0a5d157648426110e199ca7fd1c689cc395676b81aa563700c4"
+checksum = "604c7aec361252b8f1c871a7641d5e0ba3a7f5a586e51b66bc9510a5519594d9"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
+checksum = "43c82ba4cab184ea61f6edaafc1072aad3c2a17dcf4c0fce19ac5694b90d8b5f"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -1078,7 +1078,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.26",
+ "h2 0.3.27",
  "h2 0.4.11",
  "http 0.2.12",
  "http 1.3.1",
@@ -1090,7 +1090,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
+checksum = "660f70d9d8af6876b4c9aa8dcb0dbaf0f89b04ee9a4455bea1b4ba03b15f26f6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1152,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.1"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8531b6d8882fd8f48f82a9754e682e29dd44cff27154af51fa3eb730f59efb"
+checksum = "38280ac228bc479f347fcfccf4bf4d22d68f3bb4629685cb591cabd856567bbc"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -1677,9 +1677,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -1766,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1776,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1788,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1837,20 +1837,8 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2081,15 +2069,15 @@ dependencies = [
  "crc",
  "digest 0.10.7",
  "libc",
- "rand 0.9.1",
+ "rand 0.9.2",
  "regex",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if 1.0.1",
 ]
@@ -2551,9 +2539,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -2667,18 +2655,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6b7c3d347de0a9f7bfd2f853be43fe32fa6fac30c70f6d6d67a1e936b87ee"
+checksum = "d6ee17054f550fd7400e1906e2f9356c7672643ed34008a9e8abe147ccd2d821"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da3ea9e1d1a3b1593e15781f930120e72aa7501610b2f82e5b6739c72e8eac5"
+checksum = "76d07902c93376f1e96c34abc4d507c0911df3816cef50b01f5a2ff3ad8c370d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3108,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -3340,14 +3328,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3399,7 +3387,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -3450,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3466,7 +3454,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -3729,15 +3717,15 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.12"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "console 0.16.0",
+ "console",
+ "number_prefix",
  "portable-atomic",
  "rayon",
  "unicode-width",
- "unit-prefix",
  "web-time",
 ]
 
@@ -3747,7 +3735,7 @@ version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
- "console 0.15.11",
+ "console",
  "once_cell",
  "pest",
  "pest_derive",
@@ -3762,6 +3750,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if 1.0.1",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if 1.0.1",
+ "libc",
 ]
 
 [[package]]
@@ -3937,9 +3936,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -4315,9 +4314,9 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "1.1.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed69d94899cfdfba16182bd681ad9e6b7f888e29532b04c56da9ae05a4c5bc4"
+checksum = "8542f031adc257a27ba46ad904c241a88470ee95130663a9e5c08cf8e124f4d4"
 dependencies = [
  "borsh 1.5.7",
  "serde",
@@ -4325,15 +4324,15 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "futures",
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.7.0-rc.2",
+ "near-time 2.7.0-rc.3",
  "parking_lot 0.12.4",
  "serde",
  "serde_json",
@@ -4344,8 +4343,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4354,8 +4353,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "lru 0.12.5",
  "parking_lot 0.12.4",
@@ -4363,8 +4362,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "anyhow",
@@ -4380,16 +4379,16 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.0-rc.2",
+ "near-parameters 2.7.0-rc.3",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.7.0-rc.2",
- "near-schema-checker-lib 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
+ "near-schema-checker-lib 2.7.0-rc.3",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4410,19 +4409,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 2.0.1",
- "near-config-utils 2.7.0-rc.2",
- "near-crypto 2.7.0-rc.2",
+ "near-config-utils 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.3",
  "near-o11y",
- "near-parameters 2.7.0-rc.2",
- "near-primitives 2.7.0-rc.2",
- "near-time 2.7.0-rc.2",
+ "near-parameters 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.3",
+ "near-time 2.7.0-rc.3",
  "num-rational 0.3.2",
  "parking_lot 0.12.4",
  "serde",
@@ -4435,20 +4434,20 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
- "near-crypto 2.7.0-rc.2",
- "near-primitives 2.7.0-rc.2",
- "near-time 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.3",
+ "near-time 2.7.0-rc.3",
  "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "itertools 0.12.1",
@@ -4457,14 +4456,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
  "near-store",
  "parking_lot 0.12.4",
  "rand 0.8.5",
@@ -4476,17 +4475,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4503,16 +4502,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.0-rc.2",
+ "near-parameters 2.7.0-rc.3",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4541,16 +4540,16 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.7.0-rc.2",
- "near-primitives 2.7.0-rc.2",
- "near-time 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.3",
+ "near-time 2.7.0-rc.3",
  "serde",
  "strum 0.24.1",
  "thiserror 2.0.12",
@@ -4559,9 +4558,9 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94d5cbc85fdf0bf4ce0836d22243ab156b8d9491de04128eb2e1a334f3f9aec"
+checksum = "fbb6045fa1f9503c61665af42d1534b04a854a6b4aeecb33fd53a5acaa4635b7"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4571,8 +4570,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4582,9 +4581,9 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8808d0d9674795fd6f5c78a4d50b80d297cedb79731525a8111c960aa110f9e"
+checksum = "7c635fb7ddbd807d92e1a8a3dc57d45e92faa15eaf2a8f0fbc977f6bc8fda6ce"
 dependencies = [
  "blake2",
  "borsh 1.5.7",
@@ -4594,9 +4593,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 0.30.1",
- "near-schema-checker-lib 0.30.1",
- "near-stdx 0.30.1",
+ "near-config-utils 0.30.3",
+ "near-schema-checker-lib 0.30.3",
+ "near-stdx 0.30.3",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4608,8 +4607,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "blake2",
  "borsh 1.5.7",
@@ -4619,9 +4618,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.7.0-rc.2",
- "near-schema-checker-lib 2.7.0-rc.2",
- "near-stdx 2.7.0-rc.2",
+ "near-config-utils 2.7.0-rc.3",
+ "near-schema-checker-lib 2.7.0-rc.3",
+ "near-stdx 2.7.0-rc.3",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4633,14 +4632,14 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "anyhow",
  "near-chain-configs",
  "near-o11y",
- "near-primitives 2.7.0-rc.2",
- "near-time 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
+ "near-time 2.7.0-rc.3",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
@@ -4648,18 +4647,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "borsh 1.5.7",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
  "near-o11y",
- "near-primitives 2.7.0-rc.2",
- "near-schema-checker-lib 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
+ "near-schema-checker-lib 2.7.0-rc.3",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4673,38 +4672,38 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c0e4d846b9c27b30e5f24e788fb8cc55c046f72e2048e2539dbcb04d9a71c4"
+checksum = "32d6b26918e71a60b56b0fe6604198d0b29df4e0b27dc944cad7af3e1ada6976"
 dependencies = [
- "near-primitives-core 0.30.1",
+ "near-primitives-core 0.30.3",
 ]
 
 [[package]]
 name = "near-fmt"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
- "near-primitives-core 2.7.0-rc.2",
+ "near-primitives-core 2.7.0-rc.3",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.7.0-rc.2",
+ "near-config-utils 2.7.0-rc.3",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.7.0-rc.2",
+ "near-indexer-primitives 2.7.0-rc.3",
  "near-o11y",
- "near-parameters 2.7.0-rc.2",
- "near-primitives 2.7.0-rc.2",
+ "near-parameters 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.3",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4716,28 +4715,28 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0610b44393dbbed33e3919de47d12fccc3379dd30ae0614a71c30d32531327a"
+checksum = "1d8b146466a55c36171928136ca7a0b4dc7dc651ac23253ac9148ecdef32178f"
 dependencies = [
- "near-primitives 0.30.1",
+ "near-primitives 0.30.3",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
- "near-primitives 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
  "serde",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -4751,7 +4750,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
  "serde",
  "serde_json",
  "tokio",
@@ -4760,29 +4759,29 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.7.0-rc.2",
- "near-primitives 2.7.0-rc.2",
- "near-schema-checker-lib 2.7.0-rc.2",
- "near-time 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.3",
+ "near-schema-checker-lib 2.7.0-rc.3",
+ "near-time 2.7.0-rc.3",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4805,7 +4804,7 @@ dependencies = [
  "aws-types",
  "derive_builder",
  "futures",
- "near-indexer-primitives 0.30.1",
+ "near-indexer-primitives 0.30.3",
  "reqwest 0.12.22",
  "serde",
  "serde_json",
@@ -4817,19 +4816,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "anyhow",
@@ -4846,13 +4845,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.7.0-rc.2",
- "near-fmt 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
+ "near-fmt 2.7.0-rc.3",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.7.0-rc.2",
- "near-schema-checker-lib 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
+ "near-schema-checker-lib 2.7.0-rc.3",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.4",
@@ -4874,14 +4873,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.7.0-rc.2",
- "near-primitives-core 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
+ "near-primitives-core 2.7.0-rc.3",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -4899,15 +4898,15 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dbb139bec6b7088d6afab0a3662725e5ee82d0ad725b67c1d45447c3d45fe55"
+checksum = "3e364f850512d7f1ee1eb398e1da85fd3ef95eb3cbce8db2d505eed054bbe848"
 dependencies = [
  "borsh 1.5.7",
  "enum-map",
  "near-account-id",
- "near-primitives-core 0.30.1",
- "near-schema-checker-lib 0.30.1",
+ "near-primitives-core 0.30.3",
+ "near-schema-checker-lib 0.30.3",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -4918,14 +4917,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "borsh 1.5.7",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.7.0-rc.2",
- "near-schema-checker-lib 2.7.0-rc.2",
+ "near-primitives-core 2.7.0-rc.3",
+ "near-schema-checker-lib 2.7.0-rc.3",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -4936,8 +4935,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "futures",
@@ -4948,8 +4947,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "quote",
  "syn 2.0.104",
@@ -4957,21 +4956,21 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "borsh 1.5.7",
- "near-crypto 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
  "near-o11y",
- "near-primitives 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "near-primitives"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f06d70f10eb505600ec6627f5fd64a1d1700af71098282e339c993e6319151d"
+checksum = "1ca734a17b2a973e4753658dd4370f6b35e106ff6c0f9620cbe5283988597833"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4986,13 +4985,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 0.30.1",
- "near-fmt 0.30.1",
- "near-parameters 0.30.1",
- "near-primitives-core 0.30.1",
- "near-schema-checker-lib 0.30.1",
- "near-stdx 0.30.1",
- "near-time 0.30.1",
+ "near-crypto 0.30.3",
+ "near-fmt 0.30.3",
+ "near-parameters 0.30.3",
+ "near-primitives-core 0.30.3",
+ "near-schema-checker-lib 0.30.3",
+ "near-stdx 0.30.3",
+ "near-time 0.30.3",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5009,8 +5008,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5024,13 +5023,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.7.0-rc.2",
- "near-fmt 2.7.0-rc.2",
- "near-parameters 2.7.0-rc.2",
- "near-primitives-core 2.7.0-rc.2",
- "near-schema-checker-lib 2.7.0-rc.2",
- "near-stdx 2.7.0-rc.2",
- "near-time 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
+ "near-fmt 2.7.0-rc.3",
+ "near-parameters 2.7.0-rc.3",
+ "near-primitives-core 2.7.0-rc.3",
+ "near-schema-checker-lib 2.7.0-rc.3",
+ "near-stdx 2.7.0-rc.3",
+ "near-time 2.7.0-rc.3",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5050,9 +5049,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "408abb7e360ae1353d5a3cde62b4a2f0abde96c9ff4045f23cabda15c22b6ec9"
+checksum = "953534fb0dff03f2042a12a933e31d86dd79601c2640338307bba724919e1876"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5061,7 +5060,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 0.30.1",
+ "near-schema-checker-lib 0.30.3",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5071,8 +5070,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5081,7 +5080,7 @@ dependencies = [
  "derive_more 2.0.1",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.3",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5091,8 +5090,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5105,11 +5104,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.0-rc.2",
- "near-primitives 2.7.0-rc.2",
+ "near-parameters 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.3",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5121,60 +5120,60 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1fbfbc3c53b00aa893f8cb64abc5c12601edb8cecb878baf6f8f00e3184d3d"
+checksum = "ecf3abb048646186aef4796d5bcda22c2c9246beaabaf3ea568c0cce2229257b"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f424ce08c8d715f529a8f8dcd246f574042f0ed0b393d0aaefdf3cc693d5a9f"
+checksum = "1416c5b236ea30152895df73213eca04c997c7bd60d83a1c18141f8705759865"
 dependencies = [
- "near-schema-checker-core 0.30.1",
- "near-schema-checker-macro 0.30.1",
+ "near-schema-checker-core 0.30.3",
+ "near-schema-checker-macro 0.30.3",
 ]
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
- "near-schema-checker-core 2.7.0-rc.2",
- "near-schema-checker-macro 2.7.0-rc.2",
+ "near-schema-checker-core 2.7.0-rc.3",
+ "near-schema-checker-macro 2.7.0-rc.3",
 ]
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d191936f902770069255b16c95d1fb8edd6f3c3817c9228933a20ec8466737a3"
+checksum = "a60d29f7f64c2fc6d2fd25139863a6887b4d7fbcc79db8caad9c72eca67f05e9"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 
 [[package]]
 name = "near-stdx"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f292226fd8f4c7c21cf6b1da1c17e9b484ebc1b9aeb4251d69336d28b7917ace"
+checksum = "13869f432b1b457c36c9332471d868da6b0ee971e2da0b94deb376aba8d27e6b"
 
 [[package]]
 name = "near-stdx"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 
 [[package]]
 name = "near-store"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5191,14 +5190,14 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.7.0-rc.2",
- "near-fmt 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
+ "near-fmt 2.7.0-rc.3",
  "near-o11y",
- "near-parameters 2.7.0-rc.2",
- "near-primitives 2.7.0-rc.2",
- "near-schema-checker-lib 2.7.0-rc.2",
- "near-stdx 2.7.0-rc.2",
- "near-time 2.7.0-rc.2",
+ "near-parameters 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.3",
+ "near-schema-checker-lib 2.7.0-rc.3",
+ "near-stdx 2.7.0-rc.3",
+ "near-time 2.7.0-rc.3",
  "near-vm-runner",
  "num_cpus",
  "parking_lot 0.12.4",
@@ -5220,8 +5219,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "awc",
@@ -5237,9 +5236,9 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806ae1785ed79e99e9183646e5fe18ecee504385350a45c600ee189d904808a9"
+checksum = "d1b143d7249e64ebfd1f6da7b1c15f4a9d0ee5d9be3556771a5b4b665a2c22cb"
 dependencies = [
  "serde",
  "time",
@@ -5247,8 +5246,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "parking_lot 0.12.4",
  "serde",
@@ -5258,8 +5257,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5274,8 +5273,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -5293,8 +5292,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "backtrace",
  "finite-wasm",
@@ -5305,15 +5304,15 @@ dependencies = [
  "parking_lot 0.12.4",
  "rkyv",
  "rustc-demangle",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "near-vm-runner"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "anyhow",
  "blst",
@@ -5324,12 +5323,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
  "near-o11y",
- "near-parameters 2.7.0-rc.2",
- "near-primitives-core 2.7.0-rc.2",
- "near-schema-checker-lib 2.7.0-rc.2",
- "near-stdx 2.7.0-rc.2",
+ "near-parameters 2.7.0-rc.3",
+ "near-primitives-core 2.7.0-rc.3",
+ "near-schema-checker-lib 2.7.0-rc.3",
+ "near-stdx 2.7.0-rc.3",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5342,7 +5341,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "ripemd",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "serde",
  "sha2 0.10.9",
  "sha3",
@@ -5358,8 +5357,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "indexmap 2.10.0",
  "num-traits",
@@ -5369,8 +5368,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "backtrace",
  "cc",
@@ -5390,18 +5389,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.7.0-rc.2",
+ "near-primitives-core 2.7.0-rc.3",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5423,8 +5422,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.7.0-rc.2",
- "near-crypto 2.7.0-rc.2",
+ "near-config-utils 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.3",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5432,10 +5431,10 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.0-rc.2",
+ "near-parameters 2.7.0-rc.3",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.3",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5472,17 +5471,17 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.7.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
+version = "2.7.0-rc.3"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
 dependencies = [
  "borsh 1.5.7",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.3",
  "near-o11y",
- "near-parameters 2.7.0-rc.2",
- "near-primitives 2.7.0-rc.2",
- "near-primitives-core 2.7.0-rc.2",
+ "near-parameters 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.3",
+ "near-primitives-core 2.7.0-rc.3",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",
@@ -5650,6 +5649,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5663,9 +5668,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781f96d79ed0f961a7021424ab01840efbda64ae7a505aaea195efc91eaaec4"
+checksum = "efc4f07659e11cd45a341cd24d71e683e3be65d9ff1f8150061678fe60437496"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5681,7 +5686,7 @@ dependencies = [
  "parking_lot 0.12.4",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reqwest 0.12.22",
  "ring",
  "rustls-pemfile 2.2.0",
@@ -6040,7 +6045,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if 1.0.1",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.15",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -6255,7 +6260,7 @@ dependencies = [
  "hmac 0.12.1",
  "md-5",
  "memchr",
- "rand 0.9.1",
+ "rand 0.9.2",
  "sha2 0.10.9",
  "stringprep",
 ]
@@ -6568,9 +6573,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
 dependencies = [
  "memchr",
  "serde",
@@ -6588,8 +6593,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.28",
- "socket2",
+ "rustls 0.23.29",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -6605,10 +6610,10 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -6626,7 +6631,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -6694,9 +6699,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -6818,9 +6823,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -6967,7 +6972,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -7025,7 +7030,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
@@ -7250,15 +7255,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7275,15 +7280,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -7352,9 +7357,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7448,9 +7453,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -7500,9 +7505,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
 dependencies = [
  "cc",
 ]
@@ -7592,9 +7597,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -7646,7 +7651,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.10.0",
  "schemars 0.9.0",
- "schemars 1.0.3",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7837,6 +7842,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8260,27 +8275,29 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-io-timeout"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
 dependencies = [
  "pin-project-lite",
  "tokio",
@@ -8337,8 +8354,8 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.1",
- "socket2",
+ "rand 0.9.2",
+ "socket2 0.5.10",
  "tokio",
  "tokio-util",
  "whoami",
@@ -8360,7 +8377,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "tokio",
 ]
 
@@ -8449,7 +8466,7 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -8740,12 +8757,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unit-prefix"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -9315,7 +9326,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.15",
  "wasite",
  "web-sys",
 ]
@@ -9650,9 +9661,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -9693,9 +9704,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.8-2.7.0-rc.2"
+version = "0.30.8-2.7.0-rc.3"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -39,9 +39,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.3" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.3" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.3" }
 near-crypto-crates-io = { version = "0.30.1", package = "near-crypto" }
 near-primitives-crates-io = { version = "0.30.1", package = "near-primitives" }
 near-lake-framework = "0.7"


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.7.0-rc.3). New package version: 0.30.8-2.7.0-rc.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version and dependency tags to the latest release candidate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->