### PR TITLE
chore: Bump nearcore to 2.7.0-rc.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.8-2.7.0-rc.4] 2025-07-31
+
+### Changes
+
+* chore: bump nearcore to 2.7.0-rc.4 in [#244]
+
+[#244]: https://github.com/aurora-is-near/borealis-engine-lib/pull/244
+
 ## [0.30.8-2.7.0-rc.3] 2025-07-22
 
 ### Changes
@@ -323,7 +331,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.8-2.7.0-rc.3...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.30.8-2.7.0-rc.4...main
+[0.30.8-2.7.0-rc.4]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.8-2.7.0-rc.3...0.30.8-2.7.0-rc.4
 [0.30.8-2.7.0-rc.3]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.8-2.7.0-rc.2...0.30.8-2.7.0-rc.3
 [0.30.8-2.7.0-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.7-2.7.0-rc.2...0.30.8-2.7.0-rc.2
 [0.30.7-2.7.0-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.30.6-2.7.0-rc.2...0.30.7-2.7.0-rc.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.8-2.7.0-rc.3"
+version = "0.30.8-2.7.0-rc.4"
 dependencies = [
  "actix",
  "anyhow",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.8-2.7.0-rc.3"
+version = "0.30.8-2.7.0-rc.4"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.8-2.7.0-rc.3"
+version = "0.30.8-2.7.0-rc.4"
 dependencies = [
  "actix",
  "anyhow",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.8-2.7.0-rc.3"
+version = "0.30.8-2.7.0-rc.4"
 dependencies = [
  "aurora-engine",
  "aurora-engine-transactions",
@@ -677,11 +677,11 @@ dependencies = [
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
  "near-crypto 0.30.3",
- "near-crypto 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
  "near-indexer",
  "near-lake-framework",
  "near-primitives 0.30.3",
- "near-primitives 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
  "reqwest 0.12.22",
  "serde",
  "serde_json",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.8-2.7.0-rc.3"
+version = "0.30.8-2.7.0-rc.4"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd9b83179adf8998576317ce47785948bcff399ec5b15f4dfbdedd44ddf5b92"
+checksum = "c0baa720ebadea158c5bda642ac444a2af0cdf7bb66b46d1e4533de5d1f449d0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.98.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029e89cae7e628553643aecb3a3f054a0a0912ff0fd1f5d6a0b4fda421dce64b"
+checksum = "8c5eafbdcd898114b839ba68ac628e31c4cfc3e11dfca38dc1b2de2f35bb6270"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.76.0"
+version = "1.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bf26698dd6d238ef1486bdda46f22a589dc813368ba868dc3d94c8d27b56ba"
+checksum = "dbd7bc4bd34303733bded362c4c997a39130eac4310257c79aae8484b1c4b724"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.77.0"
+version = "1.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cd07ed1edd939fae854a22054299ae3576500f4e0fadc560ca44f9c6ea1664"
+checksum = "77358d25f781bb106c1a69531231d4fd12c6be904edb0c47198c604df5a2dbca"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.78.0"
+version = "1.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f7766d2344f56d10d12f3c32993da36d78217f32594fe4fb8e57a538c1cdea"
+checksum = "06e3ed2a9b828ae7763ddaed41d51724d2661a50c45f845b08967e52f4939cfc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1090,7 +1090,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -1152,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38280ac228bc479f347fcfccf4bf4d22d68f3bb4629685cb591cabd856567bbc"
+checksum = "937a49ecf061895fca4a6dd8e864208ed9be7546c0527d04bc07d502ec5fba1c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -1204,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
+checksum = "b069d19bf01e46298eaedd7c6f283fe565a59263e53eebec945f3e6398f42390"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1766,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1776,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2479,9 +2479,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynasm"
@@ -3387,7 +3387,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -3925,7 +3925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.1",
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -3936,9 +3936,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -4277,18 +4277,18 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "munge"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cce144fab80fbb74ec5b89d1ca9d41ddf6b644ab7e986f7d3ed0aab31625cb1"
+checksum = "d7feb0b48aa0a25f9fe0899482c6e1379ee7a11b24a53073eacdecb9adb6dc60"
 dependencies = [
  "munge_macro",
 ]
 
 [[package]]
 name = "munge_macro"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574af9cd5b9971cbfdf535d6a8d533778481b241c447826d976101e0149392a1"
+checksum = "f2e3795a5d2da581a8b252fec6022eee01aea10161a4d1bf237d4cbe47f7e988"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4324,15 +4324,15 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "futures",
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.7.0-rc.3",
+ "near-time 2.7.0-rc.4",
  "parking_lot 0.12.4",
  "serde",
  "serde_json",
@@ -4343,8 +4343,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4353,8 +4353,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "lru 0.12.5",
  "parking_lot 0.12.4",
@@ -4362,8 +4362,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "anyhow",
@@ -4379,16 +4379,16 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.0-rc.3",
+ "near-parameters 2.7.0-rc.4",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.7.0-rc.3",
- "near-schema-checker-lib 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
+ "near-schema-checker-lib 2.7.0-rc.4",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4409,19 +4409,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 2.0.1",
- "near-config-utils 2.7.0-rc.3",
- "near-crypto 2.7.0-rc.3",
+ "near-config-utils 2.7.0-rc.4",
+ "near-crypto 2.7.0-rc.4",
  "near-o11y",
- "near-parameters 2.7.0-rc.3",
- "near-primitives 2.7.0-rc.3",
- "near-time 2.7.0-rc.3",
+ "near-parameters 2.7.0-rc.4",
+ "near-primitives 2.7.0-rc.4",
+ "near-time 2.7.0-rc.4",
  "num-rational 0.3.2",
  "parking_lot 0.12.4",
  "serde",
@@ -4434,20 +4434,20 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
- "near-crypto 2.7.0-rc.3",
- "near-primitives 2.7.0-rc.3",
- "near-time 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
+ "near-primitives 2.7.0-rc.4",
+ "near-time 2.7.0-rc.4",
  "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "itertools 0.12.1",
@@ -4456,14 +4456,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
  "near-store",
  "parking_lot 0.12.4",
  "rand 0.8.5",
@@ -4475,17 +4475,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4502,16 +4502,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.0-rc.3",
+ "near-parameters 2.7.0-rc.4",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4540,16 +4540,16 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.7.0-rc.3",
- "near-primitives 2.7.0-rc.3",
- "near-time 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
+ "near-primitives 2.7.0-rc.4",
+ "near-time 2.7.0-rc.4",
  "serde",
  "strum 0.24.1",
  "thiserror 2.0.12",
@@ -4570,8 +4570,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4607,8 +4607,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "blake2",
  "borsh 1.5.7",
@@ -4618,9 +4618,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.7.0-rc.3",
- "near-schema-checker-lib 2.7.0-rc.3",
- "near-stdx 2.7.0-rc.3",
+ "near-config-utils 2.7.0-rc.4",
+ "near-schema-checker-lib 2.7.0-rc.4",
+ "near-stdx 2.7.0-rc.4",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4632,14 +4632,14 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "anyhow",
  "near-chain-configs",
  "near-o11y",
- "near-primitives 2.7.0-rc.3",
- "near-time 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
+ "near-time 2.7.0-rc.4",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
@@ -4647,18 +4647,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "borsh 1.5.7",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
  "near-o11y",
- "near-primitives 2.7.0-rc.3",
- "near-schema-checker-lib 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
+ "near-schema-checker-lib 2.7.0-rc.4",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4681,29 +4681,29 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
- "near-primitives-core 2.7.0-rc.3",
+ "near-primitives-core 2.7.0-rc.4",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.7.0-rc.3",
+ "near-config-utils 2.7.0-rc.4",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.7.0-rc.3",
+ "near-indexer-primitives 2.7.0-rc.4",
  "near-o11y",
- "near-parameters 2.7.0-rc.3",
- "near-primitives 2.7.0-rc.3",
+ "near-parameters 2.7.0-rc.4",
+ "near-primitives 2.7.0-rc.4",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4726,17 +4726,17 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
- "near-primitives 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
  "serde",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -4750,7 +4750,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
  "serde",
  "serde_json",
  "tokio",
@@ -4759,29 +4759,29 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.7.0-rc.3",
- "near-primitives 2.7.0-rc.3",
- "near-schema-checker-lib 2.7.0-rc.3",
- "near-time 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
+ "near-primitives 2.7.0-rc.4",
+ "near-schema-checker-lib 2.7.0-rc.4",
+ "near-time 2.7.0-rc.4",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4816,19 +4816,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "anyhow",
@@ -4845,13 +4845,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.7.0-rc.3",
- "near-fmt 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
+ "near-fmt 2.7.0-rc.4",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.7.0-rc.3",
- "near-schema-checker-lib 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
+ "near-schema-checker-lib 2.7.0-rc.4",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.4",
@@ -4873,14 +4873,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.7.0-rc.3",
- "near-primitives-core 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
+ "near-primitives-core 2.7.0-rc.4",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -4917,14 +4917,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "borsh 1.5.7",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.7.0-rc.3",
- "near-schema-checker-lib 2.7.0-rc.3",
+ "near-primitives-core 2.7.0-rc.4",
+ "near-schema-checker-lib 2.7.0-rc.4",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -4935,8 +4935,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "futures",
@@ -4947,8 +4947,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "quote",
  "syn 2.0.104",
@@ -4956,13 +4956,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "borsh 1.5.7",
- "near-crypto 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
  "near-o11y",
- "near-primitives 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
  "rand 0.8.5",
 ]
 
@@ -5008,8 +5008,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5023,13 +5023,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.7.0-rc.3",
- "near-fmt 2.7.0-rc.3",
- "near-parameters 2.7.0-rc.3",
- "near-primitives-core 2.7.0-rc.3",
- "near-schema-checker-lib 2.7.0-rc.3",
- "near-stdx 2.7.0-rc.3",
- "near-time 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
+ "near-fmt 2.7.0-rc.4",
+ "near-parameters 2.7.0-rc.4",
+ "near-primitives-core 2.7.0-rc.4",
+ "near-schema-checker-lib 2.7.0-rc.4",
+ "near-stdx 2.7.0-rc.4",
+ "near-time 2.7.0-rc.4",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5070,8 +5070,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5080,7 +5080,7 @@ dependencies = [
  "derive_more 2.0.1",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.7.0-rc.3",
+ "near-schema-checker-lib 2.7.0-rc.4",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5090,8 +5090,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5104,11 +5104,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.0-rc.3",
- "near-primitives 2.7.0-rc.3",
+ "near-parameters 2.7.0-rc.4",
+ "near-primitives 2.7.0-rc.4",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5126,8 +5126,8 @@ checksum = "ecf3abb048646186aef4796d5bcda22c2c9246beaabaf3ea568c0cce2229257b"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5141,11 +5141,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
- "near-schema-checker-core 2.7.0-rc.3",
- "near-schema-checker-macro 2.7.0-rc.3",
+ "near-schema-checker-core 2.7.0-rc.4",
+ "near-schema-checker-macro 2.7.0-rc.4",
 ]
 
 [[package]]
@@ -5156,8 +5156,8 @@ checksum = "a60d29f7f64c2fc6d2fd25139863a6887b4d7fbcc79db8caad9c72eca67f05e9"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 
 [[package]]
 name = "near-stdx"
@@ -5167,13 +5167,13 @@ checksum = "13869f432b1b457c36c9332471d868da6b0ee971e2da0b94deb376aba8d27e6b"
 
 [[package]]
 name = "near-stdx"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 
 [[package]]
 name = "near-store"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5190,14 +5190,14 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.7.0-rc.3",
- "near-fmt 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
+ "near-fmt 2.7.0-rc.4",
  "near-o11y",
- "near-parameters 2.7.0-rc.3",
- "near-primitives 2.7.0-rc.3",
- "near-schema-checker-lib 2.7.0-rc.3",
- "near-stdx 2.7.0-rc.3",
- "near-time 2.7.0-rc.3",
+ "near-parameters 2.7.0-rc.4",
+ "near-primitives 2.7.0-rc.4",
+ "near-schema-checker-lib 2.7.0-rc.4",
+ "near-stdx 2.7.0-rc.4",
+ "near-time 2.7.0-rc.4",
  "near-vm-runner",
  "num_cpus",
  "parking_lot 0.12.4",
@@ -5219,8 +5219,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "awc",
@@ -5246,8 +5246,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "parking_lot 0.12.4",
  "serde",
@@ -5257,8 +5257,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5273,8 +5273,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -5292,8 +5292,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "backtrace",
  "finite-wasm",
@@ -5311,8 +5311,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "anyhow",
  "blst",
@@ -5323,12 +5323,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
  "near-o11y",
- "near-parameters 2.7.0-rc.3",
- "near-primitives-core 2.7.0-rc.3",
- "near-schema-checker-lib 2.7.0-rc.3",
- "near-stdx 2.7.0-rc.3",
+ "near-parameters 2.7.0-rc.4",
+ "near-primitives-core 2.7.0-rc.4",
+ "near-schema-checker-lib 2.7.0-rc.4",
+ "near-stdx 2.7.0-rc.4",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5357,8 +5357,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "indexmap 2.10.0",
  "num-traits",
@@ -5368,8 +5368,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "backtrace",
  "cc",
@@ -5389,18 +5389,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.7.0-rc.3",
+ "near-primitives-core 2.7.0-rc.4",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5422,8 +5422,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.7.0-rc.3",
- "near-crypto 2.7.0-rc.3",
+ "near-config-utils 2.7.0-rc.4",
+ "near-crypto 2.7.0-rc.4",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5431,10 +5431,10 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.0-rc.3",
+ "near-parameters 2.7.0-rc.4",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.7.0-rc.3",
+ "near-primitives 2.7.0-rc.4",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5471,17 +5471,17 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.7.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.3#a88c87700a5adf12da7e5df2ae85eba7912dc636"
+version = "2.7.0-rc.4"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.4#b7b72efa10273cf7c37961f0825ad7be0216df38"
 dependencies = [
  "borsh 1.5.7",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.7.0-rc.3",
+ "near-crypto 2.7.0-rc.4",
  "near-o11y",
- "near-parameters 2.7.0-rc.3",
- "near-primitives 2.7.0-rc.3",
- "near-primitives-core 2.7.0-rc.3",
+ "near-parameters 2.7.0-rc.4",
+ "near-primitives 2.7.0-rc.4",
+ "near-primitives-core 2.7.0-rc.4",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",
@@ -6045,7 +6045,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if 1.0.1",
  "libc",
- "redox_syscall 0.5.15",
+ "redox_syscall 0.5.17",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -6223,9 +6223,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "postcard"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1de96e20f51df24ca73cafcc4690e044854d803259db27a00a461cb3b9d17a"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -6308,9 +6308,9 @@ checksum = "aa06bd51638b6e76ac9ba9b6afb4164fa647bd2916d722f2623fbb6d1ed8bdba"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
  "syn 2.0.104",
@@ -6593,7 +6593,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
@@ -6613,7 +6613,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -6823,9 +6823,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.15"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -7030,7 +7030,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
@@ -7087,9 +7087,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
+checksum = "19f5c3e5da784cd8c69d32cdc84673f3204536ca56e1fa01be31a74b92c932ac"
 dependencies = [
  "bytecheck",
  "bytes",
@@ -7106,9 +7106,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
+checksum = "4270433626cffc9c4c1d3707dd681f2a2718d3d7b09ad754bec137acecda8d22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7209,9 +7209,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -7280,9 +7280,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -8275,9 +8275,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8288,9 +8288,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8377,7 +8377,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "tokio",
 ]
 
@@ -9326,7 +9326,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
- "redox_syscall 0.5.15",
+ "redox_syscall 0.5.17",
  "wasite",
  "web-sys",
 ]
@@ -9471,7 +9471,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -9507,10 +9507,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.8-2.7.0-rc.3"
+version = "0.30.8-2.7.0-rc.4"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -39,9 +39,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.3" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.3" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.3" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.4" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.4" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.4" }
 near-crypto-crates-io = { version = "0.30.1", package = "near-crypto" }
 near-primitives-crates-io = { version = "0.30.1", package = "near-primitives" }
 near-lake-framework = "0.7"


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.7.0-rc.4). New package version: 0.30.8-2.7.0-rc.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package and dependency versions to the latest release candidate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->