### PR TITLE
chore: Bump nearcore to 2.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.30.9-2.7.1-rc.1"
+version = "0.30.9-2.7.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.30.9-2.7.1-rc.1"
+version = "0.30.9-2.7.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.30.9-2.7.1-rc.1"
+version = "0.30.9-2.7.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.30.9-2.7.1-rc.1"
+version = "0.30.9-2.7.1"
 dependencies = [
  "aurora-engine",
  "aurora-engine-transactions",
@@ -676,12 +676,12 @@ dependencies = [
  "derive_builder",
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
- "near-crypto 0.31.0",
- "near-crypto 2.7.1-rc.1",
+ "near-crypto 0.31.1",
+ "near-crypto 2.7.1",
  "near-indexer",
  "near-lake-framework",
  "near-primitives 0.31.0",
- "near-primitives 2.7.1-rc.1",
+ "near-primitives 2.7.1",
  "reqwest 0.12.23",
  "serde",
  "serde_json",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.30.9-2.7.1-rc.1"
+version = "0.30.9-2.7.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -4362,15 +4362,15 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "futures",
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.7.1-rc.1",
+ "near-time 2.7.1",
  "parking_lot 0.12.4",
  "serde",
  "serde_json",
@@ -4381,8 +4381,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4391,8 +4391,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "lru 0.12.5",
  "parking_lot 0.12.4",
@@ -4400,8 +4400,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "anyhow",
@@ -4417,16 +4417,16 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.7.1-rc.1",
+ "near-crypto 2.7.1",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.1-rc.1",
+ "near-parameters 2.7.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.7.1-rc.1",
- "near-schema-checker-lib 2.7.1-rc.1",
+ "near-primitives 2.7.1",
+ "near-schema-checker-lib 2.7.1",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4447,19 +4447,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 2.0.1",
- "near-config-utils 2.7.1-rc.1",
- "near-crypto 2.7.1-rc.1",
+ "near-config-utils 2.7.1",
+ "near-crypto 2.7.1",
  "near-o11y",
- "near-parameters 2.7.1-rc.1",
- "near-primitives 2.7.1-rc.1",
- "near-time 2.7.1-rc.1",
+ "near-parameters 2.7.1",
+ "near-primitives 2.7.1",
+ "near-time 2.7.1",
  "num-rational 0.3.2",
  "parking_lot 0.12.4",
  "serde",
@@ -4472,20 +4472,20 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
- "near-crypto 2.7.1-rc.1",
- "near-primitives 2.7.1-rc.1",
- "near-time 2.7.1-rc.1",
+ "near-crypto 2.7.1",
+ "near-primitives 2.7.1",
+ "near-time 2.7.1",
  "thiserror 2.0.16",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "itertools 0.12.1",
@@ -4494,14 +4494,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.7.1-rc.1",
+ "near-crypto 2.7.1",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.7.1-rc.1",
+ "near-primitives 2.7.1",
  "near-store",
  "parking_lot 0.12.4",
  "rand 0.8.5",
@@ -4513,17 +4513,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.7.1-rc.1",
+ "near-primitives 2.7.1",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4540,16 +4540,16 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.7.1-rc.1",
+ "near-crypto 2.7.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.1-rc.1",
+ "near-parameters 2.7.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.7.1-rc.1",
+ "near-primitives 2.7.1",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4578,16 +4578,16 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.7.1-rc.1",
- "near-primitives 2.7.1-rc.1",
- "near-time 2.7.1-rc.1",
+ "near-crypto 2.7.1",
+ "near-primitives 2.7.1",
+ "near-time 2.7.1",
  "serde",
  "strum 0.24.1",
  "thiserror 2.0.16",
@@ -4596,9 +4596,9 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae195b6ee1532570e4585cff42d8845c934ce3c5202cab96881815075ec3e771"
+checksum = "4627060004177ea30e122644de51aaf2ea076fd1b6d22f6f3d19e7dfb86af949"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4608,8 +4608,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4619,9 +4619,9 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a7f44272c24d7888bb86f9da762a94cc0943032b4d5bec27f48925edf99a2b"
+checksum = "40596a621b4cbf7c07189dac59ebf1239f8108ef4755620622db5b86743e0c3a"
 dependencies = [
  "blake2",
  "borsh 1.5.7",
@@ -4631,9 +4631,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 0.31.0",
- "near-schema-checker-lib 0.31.0",
- "near-stdx 0.31.0",
+ "near-config-utils 0.31.1",
+ "near-schema-checker-lib 0.31.1",
+ "near-stdx 0.31.1",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4645,8 +4645,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "blake2",
  "borsh 1.5.7",
@@ -4656,9 +4656,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.7.1-rc.1",
- "near-schema-checker-lib 2.7.1-rc.1",
- "near-stdx 2.7.1-rc.1",
+ "near-config-utils 2.7.1",
+ "near-schema-checker-lib 2.7.1",
+ "near-stdx 2.7.1",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4670,14 +4670,14 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "anyhow",
  "near-chain-configs",
  "near-o11y",
- "near-primitives 2.7.1-rc.1",
- "near-time 2.7.1-rc.1",
+ "near-primitives 2.7.1",
+ "near-time 2.7.1",
  "serde_json",
  "thiserror 2.0.16",
  "tokio",
@@ -4685,18 +4685,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "borsh 1.5.7",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.7.1-rc.1",
+ "near-crypto 2.7.1",
  "near-o11y",
- "near-primitives 2.7.1-rc.1",
- "near-schema-checker-lib 2.7.1-rc.1",
+ "near-primitives 2.7.1",
+ "near-schema-checker-lib 2.7.1",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4710,38 +4710,38 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be2506d8e2713191d98d298780a04a1ac0254900fbed94ef2f25cf63746c557"
+checksum = "96e9fa3af54e4b13f4f0657e3ae640e63f7f8953a5fbedf836bc47b43f973dde"
 dependencies = [
- "near-primitives-core 0.31.0",
+ "near-primitives-core 0.31.1",
 ]
 
 [[package]]
 name = "near-fmt"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
- "near-primitives-core 2.7.1-rc.1",
+ "near-primitives-core 2.7.1",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.7.1-rc.1",
+ "near-config-utils 2.7.1",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.7.1-rc.1",
+ "near-indexer-primitives 2.7.1",
  "near-o11y",
- "near-parameters 2.7.1-rc.1",
- "near-primitives 2.7.1-rc.1",
+ "near-parameters 2.7.1",
+ "near-primitives 2.7.1",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4763,17 +4763,17 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
- "near-primitives 2.7.1-rc.1",
+ "near-primitives 2.7.1",
  "serde",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -4787,7 +4787,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.7.1-rc.1",
+ "near-primitives 2.7.1",
  "serde",
  "serde_json",
  "tokio",
@@ -4796,29 +4796,29 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.7.1-rc.1",
+ "near-primitives 2.7.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.7.1-rc.1",
- "near-primitives 2.7.1-rc.1",
- "near-schema-checker-lib 2.7.1-rc.1",
- "near-time 2.7.1-rc.1",
+ "near-crypto 2.7.1",
+ "near-primitives 2.7.1",
+ "near-schema-checker-lib 2.7.1",
+ "near-time 2.7.1",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -4853,19 +4853,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.7.1-rc.1",
+ "near-primitives 2.7.1",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "anyhow",
@@ -4882,13 +4882,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.7.1-rc.1",
- "near-fmt 2.7.1-rc.1",
+ "near-crypto 2.7.1",
+ "near-fmt 2.7.1",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.7.1-rc.1",
- "near-schema-checker-lib 2.7.1-rc.1",
+ "near-primitives 2.7.1",
+ "near-schema-checker-lib 2.7.1",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.4",
@@ -4910,14 +4910,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.7.1-rc.1",
- "near-primitives-core 2.7.1-rc.1",
+ "near-crypto 2.7.1",
+ "near-primitives-core 2.7.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -4935,15 +4935,15 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd94f06e70d5a74edad686a07aeb067e495c45474038d9a8fbd3383679ecbcf"
+checksum = "a261341fca84a5322710f6f4eae45d809fce24a19b9913333e436da5d4de3574"
 dependencies = [
  "borsh 1.5.7",
  "enum-map",
  "near-account-id",
- "near-primitives-core 0.31.0",
- "near-schema-checker-lib 0.31.0",
+ "near-primitives-core 0.31.1",
+ "near-schema-checker-lib 0.31.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -4954,14 +4954,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "borsh 1.5.7",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.7.1-rc.1",
- "near-schema-checker-lib 2.7.1-rc.1",
+ "near-primitives-core 2.7.1",
+ "near-schema-checker-lib 2.7.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -4972,8 +4972,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "futures",
@@ -4984,8 +4984,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -4993,13 +4993,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "borsh 1.5.7",
- "near-crypto 2.7.1-rc.1",
+ "near-crypto 2.7.1",
  "near-o11y",
- "near-primitives 2.7.1-rc.1",
+ "near-primitives 2.7.1",
  "rand 0.8.5",
 ]
 
@@ -5021,13 +5021,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 0.31.0",
- "near-fmt 0.31.0",
- "near-parameters 0.31.0",
- "near-primitives-core 0.31.0",
- "near-schema-checker-lib 0.31.0",
- "near-stdx 0.31.0",
- "near-time 0.31.0",
+ "near-crypto 0.31.1",
+ "near-fmt 0.31.1",
+ "near-parameters 0.31.1",
+ "near-primitives-core 0.31.1",
+ "near-schema-checker-lib 0.31.1",
+ "near-stdx 0.31.1",
+ "near-time 0.31.1",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5044,8 +5044,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5059,13 +5059,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.7.1-rc.1",
- "near-fmt 2.7.1-rc.1",
- "near-parameters 2.7.1-rc.1",
- "near-primitives-core 2.7.1-rc.1",
- "near-schema-checker-lib 2.7.1-rc.1",
- "near-stdx 2.7.1-rc.1",
- "near-time 2.7.1-rc.1",
+ "near-crypto 2.7.1",
+ "near-fmt 2.7.1",
+ "near-parameters 2.7.1",
+ "near-primitives-core 2.7.1",
+ "near-schema-checker-lib 2.7.1",
+ "near-stdx 2.7.1",
+ "near-time 2.7.1",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5085,9 +5085,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8101fac92195b62b77d4a6df7c551c2ab0de45784ba9bc7c2455f6e4358333"
+checksum = "621c20e3fd77ba5e1d4fd33f6b7383dadcaca3faf60e2a8fc71a6cc7e4463c31"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5096,7 +5096,7 @@ dependencies = [
  "derive_more 2.0.1",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 0.31.0",
+ "near-schema-checker-lib 0.31.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5106,8 +5106,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5116,7 +5116,7 @@ dependencies = [
  "derive_more 2.0.1",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.7.1-rc.1",
+ "near-schema-checker-lib 2.7.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5126,8 +5126,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5140,11 +5140,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.7.1-rc.1",
+ "near-crypto 2.7.1",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.1-rc.1",
- "near-primitives 2.7.1-rc.1",
+ "near-parameters 2.7.1",
+ "near-primitives 2.7.1",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5156,60 +5156,60 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de58c48bae58a18f9aecb76af01fb3c95593ba78fee8c6a3f31ab7ef3dc05f90"
+checksum = "3515d1bd55d87bfb392f6889313dcfbcaaec4229bb4a4abb5640ab8dc5eda70c"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d1ea0f3f069646e0b08c4f3c441f5d09245de67bfb460509de6133933187b4"
+checksum = "93739f2bcb64be8bd04342beae187317836b9c2826b6cfba429c2001e4db73a8"
 dependencies = [
- "near-schema-checker-core 0.31.0",
- "near-schema-checker-macro 0.31.0",
+ "near-schema-checker-core 0.31.1",
+ "near-schema-checker-macro 0.31.1",
 ]
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
- "near-schema-checker-core 2.7.1-rc.1",
- "near-schema-checker-macro 2.7.1-rc.1",
+ "near-schema-checker-core 2.7.1",
+ "near-schema-checker-macro 2.7.1",
 ]
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3e36aa0343f305c659eaade6903a53b947364a08ba78149bed067cd3c09f83"
+checksum = "2dc45bb3760350de7f957c11827e1e20c5a4aff8d95d19fd2c0c492d795bfb02"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 
 [[package]]
 name = "near-stdx"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cf9f3637b987148b82a7fd6740dff0527b0072f0e6036d24ba4d9d34434491"
+checksum = "7e3c38fc0843ef7c5bca717cc4daaf2af05441c3cb9cf259824e226387b18740"
 
 [[package]]
 name = "near-stdx"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 
 [[package]]
 name = "near-store"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5226,14 +5226,14 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.7.1-rc.1",
- "near-fmt 2.7.1-rc.1",
+ "near-crypto 2.7.1",
+ "near-fmt 2.7.1",
  "near-o11y",
- "near-parameters 2.7.1-rc.1",
- "near-primitives 2.7.1-rc.1",
- "near-schema-checker-lib 2.7.1-rc.1",
- "near-stdx 2.7.1-rc.1",
- "near-time 2.7.1-rc.1",
+ "near-parameters 2.7.1",
+ "near-primitives 2.7.1",
+ "near-schema-checker-lib 2.7.1",
+ "near-stdx 2.7.1",
+ "near-time 2.7.1",
  "near-vm-runner",
  "num_cpus",
  "parking_lot 0.12.4",
@@ -5255,8 +5255,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "awc",
@@ -5272,9 +5272,9 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f47dedd0ca30c5a5d51bb74613b125daf490f3a1733df89b297877e476466da"
+checksum = "697acb90b55637c075ce47be4e7834654c34157b88036b199d7189ced6d0f89c"
 dependencies = [
  "parking_lot 0.12.4",
  "serde",
@@ -5283,8 +5283,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "parking_lot 0.12.4",
  "serde",
@@ -5294,8 +5294,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5310,8 +5310,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -5329,8 +5329,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "backtrace",
  "finite-wasm",
@@ -5348,8 +5348,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "anyhow",
  "blst",
@@ -5360,12 +5360,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.7.1-rc.1",
+ "near-crypto 2.7.1",
  "near-o11y",
- "near-parameters 2.7.1-rc.1",
- "near-primitives-core 2.7.1-rc.1",
- "near-schema-checker-lib 2.7.1-rc.1",
- "near-stdx 2.7.1-rc.1",
+ "near-parameters 2.7.1",
+ "near-primitives-core 2.7.1",
+ "near-schema-checker-lib 2.7.1",
+ "near-stdx 2.7.1",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5394,8 +5394,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "indexmap 2.11.0",
  "num-traits",
@@ -5405,8 +5405,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "backtrace",
  "cc",
@@ -5426,18 +5426,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.7.1-rc.1",
+ "near-primitives-core 2.7.1",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5459,8 +5459,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.7.1-rc.1",
- "near-crypto 2.7.1-rc.1",
+ "near-config-utils 2.7.1",
+ "near-crypto 2.7.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5468,10 +5468,10 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.7.1-rc.1",
+ "near-parameters 2.7.1",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.7.1-rc.1",
+ "near-primitives 2.7.1",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5508,17 +5508,17 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.7.1-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.1-rc.1#696e2f40426448d0a31018859d003a1ca88d8263"
+version = "2.7.1"
+source = "git+https://github.com/near/nearcore?tag=2.7.1#4c31269d544d6af5a3e3682bcac7f5ba789afbb9"
 dependencies = [
  "borsh 1.5.7",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.7.1-rc.1",
+ "near-crypto 2.7.1",
  "near-o11y",
- "near-parameters 2.7.1-rc.1",
- "near-primitives 2.7.1-rc.1",
- "near-primitives-core 2.7.1-rc.1",
+ "near-parameters 2.7.1",
+ "near-primitives 2.7.1",
+ "near-primitives-core 2.7.1",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.30.9-2.7.1-rc.1"
+version = "0.30.9-2.7.1"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -39,9 +39,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.12"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.7.1-rc.1" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.7.1-rc.1" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.7.1-rc.1" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.7.1" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.7.1" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.7.1" }
 near-crypto-crates-io = { version = "0.31", package = "near-crypto" }
 near-primitives-crates-io = { version = "0.31", package = "near-primitives" }
 # Temporary pin to pick up near-primitives 0.31 compatibility. Revert to crates.io once upstream releases.


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.7.1). New package version: 0.30.9-2.7.1