### PR TITLE
chore: Bump nearcore to 2.11.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.2-2.11.1] 2026-04-21
+
+### Changes
+
+* chore: bump nearcore to 2.11.1 in [#285]
+
+[#285]: https://github.com/aurora-is-near/borealis-engine-lib/pull/285
+
 ## [0.31.2-2.11.0] 2026-04-01
 
 ### Changes
@@ -591,7 +599,8 @@ Later, when `near-primitives` was updated to `0.31.0` in the `near-lake-framewor
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.31.2-2.11.0...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.31.2-2.11.1...main
+[0.31.2-2.11.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.31.2-2.11.0...0.31.2-2.11.1
 [0.31.2-2.11.0]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.31.2-2.11.0-rc.5...0.31.2-2.11.0
 [0.31.2-2.11.0-rc.5]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.31.2-2.11.0-rc.4...0.31.2-2.11.0-rc.5
 [0.31.2-2.11.0-rc.4]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.31.2-2.11.0-rc.3...0.31.2-2.11.0-rc.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.31.2-2.11.0"
+version = "0.31.2-2.11.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.31.2-2.11.0"
+version = "0.31.2-2.11.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.31.2-2.11.0"
+version = "0.31.2-2.11.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.31.2-2.11.0"
+version = "0.31.2-2.11.1"
 dependencies = [
  "aurora-engine",
  "aurora-engine-transactions",
@@ -609,11 +609,11 @@ dependencies = [
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
  "near-crypto 0.35.0-rc.1",
- "near-crypto 2.11.0",
+ "near-crypto 2.11.1",
  "near-indexer",
  "near-lake-framework",
  "near-primitives 0.35.0-rc.1",
- "near-primitives 2.11.0",
+ "near-primitives 2.11.1",
  "reqwest 0.13.1",
  "serde",
  "serde_json",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.31.2-2.11.0"
+version = "0.31.2-2.11.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -2550,7 +2550,6 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
  "signature 2.2.0",
 ]
 
@@ -2563,10 +2562,8 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core 0.6.4",
- "serde",
  "sha2 0.10.9",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2600,7 +2597,7 @@ dependencies = [
  "ff 0.12.1",
  "generic-array",
  "group 0.12.1",
- "pkcs8 0.9.0",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1 0.3.0",
  "subtle",
@@ -4320,18 +4317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4451,14 +4436,14 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "crossbeam-channel",
  "futures",
  "near-async-derive",
  "near-o11y",
- "near-time 2.11.0",
+ "near-time 2.11.1",
  "parking_lot 0.12.5",
  "serde",
  "serde_json",
@@ -4470,8 +4455,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4480,8 +4465,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "lru 0.16.3",
  "parking_lot 0.12.5",
@@ -4489,8 +4474,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4506,14 +4491,14 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.11.0",
+ "near-crypto 2.11.1",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.11.0",
+ "near-parameters 2.11.1",
  "near-pool",
- "near-primitives 2.11.0",
- "near-schema-checker-lib 2.11.0",
+ "near-primitives 2.11.1",
+ "near-schema-checker-lib 2.11.1",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4535,19 +4520,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 2.1.1",
- "near-config-utils 2.11.0",
- "near-crypto 2.11.0",
+ "near-config-utils 2.11.1",
+ "near-crypto 2.11.1",
  "near-o11y",
- "near-parameters 2.11.0",
- "near-primitives 2.11.0",
- "near-time 2.11.0",
+ "near-parameters 2.11.1",
+ "near-primitives 2.11.1",
+ "near-time 2.11.1",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
  "serde",
@@ -4560,20 +4545,20 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
- "near-crypto 2.11.0",
- "near-primitives 2.11.0",
- "near-time 2.11.0",
+ "near-crypto 2.11.1",
+ "near-primitives 2.11.1",
+ "near-time 2.11.1",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "itertools 0.14.0",
  "lru 0.16.3",
@@ -4581,12 +4566,12 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.11.0",
+ "near-crypto 2.11.1",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-pool",
- "near-primitives 2.11.0",
+ "near-primitives 2.11.1",
  "near-store",
  "parking_lot 0.12.5",
  "rand 0.8.5",
@@ -4598,17 +4583,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.11.0",
+ "near-primitives 2.11.1",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4623,15 +4608,15 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.11.0",
+ "near-crypto 2.11.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
  "near-network",
  "near-o11y",
- "near-parameters 2.11.0",
+ "near-parameters 2.11.1",
  "near-pool",
- "near-primitives 2.11.0",
+ "near-primitives 2.11.1",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4659,14 +4644,14 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.11.0",
- "near-primitives 2.11.0",
- "near-time 2.11.0",
+ "near-crypto 2.11.1",
+ "near-primitives 2.11.1",
+ "near-time 2.11.1",
  "serde",
  "strum 0.24.1",
  "thiserror 2.0.18",
@@ -4687,8 +4672,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4724,8 +4709,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "blake2",
  "borsh",
@@ -4735,9 +4720,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.11.0",
- "near-schema-checker-lib 2.11.0",
- "near-stdx 2.11.0",
+ "near-config-utils 2.11.1",
+ "near-schema-checker-lib 2.11.1",
+ "near-stdx 2.11.1",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1",
@@ -4748,27 +4733,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-crypto-ed25519-batch"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
-dependencies = [
- "curve25519-dalek",
- "ed25519-dalek",
- "merlin",
- "rand_core 0.6.4",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "near-dyn-configs"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "anyhow",
  "near-chain-configs",
  "near-o11y",
- "near-primitives 2.11.0",
- "near-time 2.11.0",
+ "near-primitives 2.11.1",
+ "near-time 2.11.1",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -4776,18 +4749,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.11.0",
+ "near-crypto 2.11.1",
  "near-o11y",
- "near-primitives 2.11.0",
- "near-schema-checker-lib 2.11.0",
+ "near-primitives 2.11.1",
+ "near-schema-checker-lib 2.11.1",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4802,8 +4775,8 @@ dependencies = [
 
 [[package]]
 name = "near-external-storage"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "anyhow",
  "futures",
@@ -4828,10 +4801,10 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
- "near-primitives-core 2.11.0",
+ "near-primitives-core 2.11.1",
 ]
 
 [[package]]
@@ -4846,8 +4819,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "anyhow",
  "futures",
@@ -4855,13 +4828,13 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.11.0",
+ "near-config-utils 2.11.1",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.11.0",
+ "near-indexer-primitives 2.11.1",
  "near-o11y",
- "near-parameters 2.11.0",
- "near-primitives 2.11.0",
+ "near-parameters 2.11.1",
+ "near-primitives 2.11.1",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4883,17 +4856,17 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
- "near-primitives 2.11.0",
+ "near-primitives 2.11.1",
  "serde",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "axum",
  "bs58 0.4.0",
@@ -4906,7 +4879,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.11.0",
+ "near-primitives 2.11.1",
  "serde",
  "serde_json",
  "tokio",
@@ -4916,12 +4889,12 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.11.0",
+ "near-primitives 2.11.1",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -4930,16 +4903,16 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.11.0",
- "near-primitives 2.11.0",
- "near-schema-checker-lib 2.11.0",
- "near-time 2.11.0",
+ "near-crypto 2.11.1",
+ "near-primitives 2.11.1",
+ "near-schema-checker-lib 2.11.1",
+ "near-time 2.11.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4997,19 +4970,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.11.0",
+ "near-primitives 2.11.1",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5025,11 +4998,11 @@ dependencies = [
  "named-lock",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.11.0",
- "near-fmt 2.11.0",
+ "near-crypto 2.11.1",
+ "near-fmt 2.11.1",
  "near-o11y",
- "near-primitives 2.11.0",
- "near-schema-checker-lib 2.11.0",
+ "near-primitives 2.11.1",
+ "near-schema-checker-lib 2.11.1",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.5",
@@ -5050,13 +5023,13 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "base64 0.21.7",
  "clap",
- "near-crypto 2.11.0",
- "near-primitives-core 2.11.0",
+ "near-crypto 2.11.1",
+ "near-primitives-core 2.11.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -5093,14 +5066,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "borsh",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.11.0",
- "near-schema-checker-lib 2.11.0",
+ "near-primitives-core 2.11.1",
+ "near-schema-checker-lib 2.11.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5111,13 +5084,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "borsh",
- "near-crypto 2.11.0",
+ "near-crypto 2.11.1",
  "near-o11y",
- "near-primitives 2.11.0",
+ "near-primitives 2.11.1",
  "rand 0.8.5",
 ]
 
@@ -5164,8 +5137,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5180,13 +5153,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.14.0",
- "near-crypto 2.11.0",
- "near-fmt 2.11.0",
- "near-parameters 2.11.0",
- "near-primitives-core 2.11.0",
- "near-schema-checker-lib 2.11.0",
- "near-stdx 2.11.0",
- "near-time 2.11.0",
+ "near-crypto 2.11.1",
+ "near-fmt 2.11.1",
+ "near-parameters 2.11.1",
+ "near-primitives-core 2.11.1",
+ "near-schema-checker-lib 2.11.1",
+ "near-stdx 2.11.1",
+ "near-time 2.11.1",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5231,8 +5204,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5242,7 +5215,7 @@ dependencies = [
  "enum-map",
  "near-account-id",
  "near-gas",
- "near-schema-checker-lib 2.11.0",
+ "near-schema-checker-lib 2.11.1",
  "near-token",
  "num-rational 0.3.2",
  "serde",
@@ -5254,8 +5227,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "axum",
  "derive_more 2.1.1",
@@ -5267,11 +5240,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.11.0",
+ "near-crypto 2.11.1",
  "near-network",
  "near-o11y",
- "near-parameters 2.11.0",
- "near-primitives 2.11.0",
+ "near-parameters 2.11.1",
+ "near-primitives 2.11.1",
  "node-runtime",
  "serde",
  "serde_json",
@@ -5291,8 +5264,8 @@ checksum = "cea45a8f193dea15f47834a0b01b55d5931bb0d18dbd72104094952332a3e7b3"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5306,11 +5279,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
- "near-schema-checker-core 2.11.0",
- "near-schema-checker-macro 2.11.0",
+ "near-schema-checker-core 2.11.1",
+ "near-schema-checker-macro 2.11.1",
 ]
 
 [[package]]
@@ -5321,8 +5294,8 @@ checksum = "52883e3a0876a8187a848e9eae66dfbf77b9bf74b05e34f03284f2ecf98aae57"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 
 [[package]]
 name = "near-stdx"
@@ -5332,13 +5305,13 @@ checksum = "f408fd817ed371cc26b22507b684c9529e83191822abaa706696e3623f554a3f"
 
 [[package]]
 name = "near-stdx"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 
 [[package]]
 name = "near-store"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -5357,15 +5330,15 @@ dependencies = [
  "near-async",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.11.0",
+ "near-crypto 2.11.1",
  "near-external-storage",
- "near-fmt 2.11.0",
+ "near-fmt 2.11.1",
  "near-o11y",
- "near-parameters 2.11.0",
- "near-primitives 2.11.0",
- "near-schema-checker-lib 2.11.0",
- "near-stdx 2.11.0",
- "near-time 2.11.0",
+ "near-parameters 2.11.1",
+ "near-primitives 2.11.1",
+ "near-schema-checker-lib 2.11.1",
+ "near-stdx 2.11.1",
+ "near-time 2.11.1",
  "near-vm-runner",
  "num_cpus",
  "parking_lot 0.12.5",
@@ -5387,8 +5360,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "futures",
  "near-async",
@@ -5412,8 +5385,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "parking_lot 0.12.5",
  "serde",
@@ -5433,8 +5406,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "enumset",
  "finite-wasm 0.5.0",
@@ -5449,8 +5422,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -5468,8 +5441,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "backtrace",
  "finite-wasm 0.5.0",
@@ -5487,8 +5460,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "anyhow",
  "blst",
@@ -5500,12 +5473,12 @@ dependencies = [
  "finite-wasm 0.6.0",
  "lru 0.16.3",
  "memoffset 0.8.0",
- "near-crypto 2.11.0",
+ "near-crypto 2.11.1",
  "near-o11y",
- "near-parameters 2.11.0",
- "near-primitives-core 2.11.0",
- "near-schema-checker-lib 2.11.0",
- "near-stdx 2.11.0",
+ "near-parameters 2.11.1",
+ "near-primitives-core 2.11.1",
+ "near-schema-checker-lib 2.11.1",
+ "near-stdx 2.11.1",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5535,8 +5508,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "indexmap 2.13.0",
  "num-traits",
@@ -5546,8 +5519,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "backtrace",
  "cc",
@@ -5567,18 +5540,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.11.0",
+ "near-primitives-core 2.11.1",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5596,8 +5569,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.11.0",
- "near-crypto 2.11.0",
+ "near-config-utils 2.11.1",
+ "near-crypto 2.11.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
@@ -5606,9 +5579,9 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.11.0",
+ "near-parameters 2.11.1",
  "near-pool",
- "near-primitives 2.11.0",
+ "near-primitives 2.11.1",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5645,33 +5618,28 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.11.0"
-source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
+version = "2.11.1"
+source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
 dependencies = [
  "ahash 0.8.12",
  "borsh",
  "bytesize",
- "crossbeam-utils",
  "dashmap",
- "ed25519-dalek",
  "itertools 0.14.0",
- "near-crypto 2.11.0",
- "near-crypto-ed25519-batch",
+ "near-crypto 2.11.1",
  "near-o11y",
- "near-parameters 2.11.0",
- "near-primitives 2.11.0",
- "near-primitives-core 2.11.0",
+ "near-parameters 2.11.1",
+ "near-primitives 2.11.1",
+ "near-primitives-core 2.11.1",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",
- "num-integer",
  "parking_lot 0.12.5",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
  "serde_json",
  "sha2 0.10.9",
- "smallvec",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -6292,17 +6260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der 0.6.1",
- "spki 0.6.0",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "spki",
 ]
 
 [[package]]
@@ -7695,7 +7653,7 @@ dependencies = [
  "base16ct 0.1.1",
  "der 0.6.1",
  "generic-array",
- "pkcs8 0.9.0",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -8121,16 +8079,6 @@ checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der 0.7.10",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.31.2-2.11.0"
+version = "0.31.2-2.11.1"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -40,9 +40,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.16"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
 near-crypto-crates-io = { version = "0.35.0-rc.1", package = "near-crypto" }
 near-primitives-crates-io = { version = "0.35.0-rc.1", package = "near-primitives" }
 # Temporary pin to pick up near-primitives 0.35.0-rc.1 compatibility. Revert to crates.io once upstream releases.


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.11.1). New package version: 0.31.2-2.11.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated workspace package version to `0.31.2-2.11.1`
  * Updated NEAR protocol core dependencies to align with latest nearcore release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->