### PR TITLE
chore: Bump nearcore to 2.12.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.2-2.12.0] 2026-06-03
+
+### Changes
+
+* chore: bump nearcore to 2.12.0 in [#290]
+
+[#290]: https://github.com/aurora-is-near/borealis-engine-lib/pull/290
+
 ## [0.31.2-2.12.0-rc.2] 2026-05-27
 
 ### Changes
@@ -615,7 +623,8 @@ Later, when `near-primitives` was updated to `0.31.0` in the `near-lake-framewor
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.31.2-2.12.0-rc.2...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.31.2-2.12.0...main
+[0.31.2-2.12.0]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.31.2-2.12.0-rc.2...0.31.2-2.12.0
 [0.31.2-2.12.0-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.31.2-2.12.0-rc.1...0.31.2-2.12.0-rc.2
 [0.31.2-2.12.0-rc.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.31.2-2.11.1...0.31.2-2.12.0-rc.1
 [0.31.2-2.11.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.31.2-2.11.0...0.31.2-2.11.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.31.2-2.12.0-rc.2"
+version = "0.31.2-2.12.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.31.2-2.12.0-rc.2"
+version = "0.31.2-2.12.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.31.2-2.12.0-rc.2"
+version = "0.31.2-2.12.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.31.2-2.12.0-rc.2"
+version = "0.31.2-2.12.0"
 dependencies = [
  "aurora-engine",
  "aurora-engine-transactions",
@@ -616,11 +616,11 @@ dependencies = [
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
  "near-crypto 0.35.1",
- "near-crypto 2.12.0-rc.2",
+ "near-crypto 2.12.0",
  "near-indexer",
  "near-lake-framework",
  "near-primitives 0.35.1",
- "near-primitives 2.12.0-rc.2",
+ "near-primitives 2.12.0",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.31.2-2.12.0-rc.2"
+version = "0.31.2-2.12.0"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -4711,14 +4711,14 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "crossbeam-channel",
  "futures",
  "near-async-derive",
  "near-o11y",
- "near-time 2.12.0-rc.2",
+ "near-time 2.12.0",
  "parking_lot 0.12.5",
  "serde",
  "serde_json",
@@ -4731,8 +4731,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4741,8 +4741,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "lru 0.16.4",
  "parking_lot 0.12.5",
@@ -4750,8 +4750,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4767,14 +4767,14 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.12.0-rc.2",
+ "near-crypto 2.12.0",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.12.0-rc.2",
+ "near-parameters 2.12.0",
  "near-pool",
- "near-primitives 2.12.0-rc.2",
- "near-schema-checker-lib 2.12.0-rc.2",
+ "near-primitives 2.12.0",
+ "near-schema-checker-lib 2.12.0",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4795,19 +4795,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 2.1.1",
- "near-config-utils 2.12.0-rc.2",
- "near-crypto 2.12.0-rc.2",
+ "near-config-utils 2.12.0",
+ "near-crypto 2.12.0",
  "near-o11y",
- "near-parameters 2.12.0-rc.2",
- "near-primitives 2.12.0-rc.2",
- "near-time 2.12.0-rc.2",
+ "near-parameters 2.12.0",
+ "near-primitives 2.12.0",
+ "near-time 2.12.0",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
  "serde",
@@ -4820,20 +4820,20 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
- "near-crypto 2.12.0-rc.2",
- "near-primitives 2.12.0-rc.2",
- "near-time 2.12.0-rc.2",
+ "near-crypto 2.12.0",
+ "near-primitives 2.12.0",
+ "near-time 2.12.0",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "itertools 0.14.0",
  "lru 0.16.4",
@@ -4841,12 +4841,12 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.12.0-rc.2",
+ "near-crypto 2.12.0",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-pool",
- "near-primitives 2.12.0-rc.2",
+ "near-primitives 2.12.0",
  "near-store",
  "parking_lot 0.12.5",
  "rand 0.8.6",
@@ -4858,17 +4858,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.12.0-rc.2",
+ "near-primitives 2.12.0",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4883,15 +4883,15 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.12.0-rc.2",
+ "near-crypto 2.12.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
  "near-network",
  "near-o11y",
- "near-parameters 2.12.0-rc.2",
+ "near-parameters 2.12.0",
  "near-pool",
- "near-primitives 2.12.0-rc.2",
+ "near-primitives 2.12.0",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4919,14 +4919,14 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.12.0-rc.2",
- "near-primitives 2.12.0-rc.2",
- "near-time 2.12.0-rc.2",
+ "near-crypto 2.12.0",
+ "near-primitives 2.12.0",
+ "near-time 2.12.0",
  "serde",
  "strum 0.24.1",
  "thiserror 2.0.18",
@@ -4947,8 +4947,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4984,8 +4984,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "blake2",
  "borsh",
@@ -4995,9 +4995,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.12.0-rc.2",
- "near-schema-checker-lib 2.12.0-rc.2",
- "near-stdx 2.12.0-rc.2",
+ "near-config-utils 2.12.0",
+ "near-schema-checker-lib 2.12.0",
+ "near-stdx 2.12.0",
  "primitive-types 0.10.1",
  "rand 0.8.6",
  "secp256k1",
@@ -5009,14 +5009,14 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "near-chain-configs",
  "near-o11y",
- "near-primitives 2.12.0-rc.2",
- "near-time 2.12.0-rc.2",
+ "near-primitives 2.12.0",
+ "near-time 2.12.0",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -5024,18 +5024,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.12.0-rc.2",
+ "near-crypto 2.12.0",
  "near-o11y",
- "near-primitives 2.12.0-rc.2",
- "near-schema-checker-lib 2.12.0-rc.2",
+ "near-primitives 2.12.0",
+ "near-schema-checker-lib 2.12.0",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -5049,8 +5049,8 @@ dependencies = [
 
 [[package]]
 name = "near-external-storage"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "futures",
@@ -5075,10 +5075,10 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
- "near-primitives-core 2.12.0-rc.2",
+ "near-primitives-core 2.12.0",
 ]
 
 [[package]]
@@ -5093,8 +5093,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "futures",
@@ -5102,13 +5102,13 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.12.0-rc.2",
+ "near-config-utils 2.12.0",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.12.0-rc.2",
+ "near-indexer-primitives 2.12.0",
  "near-o11y",
- "near-parameters 2.12.0-rc.2",
- "near-primitives 2.12.0-rc.2",
+ "near-parameters 2.12.0",
+ "near-primitives 2.12.0",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -5130,17 +5130,17 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
- "near-primitives 2.12.0-rc.2",
+ "near-primitives 2.12.0",
  "serde",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "axum",
  "bs58 0.4.0",
@@ -5156,7 +5156,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.12.0-rc.2",
+ "near-primitives 2.12.0",
  "near-store",
  "parking_lot 0.12.5",
  "serde",
@@ -5169,12 +5169,12 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.12.0-rc.2",
+ "near-primitives 2.12.0",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
@@ -5183,16 +5183,16 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.12.0-rc.2",
- "near-primitives 2.12.0-rc.2",
- "near-schema-checker-lib 2.12.0-rc.2",
- "near-time 2.12.0-rc.2",
+ "near-crypto 2.12.0",
+ "near-primitives 2.12.0",
+ "near-schema-checker-lib 2.12.0",
+ "near-time 2.12.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5250,19 +5250,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.12.0-rc.2",
+ "near-primitives 2.12.0",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5279,11 +5279,11 @@ dependencies = [
  "named-lock",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.12.0-rc.2",
- "near-fmt 2.12.0-rc.2",
+ "near-crypto 2.12.0",
+ "near-fmt 2.12.0",
  "near-o11y",
- "near-primitives 2.12.0-rc.2",
- "near-schema-checker-lib 2.12.0-rc.2",
+ "near-primitives 2.12.0",
+ "near-schema-checker-lib 2.12.0",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.5",
@@ -5304,13 +5304,13 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "base64 0.21.7",
  "clap",
- "near-crypto 2.12.0-rc.2",
- "near-primitives-core 2.12.0-rc.2",
+ "near-crypto 2.12.0",
+ "near-primitives-core 2.12.0",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -5346,14 +5346,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "borsh",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.12.0-rc.2",
- "near-schema-checker-lib 2.12.0-rc.2",
+ "near-primitives-core 2.12.0",
+ "near-schema-checker-lib 2.12.0",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5364,13 +5364,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "borsh",
- "near-crypto 2.12.0-rc.2",
+ "near-crypto 2.12.0",
  "near-o11y",
- "near-primitives 2.12.0-rc.2",
+ "near-primitives 2.12.0",
  "rand 0.8.6",
 ]
 
@@ -5417,8 +5417,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5433,13 +5433,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.14.0",
- "near-crypto 2.12.0-rc.2",
- "near-fmt 2.12.0-rc.2",
- "near-parameters 2.12.0-rc.2",
- "near-primitives-core 2.12.0-rc.2",
- "near-schema-checker-lib 2.12.0-rc.2",
- "near-stdx 2.12.0-rc.2",
- "near-time 2.12.0-rc.2",
+ "near-crypto 2.12.0",
+ "near-fmt 2.12.0",
+ "near-parameters 2.12.0",
+ "near-primitives-core 2.12.0",
+ "near-schema-checker-lib 2.12.0",
+ "near-stdx 2.12.0",
+ "near-time 2.12.0",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5484,8 +5484,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5495,7 +5495,7 @@ dependencies = [
  "enum-map",
  "near-account-id",
  "near-gas",
- "near-schema-checker-lib 2.12.0-rc.2",
+ "near-schema-checker-lib 2.12.0",
  "near-token",
  "num-rational 0.3.2",
  "serde",
@@ -5507,8 +5507,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "axum",
  "derive_more 2.1.1",
@@ -5520,11 +5520,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.12.0-rc.2",
+ "near-crypto 2.12.0",
  "near-network",
  "near-o11y",
- "near-parameters 2.12.0-rc.2",
- "near-primitives 2.12.0-rc.2",
+ "near-parameters 2.12.0",
+ "near-primitives 2.12.0",
  "node-runtime",
  "serde",
  "serde_json",
@@ -5544,8 +5544,8 @@ checksum = "d573e560c907f9f89602cf1c748505f1bf93adc1ea11de1eae96579a4e23fee9"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5559,11 +5559,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
- "near-schema-checker-core 2.12.0-rc.2",
- "near-schema-checker-macro 2.12.0-rc.2",
+ "near-schema-checker-core 2.12.0",
+ "near-schema-checker-macro 2.12.0",
 ]
 
 [[package]]
@@ -5574,8 +5574,8 @@ checksum = "fee4669ee1f3f8d0fe467c367188d6bf7ba17c215f5b2c0edec593cf4b76bbb3"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 
 [[package]]
 name = "near-stdx"
@@ -5585,13 +5585,13 @@ checksum = "586d4ca605c2540a158a4c89d46de0d2649fe52bb94db6a0ddff42a243d37d04"
 
 [[package]]
 name = "near-stdx"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 
 [[package]]
 name = "near-store"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -5610,15 +5610,15 @@ dependencies = [
  "near-async",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.12.0-rc.2",
+ "near-crypto 2.12.0",
  "near-external-storage",
- "near-fmt 2.12.0-rc.2",
+ "near-fmt 2.12.0",
  "near-o11y",
- "near-parameters 2.12.0-rc.2",
- "near-primitives 2.12.0-rc.2",
- "near-schema-checker-lib 2.12.0-rc.2",
- "near-stdx 2.12.0-rc.2",
- "near-time 2.12.0-rc.2",
+ "near-parameters 2.12.0",
+ "near-primitives 2.12.0",
+ "near-schema-checker-lib 2.12.0",
+ "near-stdx 2.12.0",
+ "near-time 2.12.0",
  "near-vm-runner",
  "num_cpus",
  "parking_lot 0.12.5",
@@ -5641,8 +5641,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "futures",
  "near-async",
@@ -5666,8 +5666,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "parking_lot 0.12.5",
  "serde",
@@ -5687,8 +5687,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "enumset",
  "finite-wasm 0.5.0",
@@ -5703,8 +5703,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -5722,8 +5722,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "backtrace",
  "finite-wasm 0.5.0",
@@ -5741,8 +5741,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "blst",
@@ -5755,12 +5755,12 @@ dependencies = [
  "finite-wasm 0.6.0",
  "lru 0.16.4",
  "memoffset 0.8.0",
- "near-crypto 2.12.0-rc.2",
+ "near-crypto 2.12.0",
  "near-o11y",
- "near-parameters 2.12.0-rc.2",
- "near-primitives-core 2.12.0-rc.2",
- "near-schema-checker-lib 2.12.0-rc.2",
- "near-stdx 2.12.0-rc.2",
+ "near-parameters 2.12.0",
+ "near-primitives-core 2.12.0",
+ "near-schema-checker-lib 2.12.0",
+ "near-stdx 2.12.0",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5791,8 +5791,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "indexmap 2.14.0",
  "num-traits",
@@ -5802,8 +5802,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "backtrace",
  "cc",
@@ -5823,18 +5823,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.12.0-rc.2",
+ "near-primitives-core 2.12.0",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5852,8 +5852,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.12.0-rc.2",
- "near-crypto 2.12.0-rc.2",
+ "near-config-utils 2.12.0",
+ "near-crypto 2.12.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
@@ -5862,9 +5862,9 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.12.0-rc.2",
+ "near-parameters 2.12.0",
  "near-pool",
- "near-primitives 2.12.0-rc.2",
+ "near-primitives 2.12.0",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5902,8 +5902,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "ahash 0.8.12",
  "borsh",
@@ -5911,11 +5911,11 @@ dependencies = [
  "dashmap",
  "itertools 0.14.0",
  "near-async",
- "near-crypto 2.12.0-rc.2",
+ "near-crypto 2.12.0",
  "near-o11y",
- "near-parameters 2.12.0-rc.2",
- "near-primitives 2.12.0-rc.2",
- "near-primitives-core 2.12.0-rc.2",
+ "near-parameters 2.12.0",
+ "near-primitives 2.12.0",
+ "near-primitives-core 2.12.0",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.31.2-2.12.0-rc.2"
+version = "0.31.2-2.12.0"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -40,9 +40,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.18"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.2" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.2" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.2" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.12.0" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.12.0" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.12.0" }
 near-crypto-crates-io = { version = "0.35", package = "near-crypto" }
 near-primitives-crates-io = { version = "0.35", package = "near-primitives" }
 # Temporary pin to pick up near-primitives 0.35 compatibility. Revert to crates.io once upstream releases.


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.12.0). New package version: 0.31.2-2.12.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workspace package moved from release-candidate to stable version (0.31.2-2.12.0).
  * Near protocol dependencies upgraded from RC to stable 2.12.0 releases, improving compatibility and stability.
* **Documentation**
  * Changelog updated with the new 0.31.2-2.12.0 release entry and associated compare links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->