### PR TITLE
chore: Bump nearcore to 2.13.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.2-2.13.1] 2026-07-15
+
+### Changes
+
+* chore: bump nearcore to 2.13.1 in [#294]
+
+[#294]: https://github.com/aurora-is-near/borealis-engine-lib/pull/294
+
 ## [0.31.2-2.13.0] 2026-07-09
 
 ### Changes
@@ -639,7 +647,8 @@ Later, when `near-primitives` was updated to `0.31.0` in the `near-lake-framewor
 
 ## [v0.10.0] 
 
-[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.31.2-2.13.0...main
+[Unreleased]: https://github.com/aurora-is-near/borealis-engine-lib/0.31.2-2.13.1...main
+[0.31.2-2.13.1]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.31.2-2.13.0...0.31.2-2.13.1
 [0.31.2-2.13.0]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.31.2-2.13.0-rc.2...0.31.2-2.13.0
 [0.31.2-2.13.0-rc.2]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.31.2-2.12.0...0.31.2-2.13.0-rc.2
 [0.31.2-2.12.0]: https://github.com/aurora-is-near/borealis-engine-lib/compare/0.31.2-2.12.0-rc.2...0.31.2-2.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner"
-version = "0.31.2-2.13.0"
+version = "0.31.2-2.13.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-app-integration-tests"
-version = "0.31.2-2.13.0"
+version = "0.31.2-2.13.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-lib"
-version = "0.31.2-2.13.0"
+version = "0.31.2-2.13.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-refiner-types"
-version = "0.31.2-2.13.0"
+version = "0.31.2-2.13.1"
 dependencies = [
  "aurora-engine",
  "aurora-engine-transactions",
@@ -616,11 +616,11 @@ dependencies = [
  "fixed-hash 0.8.0",
  "impl-serde 0.5.0",
  "near-crypto 0.37.0-rc.2",
- "near-crypto 2.13.0",
+ "near-crypto 2.13.1",
  "near-indexer",
  "near-lake-framework",
  "near-primitives 0.37.0-rc.2",
- "near-primitives 2.13.0",
+ "near-primitives 2.13.1",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-standalone-engine"
-version = "0.31.2-2.13.0"
+version = "0.31.2-2.13.1"
 dependencies = [
  "anyhow",
  "aurora-engine",
@@ -4625,14 +4625,14 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "crossbeam-channel",
  "futures",
  "near-async-derive",
  "near-o11y",
- "near-time 2.13.0",
+ "near-time 2.13.1",
  "parking_lot 0.12.5",
  "serde",
  "serde_json",
@@ -4645,8 +4645,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4655,8 +4655,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "lru 0.16.4",
  "parking_lot 0.12.5",
@@ -4664,8 +4664,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4681,14 +4681,14 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.13.0",
+ "near-crypto 2.13.1",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.13.0",
+ "near-parameters 2.13.1",
  "near-pool",
- "near-primitives 2.13.0",
- "near-schema-checker-lib 2.13.0",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
  "near-store",
  "near-vm-runner",
  "node-runtime",
@@ -4709,19 +4709,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 2.1.1",
- "near-config-utils 2.13.0",
- "near-crypto 2.13.0",
+ "near-config-utils 2.13.1",
+ "near-crypto 2.13.1",
  "near-o11y",
- "near-parameters 2.13.0",
- "near-primitives 2.13.0",
- "near-time 2.13.0",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
+ "near-time 2.13.1",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
  "serde",
@@ -4734,20 +4734,20 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
- "near-crypto 2.13.0",
- "near-primitives 2.13.0",
- "near-time 2.13.0",
+ "near-crypto 2.13.1",
+ "near-primitives 2.13.1",
+ "near-time 2.13.1",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "itertools 0.14.0",
  "lru 0.16.4",
@@ -4755,12 +4755,12 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.13.0",
+ "near-crypto 2.13.1",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-pool",
- "near-primitives 2.13.0",
+ "near-primitives 2.13.1",
  "near-store",
  "parking_lot 0.12.5",
  "rand 0.8.6",
@@ -4772,17 +4772,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.13.0",
+ "near-primitives 2.13.1",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4797,15 +4797,15 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.13.0",
+ "near-crypto 2.13.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
  "near-network",
  "near-o11y",
- "near-parameters 2.13.0",
+ "near-parameters 2.13.1",
  "near-pool",
- "near-primitives 2.13.0",
+ "near-primitives 2.13.1",
  "near-store",
  "near-telemetry",
  "near-vm-runner",
@@ -4833,14 +4833,14 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.13.0",
- "near-primitives 2.13.0",
- "near-time 2.13.0",
+ "near-crypto 2.13.1",
+ "near-primitives 2.13.1",
+ "near-time 2.13.1",
  "serde",
  "strum 0.24.1",
  "thiserror 2.0.18",
@@ -4861,8 +4861,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4900,8 +4900,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "aws-lc-rs",
  "blake2",
@@ -4912,9 +4912,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.13.0",
- "near-schema-checker-lib 2.13.0",
- "near-stdx 2.13.0",
+ "near-config-utils 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-stdx 2.13.1",
  "primitive-types 0.10.1",
  "rand 0.8.6",
  "secp256k1",
@@ -4927,14 +4927,14 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "near-chain-configs",
  "near-o11y",
- "near-primitives 2.13.0",
- "near-time 2.13.0",
+ "near-primitives 2.13.1",
+ "near-time 2.13.1",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -4942,18 +4942,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.13.0",
+ "near-crypto 2.13.1",
  "near-o11y",
- "near-primitives 2.13.0",
- "near-schema-checker-lib 2.13.0",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -4967,8 +4967,8 @@ dependencies = [
 
 [[package]]
 name = "near-external-storage"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "futures",
@@ -4993,10 +4993,10 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
- "near-primitives-core 2.13.0",
+ "near-primitives-core 2.13.1",
 ]
 
 [[package]]
@@ -5011,8 +5011,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "futures",
@@ -5020,13 +5020,13 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.13.0",
+ "near-config-utils 2.13.1",
  "near-dyn-configs",
  "near-epoch-manager",
- "near-indexer-primitives 2.13.0",
+ "near-indexer-primitives 2.13.1",
  "near-o11y",
- "near-parameters 2.13.0",
- "near-primitives 2.13.0",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -5048,17 +5048,17 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
- "near-primitives 2.13.0",
+ "near-primitives 2.13.1",
  "serde",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "axum",
  "bs58 0.4.0",
@@ -5074,7 +5074,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.13.0",
+ "near-primitives 2.13.1",
  "near-store",
  "parking_lot 0.12.5",
  "serde",
@@ -5087,12 +5087,12 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.13.0",
+ "near-primitives 2.13.1",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -5101,16 +5101,16 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.13.0",
- "near-primitives 2.13.0",
- "near-schema-checker-lib 2.13.0",
- "near-time 2.13.0",
+ "near-crypto 2.13.1",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-time 2.13.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5168,19 +5168,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.13.0",
+ "near-primitives 2.13.1",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5197,11 +5197,11 @@ dependencies = [
  "named-lock",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.13.0",
- "near-fmt 2.13.0",
+ "near-crypto 2.13.1",
+ "near-fmt 2.13.1",
  "near-o11y",
- "near-primitives 2.13.0",
- "near-schema-checker-lib 2.13.0",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.5",
@@ -5222,13 +5222,13 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "base64 0.21.7",
  "clap",
- "near-crypto 2.13.0",
- "near-primitives-core 2.13.0",
+ "near-crypto 2.13.1",
+ "near-primitives-core 2.13.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -5264,14 +5264,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "borsh",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.13.0",
- "near-schema-checker-lib 2.13.0",
+ "near-primitives-core 2.13.1",
+ "near-schema-checker-lib 2.13.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -5282,13 +5282,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "borsh",
- "near-crypto 2.13.0",
+ "near-crypto 2.13.1",
  "near-o11y",
- "near-primitives 2.13.0",
+ "near-primitives 2.13.1",
  "rand 0.8.6",
 ]
 
@@ -5335,8 +5335,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5351,13 +5351,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.14.0",
- "near-crypto 2.13.0",
- "near-fmt 2.13.0",
- "near-parameters 2.13.0",
- "near-primitives-core 2.13.0",
- "near-schema-checker-lib 2.13.0",
- "near-stdx 2.13.0",
- "near-time 2.13.0",
+ "near-crypto 2.13.1",
+ "near-fmt 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives-core 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-stdx 2.13.1",
+ "near-time 2.13.1",
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -5402,8 +5402,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5413,7 +5413,7 @@ dependencies = [
  "enum-map",
  "near-account-id",
  "near-gas",
- "near-schema-checker-lib 2.13.0",
+ "near-schema-checker-lib 2.13.1",
  "near-token",
  "num-rational 0.3.2",
  "serde",
@@ -5425,8 +5425,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "axum",
  "derive_more 2.1.1",
@@ -5438,11 +5438,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.13.0",
+ "near-crypto 2.13.1",
  "near-network",
  "near-o11y",
- "near-parameters 2.13.0",
- "near-primitives 2.13.0",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
  "node-runtime",
  "serde",
  "serde_json",
@@ -5462,8 +5462,8 @@ checksum = "481ec75b745264fa2403643acde2402536ed4273fbf05ea8749a5d1813f683a0"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5477,11 +5477,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
- "near-schema-checker-core 2.13.0",
- "near-schema-checker-macro 2.13.0",
+ "near-schema-checker-core 2.13.1",
+ "near-schema-checker-macro 2.13.1",
 ]
 
 [[package]]
@@ -5492,8 +5492,8 @@ checksum = "24abafad706a94a56a687618ae7e13b296b0443f54c7b7d92477b3b3c82e336d"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 
 [[package]]
 name = "near-stdx"
@@ -5503,13 +5503,13 @@ checksum = "f1e1cf6e256646ef9cabf86759582b2e7b06edfde846edaa68fc7d3e69d833f8"
 
 [[package]]
 name = "near-stdx"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 
 [[package]]
 name = "near-store"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -5528,15 +5528,15 @@ dependencies = [
  "near-async",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.13.0",
+ "near-crypto 2.13.1",
  "near-external-storage",
- "near-fmt 2.13.0",
+ "near-fmt 2.13.1",
  "near-o11y",
- "near-parameters 2.13.0",
- "near-primitives 2.13.0",
- "near-schema-checker-lib 2.13.0",
- "near-stdx 2.13.0",
- "near-time 2.13.0",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-stdx 2.13.1",
+ "near-time 2.13.1",
  "near-vm-runner",
  "num_cpus",
  "parking_lot 0.12.5",
@@ -5559,8 +5559,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "futures",
  "near-async",
@@ -5584,8 +5584,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "parking_lot 0.12.5",
  "serde",
@@ -5605,8 +5605,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "enumset",
  "finite-wasm 0.5.1",
@@ -5621,8 +5621,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -5640,8 +5640,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "backtrace",
  "finite-wasm 0.5.1",
@@ -5659,8 +5659,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "blst",
@@ -5673,12 +5673,12 @@ dependencies = [
  "finite-wasm 0.6.1",
  "lru 0.16.4",
  "memoffset 0.8.0",
- "near-crypto 2.13.0",
+ "near-crypto 2.13.1",
  "near-o11y",
- "near-parameters 2.13.0",
- "near-primitives-core 2.13.0",
- "near-schema-checker-lib 2.13.0",
- "near-stdx 2.13.0",
+ "near-parameters 2.13.1",
+ "near-primitives-core 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-stdx 2.13.1",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5709,8 +5709,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "indexmap 2.14.0",
  "num-traits",
@@ -5720,8 +5720,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "backtrace",
  "cc",
@@ -5741,18 +5741,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.13.0",
+ "near-primitives-core 2.13.1",
  "near-vm-runner",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5770,8 +5770,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.13.0",
- "near-crypto 2.13.0",
+ "near-config-utils 2.13.1",
+ "near-crypto 2.13.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
@@ -5780,9 +5780,9 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.13.0",
+ "near-parameters 2.13.1",
  "near-pool",
- "near-primitives 2.13.0",
+ "near-primitives 2.13.1",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
@@ -5820,8 +5820,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.13.0"
-source = "git+https://github.com/near/nearcore?tag=2.13.0#499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "ahash 0.8.12",
  "borsh",
@@ -5829,11 +5829,11 @@ dependencies = [
  "dashmap",
  "itertools 0.14.0",
  "near-async",
- "near-crypto 2.13.0",
+ "near-crypto 2.13.1",
  "near-o11y",
- "near-parameters 2.13.0",
- "near-primitives 2.13.0",
- "near-primitives-core 2.13.0",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
+ "near-primitives-core 2.13.1",
  "near-store",
  "near-vm-runner",
  "near-wallet-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
-version = "0.31.2-2.13.0"
+version = "0.31.2-2.13.1"
 edition = "2024"
 homepage = "https://github.com/aurora-is-near/aurora-standalone"
 repository = "https://github.com/aurora-is-near/aurora-standalone"
@@ -40,9 +40,9 @@ hex = "0.4"
 impl-serde = "0.5"
 lazy_static = "1"
 lru = "0.18"
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.13.0" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.13.0" }
-near-primitives = { git = "https://github.com/near/nearcore", tag = "2.13.0" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-primitives = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
 near-crypto-crates-io = { version = "0.37.0-rc.2", package = "near-crypto" }
 near-primitives-crates-io = { version = "0.37.0-rc.2", package = "near-primitives" }
 # Temporary pin to pick up near-primitives 0.35 compatibility. Revert to crates.io once upstream releases.


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.13.1). New package version: 0.31.2-2.13.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application version to 0.31.2-2.13.1.
  * Updated bundled component versions to 2.13.1.
  * Added release notes and comparison links for the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->